### PR TITLE
Cleanup tests

### DIFF
--- a/packages/tailwindcss/src/at-import.test.ts
+++ b/packages/tailwindcss/src/at-import.test.ts
@@ -560,23 +560,18 @@ test('emits the right base for @source found inside JS configs and plugins from 
 })
 
 test('it crashes when inside a cycle', async () => {
+  let input = css`
+    @import 'foo.css';
+  `
+
   let loadStylesheet = () =>
     Promise.resolve({
-      content: css`
-        @import 'foo.css';
-      `,
+      content: input,
       base: '/root',
       path: '',
     })
 
-  await expect(
-    compileCss(
-      css`
-        @import 'foo.css';
-      `,
-      { base: '/root', loadStylesheet },
-    ),
-  ).rejects.toMatchInlineSnapshot(
+  await expect(compileCss(input, { base: '/root', loadStylesheet })).rejects.toMatchInlineSnapshot(
     `[Error: Exceeded maximum recursion depth while resolving \`foo.css\` in \`/root\`)]`,
   )
 })

--- a/packages/tailwindcss/src/at-import.test.ts
+++ b/packages/tailwindcss/src/at-import.test.ts
@@ -1,37 +1,10 @@
 import dedent from 'dedent'
 import { expect, test, vi } from 'vitest'
-import type { Plugin } from './compat/plugin-api'
 import { compile, type Config } from './index'
 import plugin from './plugin'
-import { optimizeCss, pretty } from './test-utils/run'
+import { run } from './test-utils/run'
 
 const css = dedent
-
-async function run(
-  css: string,
-  {
-    loadStylesheet = () => Promise.reject(new Error('Unexpected stylesheet')),
-    loadModule = () => Promise.reject(new Error('Unexpected module')),
-    candidates = [],
-    optimize = true,
-  }: {
-    loadStylesheet?: (
-      id: string,
-      base: string,
-    ) => Promise<{ content: string; base: string; path: string }>
-    loadModule?: (
-      id: string,
-      base: string,
-      resourceHint: 'plugin' | 'config',
-    ) => Promise<{ module: Config | Plugin; base: string; path: string }>
-    candidates?: string[]
-    optimize?: boolean
-  },
-) {
-  let compiler = await compile(css, { base: '/root', loadStylesheet, loadModule })
-  let result = compiler.build(candidates)
-  return optimize ? optimizeCss(result) : pretty(result)
-}
 
 test('can resolve relative @imports', async () => {
   let loadStylesheet = async (id: string, base: string) => {
@@ -48,14 +21,15 @@ test('can resolve relative @imports', async () => {
     }
   }
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import './foo/bar.css';
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     .foo {
       color: red;
@@ -89,14 +63,15 @@ test('can recursively resolve relative @imports', async () => {
     throw new Error(`Unexpected import: ${id}`)
   }
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import './foo/bar.css';
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     .baz {
       color: #00f;
@@ -120,14 +95,15 @@ let loadStylesheet = async (id: string) => {
 }
 
 test('extracts path from @import nodes', async () => {
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css';
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     a {
       color: red;
@@ -135,14 +111,15 @@ test('extracts path from @import nodes', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import './example.css';
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     a {
       color: red;
@@ -150,14 +127,15 @@ test('extracts path from @import nodes', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import '/example.css';
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     a {
       color: red;
@@ -167,94 +145,101 @@ test('extracts path from @import nodes', async () => {
 })
 
 test('url() imports are passed-through', async () => {
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import url('example.css');
       `,
-      { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
+      { base: '/root', loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')) },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
-    @import url('example.css');
+    @import "example.css";
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import url('./example.css');
       `,
-      { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
+      { base: '/root', loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')) },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
-    @import url('./example.css');
+    @import "./example.css";
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import url('/example.css');
       `,
-      { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
+      { base: '/root', loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')) },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
-    @import url('/example.css');
+    @import "/example.css";
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import url(example.css);
       `,
-      { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
+      { base: '/root', loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')) },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
-    @import url(example.css);
+    @import "example.css";
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import url(./example.css);
       `,
-      { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
+      { base: '/root', loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')) },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
-    @import url(./example.css);
+    @import "./example.css";
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import url(/example.css);
       `,
-      { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
+      { base: '/root', loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')) },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
-    @import url(/example.css);
+    @import "/example.css";
     "
   `)
 })
 
 test('handles case-insensitive @import directive', async () => {
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css';
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     a {
       color: red;
@@ -264,14 +249,15 @@ test('handles case-insensitive @import directive', async () => {
 })
 
 test('@media', async () => {
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' print;
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @media print {
       a {
@@ -281,14 +267,15 @@ test('@media', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' print, screen;
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @media print, screen {
       a {
@@ -298,14 +285,15 @@ test('@media', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' screen and (orientation: landscape);
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @media screen and (orientation: landscape) {
       a {
@@ -315,14 +303,15 @@ test('@media', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' foo(bar);
       `,
-      { loadStylesheet, optimize: false },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @media foo(bar) {
       a {
@@ -334,14 +323,15 @@ test('@media', async () => {
 })
 
 test('@supports', async () => {
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' supports(display: grid);
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @supports (display: grid) {
       a {
@@ -351,14 +341,15 @@ test('@supports', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' supports(display: grid) screen and (max-width: 400px);
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @supports (display: grid) {
       @media screen and (max-width: 400px) {
@@ -370,15 +361,16 @@ test('@supports', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' supports((not (display: grid)) and (display: flex)) screen and
           (max-width: 400px);
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @supports (not (display: grid)) and (display: flex) {
       @media screen and (max-width: 400px) {
@@ -390,16 +382,17 @@ test('@supports', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       // prettier-ignore
       css`
         @import 'example.css'
         supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @supports selector(h2 > p) and font-tech(color-COLRv1) {
       a {
@@ -411,14 +404,15 @@ test('@supports', async () => {
 })
 
 test('@layer', async () => {
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' layer(utilities);
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @layer utilities {
       a {
@@ -428,14 +422,15 @@ test('@layer', async () => {
     "
   `)
 
-  await expect(
-    run(
+  expect(
+    await run(
+      [],
       css`
         @import 'example.css' layer();
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     @layer {
       a {
@@ -447,13 +442,15 @@ test('@layer', async () => {
 })
 
 test('supports theme(reference) imports', async () => {
-  await expect(
-    run(
+  expect(
+    await run(
+      ['text-red-500'],
       css`
         @tailwind utilities;
         @import 'example.css' theme(reference);
       `,
       {
+        base: '/root',
         loadStylesheet: () =>
           Promise.resolve({
             content: css`
@@ -464,10 +461,9 @@ test('supports theme(reference) imports', async () => {
             base: '',
             path: '',
           }),
-        candidates: ['text-red-500'],
       },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     .text-red-500 {
       color: var(--color-red-500, red);
@@ -490,12 +486,13 @@ test('updates the base when loading modules inside nested files', async () => {
 
   expect(
     await run(
+      [],
       css`
         @import './foo/bar.css';
         @config './root-config.js';
         @plugin './root-plugin.js';
       `,
-      { loadStylesheet, loadModule },
+      { base: '/root', loadStylesheet, loadModule },
     ),
   ).toBe('')
 
@@ -597,10 +594,11 @@ test('it crashes when inside a cycle', async () => {
 
   await expect(
     run(
+      [],
       css`
         @import 'foo.css';
       `,
-      { loadStylesheet },
+      { base: '/root', loadStylesheet },
     ),
   ).rejects.toMatchInlineSnapshot(
     `[Error: Exceeded maximum recursion depth while resolving \`foo.css\` in \`/root\`)]`,
@@ -625,15 +623,16 @@ test('resolves @reference as `@import "…" reference`', async () => {
     }
   }
 
-  await expect(
-    run(
+  expect(
+    await run(
+      ['text-red-500'],
       css`
         @reference './foo/bar.css';
         @tailwind utilities;
       `,
-      { loadStylesheet, candidates: ['text-red-500'] },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     .text-red-500 {
       color: var(--color-red-500, red);
@@ -659,15 +658,16 @@ test('resolves `@variant` used as `@custom-variant` inside `@reference`', async 
     }
   }
 
-  await expect(
-    run(
+  expect(
+    await run(
+      ['dark:flex'],
       css`
         @reference './foo/bar.css';
         @tailwind utilities;
       `,
-      { loadStylesheet, candidates: ['dark:flex'] },
+      { base: '/root', loadStylesheet },
     ),
-  ).resolves.toMatchInlineSnapshot(`
+  ).toMatchInlineSnapshot(`
     "
     .dark\\:flex:where([data-theme="dark"] *) {
       display: flex;

--- a/packages/tailwindcss/src/at-import.test.ts
+++ b/packages/tailwindcss/src/at-import.test.ts
@@ -2,7 +2,7 @@ import dedent from 'dedent'
 import { expect, test, vi } from 'vitest'
 import { compile, type Config } from './index'
 import plugin from './plugin'
-import { run } from './test-utils/run'
+import { compileCss, run } from './test-utils/run'
 
 const css = dedent
 
@@ -22,8 +22,7 @@ test('can resolve relative @imports', async () => {
   }
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import './foo/bar.css';
       `,
@@ -64,8 +63,7 @@ test('can recursively resolve relative @imports', async () => {
   }
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import './foo/bar.css';
       `,
@@ -96,8 +94,7 @@ let loadStylesheet = async (id: string) => {
 
 test('extracts path from @import nodes', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css';
       `,
@@ -112,8 +109,7 @@ test('extracts path from @import nodes', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import './example.css';
       `,
@@ -128,8 +124,7 @@ test('extracts path from @import nodes', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import '/example.css';
       `,
@@ -146,8 +141,7 @@ test('extracts path from @import nodes', async () => {
 
 test('url() imports are passed-through', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import url('example.css');
       `,
@@ -160,8 +154,7 @@ test('url() imports are passed-through', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import url('./example.css');
       `,
@@ -174,8 +167,7 @@ test('url() imports are passed-through', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import url('/example.css');
       `,
@@ -188,8 +180,7 @@ test('url() imports are passed-through', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import url(example.css);
       `,
@@ -202,8 +193,7 @@ test('url() imports are passed-through', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import url(./example.css);
       `,
@@ -216,8 +206,7 @@ test('url() imports are passed-through', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import url(/example.css);
       `,
@@ -232,8 +221,7 @@ test('url() imports are passed-through', async () => {
 
 test('handles case-insensitive @import directive', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css';
       `,
@@ -250,8 +238,7 @@ test('handles case-insensitive @import directive', async () => {
 
 test('@media', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' print;
       `,
@@ -268,8 +255,7 @@ test('@media', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' print, screen;
       `,
@@ -286,8 +272,7 @@ test('@media', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' screen and (orientation: landscape);
       `,
@@ -304,8 +289,7 @@ test('@media', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' foo(bar);
       `,
@@ -324,8 +308,7 @@ test('@media', async () => {
 
 test('@supports', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' supports(display: grid);
       `,
@@ -342,8 +325,7 @@ test('@supports', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' supports(display: grid) screen and (max-width: 400px);
       `,
@@ -362,8 +344,7 @@ test('@supports', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' supports((not (display: grid)) and (display: flex)) screen and
           (max-width: 400px);
@@ -383,13 +364,12 @@ test('@supports', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       // prettier-ignore
       css`
-        @import 'example.css'
-        supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
-      `,
+      @import 'example.css'
+      supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
+    `,
       { base: '/root', loadStylesheet },
     ),
   ).toMatchInlineSnapshot(`
@@ -405,8 +385,7 @@ test('@supports', async () => {
 
 test('@layer', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' layer(utilities);
       `,
@@ -423,8 +402,7 @@ test('@layer', async () => {
   `)
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import 'example.css' layer();
       `,
@@ -485,8 +463,7 @@ test('updates the base when loading modules inside nested files', async () => {
   using loadModule = vi.fn().mockResolvedValue({ base: '', path: '', module: () => {} })
 
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @import './foo/bar.css';
         @config './root-config.js';
@@ -593,8 +570,7 @@ test('it crashes when inside a cycle', async () => {
     })
 
   await expect(
-    run(
-      [],
+    compileCss(
       css`
         @import 'foo.css';
       `,

--- a/packages/tailwindcss/src/at-import.test.ts
+++ b/packages/tailwindcss/src/at-import.test.ts
@@ -7,7 +7,7 @@ import { compileCss, run } from './test-utils/run'
 const css = dedent
 
 test('can resolve relative @imports', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  async function loadStylesheet(id: string, base: string) {
     expect(base).toBe('/root')
     expect(id).toBe('./foo/bar.css')
     return {
@@ -38,7 +38,7 @@ test('can resolve relative @imports', async () => {
 })
 
 test('can recursively resolve relative @imports', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  async function loadStylesheet(id: string, base: string) {
     if (base === '/root' && id === './foo/bar.css') {
       return {
         content: css`
@@ -83,7 +83,7 @@ let exampleCSS = css`
     color: red;
   }
 `
-let loadStylesheet = async (id: string) => {
+async function loadStylesheet(id: string) {
   if (!id.endsWith('example.css')) throw new Error('Unexpected import: ' + id)
   return {
     content: exampleCSS,
@@ -451,15 +451,16 @@ test('supports theme(reference) imports', async () => {
 })
 
 test('updates the base when loading modules inside nested files', async () => {
-  let loadStylesheet = () =>
-    Promise.resolve({
+  async function loadStylesheet() {
+    return {
       content: css`
         @config './nested-config.js';
         @plugin './nested-plugin.js';
       `,
       base: '/root/foo',
       path: '',
-    })
+    }
+  }
   using loadModule = vi.fn().mockResolvedValue({ base: '', path: '', module: () => {} })
 
   expect(
@@ -480,14 +481,15 @@ test('updates the base when loading modules inside nested files', async () => {
 })
 
 test('emits the right base for @source directives inside nested files', async () => {
-  let loadStylesheet = () =>
-    Promise.resolve({
+  async function loadStylesheet() {
+    return {
       content: css`
         @source './nested/**/*.css';
       `,
       base: '/root/foo',
       path: '',
-    })
+    }
+  }
 
   let compiler = await compile(
     css`
@@ -504,15 +506,17 @@ test('emits the right base for @source directives inside nested files', async ()
 })
 
 test('emits the right base for @source found inside JS configs and plugins from nested imports', async () => {
-  let loadStylesheet = () =>
-    Promise.resolve({
+  async function loadStylesheet() {
+    return {
       content: css`
         @config './nested-config.js';
         @plugin './nested-plugin.js';
       `,
       base: '/root/foo',
       path: '',
-    })
+    }
+  }
+
   using loadModule = vi.fn().mockImplementation((id: string) => {
     let base = id.includes('nested') ? '/root/foo' : '/root'
     if (id.includes('config')) {
@@ -564,12 +568,13 @@ test('it crashes when inside a cycle', async () => {
     @import 'foo.css';
   `
 
-  let loadStylesheet = () =>
-    Promise.resolve({
+  async function loadStylesheet() {
+    return {
       content: input,
       base: '/root',
       path: '',
-    })
+    }
+  }
 
   await expect(compileCss(input, { base: '/root', loadStylesheet })).rejects.toMatchInlineSnapshot(
     `[Error: Exceeded maximum recursion depth while resolving \`foo.css\` in \`/root\`)]`,
@@ -577,7 +582,7 @@ test('it crashes when inside a cycle', async () => {
 })
 
 test('resolves @reference as `@import "…" reference`', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  async function loadStylesheet(id: string, base: string) {
     expect(base).toBe('/root')
     expect(id).toBe('./foo/bar.css')
     return {
@@ -613,7 +618,7 @@ test('resolves @reference as `@import "…" reference`', async () => {
 })
 
 test('resolves `@variant` used as `@custom-variant` inside `@reference`', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  async function loadStylesheet(id: string, base: string) {
     expect(base).toBe('/root')
     expect(id).toBe('./foo/bar.css')
     return {

--- a/packages/tailwindcss/src/at-import.test.ts
+++ b/packages/tailwindcss/src/at-import.test.ts
@@ -367,9 +367,9 @@ test('@supports', async () => {
     await compileCss(
       // prettier-ignore
       css`
-      @import 'example.css'
-      supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
-    `,
+        @import 'example.css'
+        supports((selector(h2 > p)) and (font-tech(color-COLRv1)));
+      `,
       { base: '/root', loadStylesheet },
     ),
   ).toMatchInlineSnapshot(`

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile, type Config } from '..'
 import { default as plugin } from '../plugin'
-import { compileCss } from '../test-utils/run'
+import { compileCss, run } from '../test-utils/run'
 import flattenColorPalette from './flatten-color-palette'
 
 const css = String.raw
@@ -21,12 +21,12 @@ test('Config files can add content', async () => {
 
 test('Config files can change dark mode (media)', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['dark:underline'],
       css`
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['dark:underline'],
       {
         loadModule: async () => ({ module: { darkMode: 'media' }, base: '/root', path: '' }),
       },
@@ -44,12 +44,12 @@ test('Config files can change dark mode (media)', async () => {
 
 test('Config files can change dark mode (selector)', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['dark:underline'],
       css`
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['dark:underline'],
       {
         loadModule: async () => ({ module: { darkMode: 'selector' }, base: '/root', path: '' }),
       },
@@ -65,12 +65,12 @@ test('Config files can change dark mode (selector)', async () => {
 
 test('Config files can change dark mode (variant)', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['dark:underline'],
       css`
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['dark:underline'],
       {
         loadModule: async () => ({
           module: { darkMode: ['variant', '&:where(:not(.light))'] },
@@ -90,12 +90,12 @@ test('Config files can change dark mode (variant)', async () => {
 
 test('Config files can add plugins', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['no-scrollbar'],
       css`
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['no-scrollbar'],
       {
         loadModule: async () => ({
           module: {
@@ -125,12 +125,12 @@ test('Config files can add plugins', async () => {
 
 test('Plugins loaded from config files can contribute to the config', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['dark:underline'],
       css`
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['dark:underline'],
       {
         loadModule: async () => ({
           module: {
@@ -156,12 +156,12 @@ test('Plugins loaded from config files can contribute to the config', async () =
 
 test('Config file presets can contribute to the config', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['dark:underline'],
       css`
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['dark:underline'],
       {
         loadModule: async () => ({
           module: { presets: [{ darkMode: ['variant', '&:where(:not(.light))'] }] },
@@ -181,12 +181,12 @@ test('Config file presets can contribute to the config', async () => {
 
 test('Config files can affect the theme', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['bg-primary', 'scrollbar-primary'],
       css`
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['bg-primary', 'scrollbar-primary'],
       {
         loadModule: async () => ({
           module: {
@@ -229,7 +229,8 @@ test('Config files can affect the theme', async () => {
 // https://github.com/tailwindlabs/tailwindcss/issues/19091
 test('Accessing a default color if a sub-color exists via CSS should work as expected', async () => {
   expect(
-    await compileCss(
+    await run(
+      [],
       css`
         @tailwind utilities;
         @config "./config.js";
@@ -239,7 +240,6 @@ test('Accessing a default color if a sub-color exists via CSS should work as exp
           border-color: theme('colors.foo');
         }
       `,
-      [],
       {
         loadModule: async () => ({
           module: {
@@ -273,14 +273,14 @@ test('Accessing a default color if a sub-color exists via CSS should work as exp
 
 test('Variants in CSS overwrite variants from plugins', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['dark:underline', 'light:underline'],
       css`
         @tailwind utilities;
         @config "./config.js";
         @custom-variant dark (&:is(.my-dark));
         @custom-variant light (&:is(.my-light));
       `,
-      ['dark:underline', 'light:underline'],
       {
         loadModule: async () => ({
           module: {
@@ -310,7 +310,8 @@ describe('theme callbacks', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['leading-base', 'leading-md', 'leading-xl', 'prose'],
         css`
           @theme default {
             --text-base: 0rem;
@@ -327,7 +328,6 @@ describe('theme callbacks', () => {
           @tailwind utilities;
           @config "./config.js";
         `,
-        ['leading-base', 'leading-md', 'leading-xl', 'prose'],
         {
           loadModule: async () => ({
             module: {
@@ -431,7 +431,8 @@ describe('theme callbacks', () => {
 describe('theme overrides order', () => {
   test('user theme > js config > default theme', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-red', 'bg-blue'],
         css`
           @theme default {
             --color-red: red;
@@ -442,7 +443,6 @@ describe('theme overrides order', () => {
           @tailwind utilities;
           @config "./config.js";
         `,
-        ['bg-red', 'bg-blue'],
         {
           loadModule: async () => ({
             module: {
@@ -479,21 +479,7 @@ describe('theme overrides order', () => {
 
   test('user theme > js config > default theme (with nested object)', async () => {
     expect(
-      await compileCss(
-        css`
-          @theme default {
-            --color-slate-100: #000100;
-            --color-slate-200: #000200;
-            --color-slate-300: #000300;
-          }
-          @theme {
-            --color-slate-400: #100400;
-            --color-slate-500: #100500;
-          }
-          @tailwind utilities;
-          @config "./config.js";
-          @plugin "./plugin.js";
-        `,
+      await run(
         [
           'bg-slate-100',
           'bg-slate-200',
@@ -508,6 +494,20 @@ describe('theme overrides order', () => {
           'hover-bg-slate-500',
           'hover-bg-slate-600',
         ],
+        css`
+          @theme default {
+            --color-slate-100: #000100;
+            --color-slate-200: #000200;
+            --color-slate-300: #000300;
+          }
+          @theme {
+            --color-slate-400: #100400;
+            --color-slate-500: #100500;
+          }
+          @tailwind utilities;
+          @config "./config.js";
+          @plugin "./plugin.js";
+        `,
         {
           loadModule: async (id) => {
             if (id.includes('config.js')) {
@@ -615,7 +615,8 @@ describe('theme overrides order', () => {
 describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` sets `--default-font-family`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['font-sans'],
         css`
           @theme default {
             --default-font-family: var(--font-family-sans);
@@ -625,7 +626,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-sans'],
         {
           loadModule: async () => ({
             module: {
@@ -653,7 +653,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-sans'],
         css`
           @theme default {
             --default-font-family: var(--font-family-sans);
@@ -663,7 +664,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-sans'],
         {
           loadModule: async () => ({
             module: {
@@ -692,7 +692,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-sans'],
         css`
           @theme default {
             --default-font-family: var(--font-family-sans);
@@ -702,7 +703,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-sans'],
         {
           loadModule: async () => ({
             module: {
@@ -731,7 +731,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-sans'],
         css`
           @theme default {
             --default-font-family: var(--font-family-sans);
@@ -741,7 +742,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-sans'],
         {
           loadModule: async () => ({
             module: {
@@ -774,7 +774,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-sans'],
         css`
           @theme default {
             --default-font-family: var(--font-family-sans);
@@ -787,7 +788,6 @@ describe('default font family compatibility', () => {
           }
           @tailwind utilities;
         `,
-        ['font-sans'],
         {
           loadModule: async () => ({
             module: {
@@ -819,7 +819,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-sans'],
         css`
           @theme default {
             --default-font-family: var(--font-family-sans);
@@ -829,7 +830,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-sans'],
         {
           loadModule: async () => ({
             module: {
@@ -857,7 +857,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-sans'],
         css`
           @theme default {
             --default-font-family: var(--font-family-sans);
@@ -867,7 +868,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-sans'],
         {
           loadModule: async () => ({
             module: {
@@ -887,7 +887,8 @@ describe('default font family compatibility', () => {
 
   test('overriding `fontFamily.mono` sets `--default-mono-font-family`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['font-mono'],
         css`
           @theme default {
             --default-mono-font-family: var(--font-family-mono);
@@ -899,7 +900,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-mono'],
         {
           loadModule: async () => ({
             module: {
@@ -927,7 +927,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-mono'],
         css`
           @theme default {
             --default-mono-font-family: var(--font-family-mono);
@@ -939,7 +940,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-mono'],
         {
           loadModule: async () => ({
             module: {
@@ -968,7 +968,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-mono'],
         css`
           @theme default {
             --default-mono-font-family: var(--font-family-mono);
@@ -980,7 +981,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-mono'],
         {
           loadModule: async () => ({
             module: {
@@ -1009,7 +1009,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-mono'],
         css`
           @theme default {
             --default-mono-font-family: var(--font-mono);
@@ -1019,7 +1020,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-mono'],
         {
           loadModule: async () => ({
             module: {
@@ -1052,7 +1052,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-mono'],
         css`
           @theme default {
             --default-mono-font-family: var(--font-mono);
@@ -1065,7 +1066,6 @@ describe('default font family compatibility', () => {
           }
           @tailwind utilities;
         `,
-        ['font-mono'],
         {
           loadModule: async () => ({
             module: {
@@ -1097,7 +1097,8 @@ describe('default font family compatibility', () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['font-mono'],
         css`
           @theme default {
             --default-mono-font-family: var(--font-family-mono);
@@ -1109,7 +1110,6 @@ describe('default font family compatibility', () => {
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['font-mono'],
         {
           loadModule: async () => ({
             module: {
@@ -1130,11 +1130,7 @@ describe('default font family compatibility', () => {
 
 test('creates variants for `data`, `supports`, and `aria` theme options at the same level as the core utility ', async () => {
   expect(
-    await compileCss(
-      css`
-        @tailwind utilities;
-        @config "./config.js";
-      `,
+    await run(
       [
         'aria-polite:underline',
         'supports-child-combinator:underline',
@@ -1150,6 +1146,10 @@ test('creates variants for `data`, `supports`, and `aria` theme options at the s
         // the other custom variants.
         'print:flex',
       ],
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
       {
         loadModule: async () => ({
           module: {
@@ -1216,7 +1216,8 @@ test('creates variants for `data`, `supports`, and `aria` theme options at the s
 
 test('merges css breakpoints with js config screens', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['sm:flex', 'md:flex', 'lg:flex', 'min-sm:max-md:underline'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -1231,7 +1232,6 @@ test('merges css breakpoints with js config screens', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['sm:flex', 'md:flex', 'lg:flex', 'min-sm:max-md:underline'],
       {
         loadModule: async () => ({
           module: {
@@ -1280,7 +1280,8 @@ test('merges css breakpoints with js config screens', async () => {
 test('utilities must be prefixed', async () => {
   // Prefixed utilities are generated
   expect(
-    await compileCss(
+    await run(
+      ['tw:underline', 'tw:hover:line-through', 'tw:custom'],
       css`
         @tailwind utilities;
         @config "./config.js";
@@ -1289,7 +1290,6 @@ test('utilities must be prefixed', async () => {
           color: red;
         }
       `,
-      ['tw:underline', 'tw:hover:line-through', 'tw:custom'],
       {
         loadModule: async (_id, base) => ({
           path: '',
@@ -1318,7 +1318,8 @@ test('utilities must be prefixed', async () => {
 
   // Non-prefixed utilities are ignored
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'hover:line-through', 'custom'],
       css`
         @tailwind utilities;
         @config "./config.js";
@@ -1327,7 +1328,6 @@ test('utilities must be prefixed', async () => {
           color: red;
         }
       `,
-      ['underline', 'hover:line-through', 'custom'],
       {
         loadModule: async (_id, base) => ({
           path: '',
@@ -1342,7 +1342,8 @@ test('utilities must be prefixed', async () => {
 test('utilities used in @apply must be prefixed', async () => {
   // Prefixed utilities are generated
   expect(
-    await compileCss(
+    await run(
+      [],
       css`
         @config "./config.js";
 
@@ -1350,7 +1351,6 @@ test('utilities used in @apply must be prefixed', async () => {
           @apply tw:underline;
         }
       `,
-      [],
       {
         loadModule: async (_id, base) => ({
           path: '',
@@ -1393,7 +1393,8 @@ test('utilities used in @apply must be prefixed', async () => {
 
 test('Prefixes configured in CSS take precedence over those defined in JS configs', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['wat:custom'],
       css`
         @theme prefix(wat) {
           --color-red: #f00;
@@ -1409,7 +1410,6 @@ test('Prefixes configured in CSS take precedence over those defined in JS config
           color: red;
         }
       `,
-      ['wat:custom'],
       {
         async loadModule(_id, base) {
           return {
@@ -1452,7 +1452,8 @@ test('a prefix must be letters only', async () => {
 
 test('important: `#app`', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'hover:line-through', 'custom'],
       css`
         @tailwind utilities;
         @config "./config.js";
@@ -1461,7 +1462,6 @@ test('important: `#app`', async () => {
           color: red;
         }
       `,
-      ['underline', 'hover:line-through', 'custom'],
       {
         loadModule: async (_id, base) => ({
           path: '',
@@ -1491,7 +1491,8 @@ test('important: `#app`', async () => {
 
 test('important: true', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'hover:line-through', 'custom'],
       css`
         @tailwind utilities;
         @config "./config.js";
@@ -1500,7 +1501,6 @@ test('important: true', async () => {
           color: red;
         }
       `,
-      ['underline', 'hover:line-through', 'custom'],
       {
         loadModule: async (_id, base) => ({
           path: '',
@@ -1531,7 +1531,8 @@ test('important: true', async () => {
 test('blocklisted candidates are not generated', async () => {
   // bg-white will not get generated
   expect(
-    await compileCss(
+    await run(
+      ['bg-white'],
       css`
         @theme reference {
           --color-white: #fff;
@@ -1540,7 +1541,6 @@ test('blocklisted candidates are not generated', async () => {
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['bg-white'],
       {
         async loadModule(_id, base) {
           return {
@@ -1557,7 +1557,8 @@ test('blocklisted candidates are not generated', async () => {
 
   // underline will as will md:bg-white
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'bg-white', 'md:bg-white'],
       css`
         @theme reference {
           --color-white: #fff;
@@ -1566,7 +1567,6 @@ test('blocklisted candidates are not generated', async () => {
         @tailwind utilities;
         @config "./config.js";
       `,
-      ['underline', 'bg-white', 'md:bg-white'],
       {
         async loadModule(_id, base) {
           return {
@@ -1751,7 +1751,8 @@ test('old theme values are merged with their renamed counterparts in the CSS the
 
 test('handles setting theme keys to null', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['bg-red-50', 'bg-red-100', 'bg-red-200'],
       css`
         @theme default {
           --color-red-50: oklch(0.971 0.013 17.38);
@@ -1764,7 +1765,6 @@ test('handles setting theme keys to null', async () => {
           --color-red-200: oklch(0.885 0.062 18.334);
         }
       `,
-      ['bg-red-50', 'bg-red-100', 'bg-red-200'],
       {
         loadModule: async () => {
           return {
@@ -1842,14 +1842,7 @@ test('The theme() function does not try indexing into strings', async () => {
 
 test('camel case keys are preserved', async () => {
   expect(
-    await compileCss(
-      css`
-        @tailwind utilities;
-        @theme {
-          --color-blue-green: slate;
-        }
-        @config "./plugin.js";
-      `,
+    await run(
       [
         // From CSS
         'bg-blue-green', // should be output
@@ -1859,6 +1852,13 @@ test('camel case keys are preserved', async () => {
         'bg-light-green', // should not be output
         'bg-lightGreen', // should be
       ],
+      css`
+        @tailwind utilities;
+        @theme {
+          --color-blue-green: slate;
+        }
+        @config "./plugin.js";
+      `,
       {
         loadModule: async () => {
           return {

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile, type Config } from '..'
 import { default as plugin } from '../plugin'
-import { pretty } from '../test-utils/run'
+import { compileCss } from '../test-utils/run'
 import flattenColorPalette from './flatten-color-palette'
 
 const css = String.raw
@@ -20,19 +20,21 @@ test('Config files can add content', async () => {
 })
 
 test('Config files can change dark mode (media)', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({ module: { darkMode: 'media' }, base: '/root', path: '' }),
-  })
-
-  expect(pretty(compiler.build(['dark:underline']))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['dark:underline'],
+      {
+        loadModule: async () => ({ module: { darkMode: 'media' }, base: '/root', path: '' }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
-    .dark\\:underline {
-      @media (prefers-color-scheme: dark) {
+    @media (prefers-color-scheme: dark) {
+      .dark\\:underline {
         text-decoration-line: underline;
       }
     }
@@ -41,76 +43,78 @@ test('Config files can change dark mode (media)', async () => {
 })
 
 test('Config files can change dark mode (selector)', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({ module: { darkMode: 'selector' }, base: '/root', path: '' }),
-  })
-
-  expect(pretty(compiler.build(['dark:underline']))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['dark:underline'],
+      {
+        loadModule: async () => ({ module: { darkMode: 'selector' }, base: '/root', path: '' }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
-    .dark\\:underline {
-      &:where(.dark, .dark *) {
-        text-decoration-line: underline;
-      }
+    .dark\\:underline:where(.dark, .dark *) {
+      text-decoration-line: underline;
     }
     "
   `)
 })
 
 test('Config files can change dark mode (variant)', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: { darkMode: ['variant', '&:where(:not(.light))'] },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['dark:underline']))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['dark:underline'],
+      {
+        loadModule: async () => ({
+          module: { darkMode: ['variant', '&:where(:not(.light))'] },
+          base: '/root',
+          path: '',
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
-    .dark\\:underline {
-      &:where(:not(.light)) {
-        text-decoration-line: underline;
-      }
+    .dark\\:underline:where(:not(.light)) {
+      text-decoration-line: underline;
     }
     "
   `)
 })
 
 test('Config files can add plugins', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        plugins: [
-          plugin(function ({ addUtilities }) {
-            addUtilities({
-              '.no-scrollbar': {
-                'scrollbar-width': 'none',
-              },
-            })
-          }),
-        ],
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['no-scrollbar'],
+      {
+        loadModule: async () => ({
+          module: {
+            plugins: [
+              plugin(function ({ addUtilities }) {
+                addUtilities({
+                  '.no-scrollbar': {
+                    'scrollbar-width': 'none',
+                  },
+                })
+              }),
+            ],
+          },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['no-scrollbar']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .no-scrollbar {
       scrollbar-width: none;
@@ -120,104 +124,101 @@ test('Config files can add plugins', async () => {
 })
 
 test('Plugins loaded from config files can contribute to the config', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        plugins: [
-          plugin(() => {}, {
-            darkMode: ['variant', '&:where(:not(.light))'],
-          }),
-        ],
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['dark:underline'],
+      {
+        loadModule: async () => ({
+          module: {
+            plugins: [
+              plugin(() => {}, {
+                darkMode: ['variant', '&:where(:not(.light))'],
+              }),
+            ],
+          },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['dark:underline']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
-    .dark\\:underline {
-      &:where(:not(.light)) {
-        text-decoration-line: underline;
-      }
+    .dark\\:underline:where(:not(.light)) {
+      text-decoration-line: underline;
     }
     "
   `)
 })
 
 test('Config file presets can contribute to the config', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        presets: [
-          {
-            darkMode: ['variant', '&:where(:not(.light))'],
-          },
-        ],
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['dark:underline'],
+      {
+        loadModule: async () => ({
+          module: { presets: [{ darkMode: ['variant', '&:where(:not(.light))'] }] },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['dark:underline']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
-    .dark\\:underline {
-      &:where(:not(.light)) {
-        text-decoration-line: underline;
-      }
+    .dark\\:underline:where(:not(.light)) {
+      text-decoration-line: underline;
     }
     "
   `)
 })
 
 test('Config files can affect the theme', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          extend: {
-            colors: {
-              primary: '#c0ffee',
-            },
-          },
-        },
-
-        plugins: [
-          plugin(function ({ addUtilities, theme }) {
-            addUtilities({
-              '.scrollbar-primary': {
-                scrollbarColor: theme('colors.primary'),
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['bg-primary', 'scrollbar-primary'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                colors: {
+                  primary: '#c0ffee',
+                },
               },
-            })
-          }),
-        ],
-      },
-      base: '/root',
-      path: '',
-    }),
-  })
+            },
 
-  expect(pretty(compiler.build(['bg-primary', 'scrollbar-primary']))).toMatchInlineSnapshot(`
+            plugins: [
+              plugin(function ({ addUtilities, theme }) {
+                addUtilities({
+                  '.scrollbar-primary': {
+                    scrollbarColor: theme('colors.primary'),
+                  },
+                })
+              }),
+            ],
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .scrollbar-primary {
       scrollbar-color: #c0ffee;
     }
+
     .bg-primary {
       background-color: #c0ffee;
     }
@@ -227,38 +228,40 @@ test('Config files can affect the theme', async () => {
 
 // https://github.com/tailwindlabs/tailwindcss/issues/19091
 test('Accessing a default color if a sub-color exists via CSS should work as expected', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
 
-    .example {
-      color: theme('colors.foo-bar');
-      border-color: theme('colors.foo');
-    }
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          // Internally this object gets converted to something like:
-          // ```
-          // {
-          //   foo: { DEFAULT: 'var(--foo-foo)', bar: 'var(--foo-foo-bar)' },
-          // }
-          // ```
-          colors: {
-            foo: 'var(--foo-foo)',
-            'foo-bar': 'var(--foo-foo-bar)',
+        .example {
+          color: theme('colors.foo-bar');
+          border-color: theme('colors.foo');
+        }
+      `,
+      [],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              // Internally this object gets converted to something like:
+              // ```
+              // {
+              //   foo: { DEFAULT: 'var(--foo-foo)', bar: 'var(--foo-foo-bar)' },
+              // }
+              // ```
+              colors: {
+                foo: 'var(--foo-foo)',
+                'foo-bar': 'var(--foo-foo-bar)',
+              },
+            },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .example {
       color: var(--foo-foo-bar);
@@ -269,39 +272,34 @@ test('Accessing a default color if a sub-color exists via CSS should work as exp
 })
 
 test('Variants in CSS overwrite variants from plugins', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-    @custom-variant dark (&:is(.my-dark));
-    @custom-variant light (&:is(.my-light));
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        darkMode: ['variant', '&:is(.dark)'],
-        plugins: [
-          plugin(function ({ addVariant }) {
-            addVariant('light', '&:is(.light)')
-          }),
-        ],
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+        @custom-variant dark (&:is(.my-dark));
+        @custom-variant light (&:is(.my-light));
+      `,
+      ['dark:underline', 'light:underline'],
+      {
+        loadModule: async () => ({
+          module: {
+            darkMode: ['variant', '&:is(.dark)'],
+            plugins: [
+              plugin(function ({ addVariant }) {
+                addVariant('light', '&:is(.light)')
+              }),
+            ],
+          },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['dark:underline', 'light:underline']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
-    .dark\\:underline {
-      &:is(.my-dark) {
-        text-decoration-line: underline;
-      }
-    }
-    .light\\:underline {
-      &:is(.my-light) {
-        text-decoration-line: underline;
-      }
+    .dark\\:underline.my-dark, .light\\:underline.my-light {
+      text-decoration-line: underline;
     }
     "
   `)
@@ -311,158 +309,167 @@ describe('theme callbacks', () => {
   test('tuple values from the config overwrite `@theme default` tuple-ish values from the CSS theme', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --text-base: 0rem;
-        --text-base--line-height: 1rem;
-        --text-md: 0rem;
-        --text-md--line-height: 1rem;
-        --text-xl: 0rem;
-        --text-xl--line-height: 1rem;
-      }
-      @theme {
-        --text-base: 100rem;
-        --text-md--line-height: 101rem;
-      }
-      @tailwind utilities;
-      @config "./config.js";
-    `
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --text-base: 0rem;
+            --text-base--line-height: 1rem;
+            --text-md: 0rem;
+            --text-md--line-height: 1rem;
+            --text-xl: 0rem;
+            --text-xl--line-height: 1rem;
+          }
+          @theme {
+            --text-base: 100rem;
+            --text-md--line-height: 101rem;
+          }
+          @tailwind utilities;
+          @config "./config.js";
+        `,
+        ['leading-base', 'leading-md', 'leading-xl', 'prose'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                extend: {
+                  fontSize: {
+                    base: ['200rem', { lineHeight: '201rem' }],
+                    md: ['200rem', { lineHeight: '201rem' }],
+                    xl: ['200rem', { lineHeight: '201rem' }],
+                  },
 
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            extend: {
-              fontSize: {
-                base: ['200rem', { lineHeight: '201rem' }],
-                md: ['200rem', { lineHeight: '201rem' }],
-                xl: ['200rem', { lineHeight: '201rem' }],
+                  // Direct access
+                  lineHeight: ({ theme }) => ({
+                    base: theme('fontSize.base[1].lineHeight'),
+                    md: theme('fontSize.md[1].lineHeight'),
+                    xl: theme('fontSize.xl[1].lineHeight'),
+                  }),
+
+                  // Tuple access
+                  typography: ({ theme }) => ({
+                    '[class~=lead-base]': {
+                      fontSize: theme('fontSize.base')[0],
+                      ...theme('fontSize.base')[1],
+                    },
+                    '[class~=lead-md]': {
+                      fontSize: theme('fontSize.md')[0],
+                      ...theme('fontSize.md')[1],
+                    },
+                    '[class~=lead-xl]': {
+                      fontSize: theme('fontSize.xl')[0],
+                      ...theme('fontSize.xl')[1],
+                    },
+                  }),
+                },
               },
 
-              // Direct access
-              lineHeight: ({ theme }) => ({
-                base: theme('fontSize.base[1].lineHeight'),
-                md: theme('fontSize.md[1].lineHeight'),
-                xl: theme('fontSize.xl[1].lineHeight'),
-              }),
+              plugins: [
+                plugin(function ({ addUtilities, theme }) {
+                  addUtilities({
+                    '.prose': {
+                      ...theme('typography'),
+                    },
+                  })
+                }),
+              ],
+            } satisfies Config,
+            base: '/root',
+            path: '',
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      @layer properties {
+        @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+          *, :before, :after, ::backdrop {
+            --tw-leading: initial;
+          }
+        }
+      }
 
-              // Tuple access
-              typography: ({ theme }) => ({
-                '[class~=lead-base]': {
-                  fontSize: theme('fontSize.base')[0],
-                  ...theme('fontSize.base')[1],
-                },
-                '[class~=lead-md]': {
-                  fontSize: theme('fontSize.md')[0],
-                  ...theme('fontSize.md')[1],
-                },
-                '[class~=lead-xl]': {
-                  fontSize: theme('fontSize.xl')[0],
-                  ...theme('fontSize.xl')[1],
-                },
-              }),
-            },
-          },
+      .prose [class~="lead-base"] {
+        font-size: 100rem;
+        line-height: 201rem;
+      }
 
-          plugins: [
-            plugin(function ({ addUtilities, theme }) {
-              addUtilities({
-                '.prose': {
-                  ...theme('typography'),
-                },
-              })
-            }),
-          ],
-        } satisfies Config,
-        base: '/root',
-        path: '',
-      }),
-    })
+      .prose [class~="lead-md"] {
+        font-size: 200rem;
+        line-height: 101rem;
+      }
 
-    expect(pretty(compiler.build(['leading-base', 'leading-md', 'leading-xl', 'prose'])))
-      .toMatchInlineSnapshot(`
-        "
-        @layer properties;
-        .prose {
-          [class~=lead-base] {
-            font-size: 100rem;
-            line-height: 201rem;
-          }
-          [class~=lead-md] {
-            font-size: 200rem;
-            line-height: 101rem;
-          }
-          [class~=lead-xl] {
-            font-size: 200rem;
-            line-height: 201rem;
-          }
-        }
-        .leading-base {
-          --tw-leading: 201rem;
-          line-height: 201rem;
-        }
-        .leading-md {
-          --tw-leading: 101rem;
-          line-height: 101rem;
-        }
-        .leading-xl {
-          --tw-leading: 201rem;
-          line-height: 201rem;
-        }
-        @property --tw-leading {
-          syntax: "*";
-          inherits: false;
-        }
-        @layer properties {
-          @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
-            *, ::before, ::after, ::backdrop {
-              --tw-leading: initial;
-            }
-          }
-        }
-        "
-      `)
+      .prose [class~="lead-xl"] {
+        font-size: 200rem;
+        line-height: 201rem;
+      }
+
+      .leading-base {
+        --tw-leading: 201rem;
+        line-height: 201rem;
+      }
+
+      .leading-md {
+        --tw-leading: 101rem;
+        line-height: 101rem;
+      }
+
+      .leading-xl {
+        --tw-leading: 201rem;
+        line-height: 201rem;
+      }
+
+      @property --tw-leading {
+        syntax: "*";
+        inherits: false
+      }
+      "
+    `)
   })
 })
 
 describe('theme overrides order', () => {
   test('user theme > js config > default theme', async () => {
-    let input = css`
-      @theme default {
-        --color-red: red;
-      }
-      @theme {
-        --color-blue: blue;
-      }
-      @tailwind utilities;
-      @config "./config.js";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            extend: {
-              colors: {
-                red: 'very-red',
-                blue: 'very-blue',
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --color-red: red;
+          }
+          @theme {
+            --color-blue: blue;
+          }
+          @tailwind utilities;
+          @config "./config.js";
+        `,
+        ['bg-red', 'bg-blue'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                extend: {
+                  colors: {
+                    red: 'very-red',
+                    blue: 'very-blue',
+                  },
+                },
               },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['bg-red', 'bg-blue']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-blue: blue;
       }
+
       .bg-blue {
         background-color: var(--color-blue);
       }
+
       .bg-red {
         background-color: very-red;
       }
@@ -471,67 +478,23 @@ describe('theme overrides order', () => {
   })
 
   test('user theme > js config > default theme (with nested object)', async () => {
-    let input = css`
-      @theme default {
-        --color-slate-100: #000100;
-        --color-slate-200: #000200;
-        --color-slate-300: #000300;
-      }
-      @theme {
-        --color-slate-400: #100400;
-        --color-slate-500: #100500;
-      }
-      @tailwind utilities;
-      @config "./config.js";
-      @plugin "./plugin.js";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id) => {
-        if (id.includes('config.js')) {
-          return {
-            module: {
-              theme: {
-                extend: {
-                  colors: {
-                    slate: {
-                      200: '#200200',
-                      400: '#200400',
-                      600: '#200600',
-                    },
-                  },
-                },
-              },
-            } satisfies Config,
-            base: '/root',
-            path: '',
-          }
-        } else {
-          return {
-            module: plugin(({ matchUtilities, theme }) => {
-              matchUtilities(
-                {
-                  'hover-bg': (value) => {
-                    return {
-                      '&:hover': {
-                        backgroundColor: value,
-                      },
-                    }
-                  },
-                },
-                { values: flattenColorPalette(theme('colors')) },
-              )
-            }),
-            base: '/root',
-            path: '',
-          }
-        }
-      },
-    })
-
     expect(
-      pretty(
-        compiler.build([
+      await compileCss(
+        css`
+          @theme default {
+            --color-slate-100: #000100;
+            --color-slate-200: #000200;
+            --color-slate-300: #000300;
+          }
+          @theme {
+            --color-slate-400: #100400;
+            --color-slate-500: #100500;
+          }
+          @tailwind utilities;
+          @config "./config.js";
+          @plugin "./plugin.js";
+        `,
+        [
           'bg-slate-100',
           'bg-slate-200',
           'bg-slate-300',
@@ -544,7 +507,49 @@ describe('theme overrides order', () => {
           'hover-bg-slate-400',
           'hover-bg-slate-500',
           'hover-bg-slate-600',
-        ]),
+        ],
+        {
+          loadModule: async (id) => {
+            if (id.includes('config.js')) {
+              return {
+                module: {
+                  theme: {
+                    extend: {
+                      colors: {
+                        slate: {
+                          200: '#200200',
+                          400: '#200400',
+                          600: '#200600',
+                        },
+                      },
+                    },
+                  },
+                } satisfies Config,
+                base: '/root',
+                path: '',
+              }
+            } else {
+              return {
+                module: plugin(({ matchUtilities, theme }) => {
+                  matchUtilities(
+                    {
+                      'hover-bg': (value) => {
+                        return {
+                          '&:hover': {
+                            backgroundColor: value,
+                          },
+                        }
+                      },
+                    },
+                    { values: flattenColorPalette(theme('colors')) },
+                  )
+                }),
+                base: '/root',
+                path: '',
+              }
+            }
+          },
+        },
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -554,53 +559,53 @@ describe('theme overrides order', () => {
         --color-slate-400: #100400;
         --color-slate-500: #100500;
       }
+
       .bg-slate-100 {
         background-color: var(--color-slate-100);
       }
+
       .bg-slate-200 {
         background-color: #200200;
       }
+
       .bg-slate-300 {
         background-color: var(--color-slate-300);
       }
+
       .bg-slate-400 {
         background-color: var(--color-slate-400);
       }
+
       .bg-slate-500 {
         background-color: var(--color-slate-500);
       }
+
       .bg-slate-600 {
         background-color: #200600;
       }
-      .hover-bg-slate-100 {
-        &:hover {
-          background-color: #000100;
-        }
+
+      .hover-bg-slate-100:hover {
+        background-color: #000100;
       }
-      .hover-bg-slate-200 {
-        &:hover {
-          background-color: #200200;
-        }
+
+      .hover-bg-slate-200:hover {
+        background-color: #200200;
       }
-      .hover-bg-slate-300 {
-        &:hover {
-          background-color: #000300;
-        }
+
+      .hover-bg-slate-300:hover {
+        background-color: #000300;
       }
-      .hover-bg-slate-400 {
-        &:hover {
-          background-color: #100400;
-        }
+
+      .hover-bg-slate-400:hover {
+        background-color: #100400;
       }
-      .hover-bg-slate-500 {
-        &:hover {
-          background-color: #100500;
-        }
+
+      .hover-bg-slate-500:hover {
+        background-color: #100500;
       }
-      .hover-bg-slate-600 {
-        &:hover {
-          background-color: #200600;
-        }
+
+      .hover-bg-slate-600:hover {
+        background-color: #200600;
       }
       "
     `)
@@ -609,31 +614,33 @@ describe('theme overrides order', () => {
 
 describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` sets `--default-font-family`', async () => {
-    let input = css`
-      @theme default {
-        --default-font-family: var(--font-family-sans);
-        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              sans: 'Potato Sans',
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-font-family: var(--font-family-sans);
+            --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+            --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-sans'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  sans: 'Potato Sans',
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-sans']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-sans {
         font-family: Potato Sans;
@@ -645,35 +652,37 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans[1].fontFeatureSettings` sets `--default-font-feature-settings`', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-font-family: var(--font-family-sans);
-        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              sans: ['Potato Sans', { fontFeatureSettings: '"cv06"' }],
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-font-family: var(--font-family-sans);
+            --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+            --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-sans'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  sans: ['Potato Sans', { fontFeatureSettings: '"cv06"' }],
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-sans']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-sans {
-        font-family: Potato Sans;
         font-feature-settings: "cv06";
+        font-family: Potato Sans;
       }
       "
     `)
@@ -682,35 +691,37 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans[1].fontVariationSettings` sets `--default-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-font-family: var(--font-family-sans);
-        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              sans: ['Potato Sans', { fontVariationSettings: '"XHGT" 0.7' }],
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-font-family: var(--font-family-sans);
+            --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+            --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-sans'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  sans: ['Potato Sans', { fontVariationSettings: '"XHGT" 0.7' }],
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-sans']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-sans {
+        font-variation-settings: "XHGT" .7;
         font-family: Potato Sans;
-        font-variation-settings: "XHGT" 0.7;
       }
       "
     `)
@@ -719,39 +730,41 @@ describe('default font family compatibility', () => {
   test('overriding `fontFeatureSettings` and `fontVariationSettings` for `fontFamily.sans` sets `--default-font-feature-settings` and `--default-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-font-family: var(--font-family-sans);
-        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              sans: [
-                'Potato Sans',
-                { fontFeatureSettings: '"cv06"', fontVariationSettings: '"XHGT" 0.7' },
-              ],
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-font-family: var(--font-family-sans);
+            --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+            --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-sans'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  sans: [
+                    'Potato Sans',
+                    { fontFeatureSettings: '"cv06"', fontVariationSettings: '"XHGT" 0.7' },
+                  ],
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-sans']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-sans {
-        font-family: Potato Sans;
         font-feature-settings: "cv06";
-        font-variation-settings: "XHGT" 0.7;
+        font-variation-settings: "XHGT" .7;
+        font-family: Potato Sans;
       }
       "
     `)
@@ -760,38 +773,41 @@ describe('default font family compatibility', () => {
   test('overriding `--font-family-sans` in `@theme` without `default` preserves the original `--default-font-*` values', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-font-family: var(--font-family-sans);
-        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
-      }
-      @config "./config.js";
-      @theme {
-        --font-sans: Sandwich Sans;
-      }
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              sans: 'Potato Sans',
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-font-family: var(--font-family-sans);
+            --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+            --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+          }
+          @config "./config.js";
+          @theme {
+            --font-sans: Sandwich Sans;
+          }
+          @tailwind utilities;
+        `,
+        ['font-sans'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  sans: 'Potato Sans',
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-sans']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --font-sans: Sandwich Sans;
       }
+
       .font-sans {
         font-family: var(--font-sans);
       }
@@ -802,31 +818,33 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` in a config file with an array sets `--default-font-family`', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-font-family: var(--font-family-sans);
-        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              sans: ['Inter', 'system-ui', 'sans-serif'],
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-font-family: var(--font-family-sans);
+            --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+            --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-sans'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  sans: ['Inter', 'system-ui', 'sans-serif'],
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-sans']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-sans {
         font-family: Inter, system-ui, sans-serif;
@@ -838,59 +856,65 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` in a config file with an unexpected type is ignored', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-font-family: var(--font-family-sans);
-        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
-        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              sans: { foo: 'bar', banana: 'sandwich' },
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-font-family: var(--font-family-sans);
+            --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+            --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-sans'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  sans: { foo: 'bar', banana: 'sandwich' },
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-sans']))).toEqual('')
+      ),
+    ).toEqual('')
   })
 
   test('overriding `fontFamily.mono` sets `--default-mono-font-family`', async () => {
-    let input = css`
-      @theme default {
-        --default-mono-font-family: var(--font-family-mono);
-        --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
-        --default-mono-font-variation-settings: var(--font-family-mono--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              mono: 'Potato Mono',
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-mono-font-family: var(--font-family-mono);
+            --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
+            --default-mono-font-variation-settings: var(
+              --font-family-mono--font-variation-settings
+            );
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-mono'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  mono: 'Potato Mono',
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-mono']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-mono {
         font-family: Potato Mono;
@@ -902,35 +926,39 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.mono[1].fontFeatureSettings` sets `--default-mono-font-feature-settings`', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-mono-font-family: var(--font-family-mono);
-        --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
-        --default-mono-font-variation-settings: var(--font-family-mono--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              mono: ['Potato Mono', { fontFeatureSettings: '"cv06"' }],
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-mono-font-family: var(--font-family-mono);
+            --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
+            --default-mono-font-variation-settings: var(
+              --font-family-mono--font-variation-settings
+            );
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-mono'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  mono: ['Potato Mono', { fontFeatureSettings: '"cv06"' }],
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-mono']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-mono {
-        font-family: Potato Mono;
         font-feature-settings: "cv06";
+        font-family: Potato Mono;
       }
       "
     `)
@@ -939,35 +967,39 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.mono[1].fontVariationSettings` sets `--default-mono-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-mono-font-family: var(--font-family-mono);
-        --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
-        --default-mono-font-variation-settings: var(--font-family-mono--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              mono: ['Potato Mono', { fontVariationSettings: '"XHGT" 0.7' }],
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-mono-font-family: var(--font-family-mono);
+            --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
+            --default-mono-font-variation-settings: var(
+              --font-family-mono--font-variation-settings
+            );
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-mono'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  mono: ['Potato Mono', { fontVariationSettings: '"XHGT" 0.7' }],
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-mono']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-mono {
+        font-variation-settings: "XHGT" .7;
         font-family: Potato Mono;
-        font-variation-settings: "XHGT" 0.7;
       }
       "
     `)
@@ -976,39 +1008,41 @@ describe('default font family compatibility', () => {
   test('overriding `fontFeatureSettings` and `fontVariationSettings` for `fontFamily.mono` sets `--default-mono-font-feature-settings` and `--default-mono-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-mono-font-family: var(--font-mono);
-        --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
-        --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              mono: [
-                'Potato Mono',
-                { fontFeatureSettings: '"cv06"', fontVariationSettings: '"XHGT" 0.7' },
-              ],
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-mono-font-family: var(--font-mono);
+            --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
+            --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-mono'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  mono: [
+                    'Potato Mono',
+                    { fontFeatureSettings: '"cv06"', fontVariationSettings: '"XHGT" 0.7' },
+                  ],
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-mono']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .font-mono {
-        font-family: Potato Mono;
         font-feature-settings: "cv06";
-        font-variation-settings: "XHGT" 0.7;
+        font-variation-settings: "XHGT" .7;
+        font-family: Potato Mono;
       }
       "
     `)
@@ -1017,38 +1051,41 @@ describe('default font family compatibility', () => {
   test('overriding `--font-family-mono` in `@theme` without `default` preserves the original `--default-mono-font-*` values', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-mono-font-family: var(--font-mono);
-        --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
-        --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
-      }
-      @config "./config.js";
-      @theme {
-        --font-mono: Sandwich Mono;
-      }
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              mono: 'Potato Mono',
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-mono-font-family: var(--font-mono);
+            --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
+            --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
+          }
+          @config "./config.js";
+          @theme {
+            --font-mono: Sandwich Mono;
+          }
+          @tailwind utilities;
+        `,
+        ['font-mono'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  mono: 'Potato Mono',
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-mono']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --font-mono: Sandwich Mono;
       }
+
       .font-mono {
         font-family: var(--font-mono);
       }
@@ -1059,66 +1096,46 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.mono` in a config file with an unexpected type is ignored', async ({
     expect,
   }) => {
-    let input = css`
-      @theme default {
-        --default-mono-font-family: var(--font-family-mono);
-        --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
-        --default-mono-font-variation-settings: var(--font-family-mono--font-variation-settings);
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            fontFamily: {
-              mono: { foo: 'bar', banana: 'sandwich' },
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --default-mono-font-family: var(--font-family-mono);
+            --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
+            --default-mono-font-variation-settings: var(
+              --font-family-mono--font-variation-settings
+            );
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['font-mono'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                fontFamily: {
+                  mono: { foo: 'bar', banana: 'sandwich' },
+                },
+              },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(pretty(compiler.build(['font-mono']))).toEqual('')
+      ),
+    ).toEqual('')
   })
 })
 
 test('creates variants for `data`, `supports`, and `aria` theme options at the same level as the core utility ', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          extend: {
-            aria: {
-              polite: 'live="polite"',
-            },
-            supports: {
-              'child-combinator': 'selector(h2 > p)',
-              foo: 'bar',
-            },
-            data: {
-              checked: 'ui~="checked"',
-            },
-          },
-        },
-      },
-      base: '/root',
-      path: '',
-    }),
-  })
-
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      [
         'aria-polite:underline',
         'supports-child-combinator:underline',
         'supports-foo:underline',
@@ -1132,47 +1149,64 @@ test('creates variants for `data`, `supports`, and `aria` theme options at the s
         // The `print` variant should still be sorted last, even after registering
         // the other custom variants.
         'print:flex',
-      ]),
+      ],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                aria: {
+                  polite: 'live="polite"',
+                },
+                supports: {
+                  'child-combinator': 'selector(h2 > p)',
+                  foo: 'bar',
+                },
+                data: {
+                  checked: 'ui~="checked"',
+                },
+              },
+            },
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
-    .aria-hidden\\:flex {
-      &[aria-hidden="true"] {
+    .aria-hidden\\:flex[aria-hidden="true"] {
+      display: flex;
+    }
+
+    .aria-polite\\:underline[aria-live="polite"], .data-checked\\:underline[data-ui~="checked"] {
+      text-decoration-line: underline;
+    }
+
+    .data-foo\\:flex[data-foo] {
+      display: flex;
+    }
+
+    @supports selector(h2 > p) {
+      .supports-child-combinator\\:underline {
+        text-decoration-line: underline;
+      }
+    }
+
+    @supports (bar: var(--tw)) {
+      .supports-foo\\:underline {
+        text-decoration-line: underline;
+      }
+    }
+
+    @supports (grid: var(--tw)) {
+      .supports-grid\\:flex {
         display: flex;
       }
     }
-    .aria-polite\\:underline {
-      &[aria-live="polite"] {
-        text-decoration-line: underline;
-      }
-    }
-    .data-checked\\:underline {
-      &[data-ui~="checked"] {
-        text-decoration-line: underline;
-      }
-    }
-    .data-foo\\:flex {
-      &[data-foo] {
-        display: flex;
-      }
-    }
-    .supports-child-combinator\\:underline {
-      @supports selector(h2 > p) {
-        text-decoration-line: underline;
-      }
-    }
-    .supports-foo\\:underline {
-      @supports (bar: var(--tw)) {
-        text-decoration-line: underline;
-      }
-    }
-    .supports-grid\\:flex {
-      @supports (grid: var(--tw)) {
-        display: flex;
-      }
-    }
-    .print\\:flex {
-      @media print {
+
+    @media print {
+      .print\\:flex {
         display: flex;
       }
     }
@@ -1181,136 +1215,151 @@ test('creates variants for `data`, `supports`, and `aria` theme options at the s
 })
 
 test('merges css breakpoints with js config screens', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @theme {
-      --breakpoint-md: 50rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          extend: {
-            screens: {
-              sm: '44rem',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @theme {
+          --breakpoint-md: 50rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['sm:flex', 'md:flex', 'lg:flex', 'min-sm:max-md:underline'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                screens: {
+                  sm: '44rem',
+                },
+              },
             },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['sm:flex', 'md:flex', 'lg:flex', 'min-sm:max-md:underline'])))
-    .toMatchInlineSnapshot(`
-      "
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    @media (min-width: 44rem) {
       .sm\\:flex {
-        @media (width >= 44rem) {
-          display: flex;
+        display: flex;
+      }
+
+      @media not all and (min-width: 50rem) {
+        .min-sm\\:max-md\\:underline {
+          text-decoration-line: underline;
         }
       }
-      .min-sm\\:max-md\\:underline {
-        @media (width >= 44rem) {
-          @media (width < 50rem) {
-            text-decoration-line: underline;
-          }
-        }
-      }
+    }
+
+    @media (min-width: 50rem) {
       .md\\:flex {
-        @media (width >= 50rem) {
-          display: flex;
-        }
+        display: flex;
       }
+    }
+
+    @media (min-width: 64rem) {
       .lg\\:flex {
-        @media (width >= 64rem) {
-          display: flex;
-        }
+        display: flex;
       }
-      "
-    `)
+    }
+    "
+  `)
 })
 
 test('utilities must be prefixed', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
+  // Prefixed utilities are generated
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
 
-    @utility custom {
+        @utility custom {
+          color: red;
+        }
+      `,
+      ['tw:underline', 'tw:hover:line-through', 'tw:custom'],
+      {
+        loadModule: async (_id, base) => ({
+          path: '',
+          base,
+          module: { prefix: 'tw' },
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    .tw\\:custom {
       color: red;
     }
-  `
 
-  let compiler = await compile(input, {
-    loadModule: async (id, base) => ({
-      path: '',
-      base,
-      module: { prefix: 'tw' },
-    }),
-  })
+    .tw\\:underline {
+      text-decoration-line: underline;
+    }
 
-  // Prefixed utilities are generated
-  expect(pretty(compiler.build(['tw:underline', 'tw:hover:line-through', 'tw:custom'])))
-    .toMatchInlineSnapshot(`
-      "
-      .tw\\:custom {
-        color: red;
+    @media (hover: hover) {
+      .tw\\:hover\\:line-through:hover {
+        text-decoration-line: line-through;
       }
-      .tw\\:underline {
-        text-decoration-line: underline;
-      }
-      .tw\\:hover\\:line-through {
-        &:hover {
-          @media (hover: hover) {
-            text-decoration-line: line-through;
-          }
-        }
-      }
-      "
-    `)
+    }
+    "
+  `)
 
   // Non-prefixed utilities are ignored
-  compiler = await compile(input, {
-    loadModule: async (id, base) => ({
-      path: '',
-      base,
-      module: { prefix: 'tw' },
-    }),
-  })
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
 
-  expect(compiler.build(['underline', 'hover:line-through', 'custom'])).toEqual('')
+        @utility custom {
+          color: red;
+        }
+      `,
+      ['underline', 'hover:line-through', 'custom'],
+      {
+        loadModule: async (_id, base) => ({
+          path: '',
+          base,
+          module: { prefix: 'tw' },
+        }),
+      },
+    ),
+  ).toEqual('')
 })
 
 test('utilities used in @apply must be prefixed', async () => {
-  let compiler = await compile(
-    css`
-      @config "./config.js";
-
-      .my-underline {
-        @apply tw:underline;
-      }
-    `,
-    {
-      loadModule: async (id, base) => ({
-        path: '',
-        base,
-        module: { prefix: 'tw' },
-      }),
-    },
-  )
-
   // Prefixed utilities are generated
-  expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @config "./config.js";
+
+        .my-underline {
+          @apply tw:underline;
+        }
+      `,
+      [],
+      {
+        loadModule: async (_id, base) => ({
+          path: '',
+          base,
+          module: { prefix: 'tw' },
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .my-underline {
       text-decoration-line: underline;
@@ -1330,7 +1379,7 @@ test('utilities used in @apply must be prefixed', async () => {
         }
       `,
       {
-        loadModule: async (id, base) => ({
+        loadModule: async (_id, base) => ({
           path: '',
           base,
           module: { prefix: 'tw' },
@@ -1343,34 +1392,35 @@ test('utilities used in @apply must be prefixed', async () => {
 })
 
 test('Prefixes configured in CSS take precedence over those defined in JS configs', async () => {
-  let compiler = await compile(
-    css`
-      @theme prefix(wat) {
-        --color-red: #f00;
-        --color-green: #0f0;
-        --breakpoint-sm: 640px;
-      }
-
-      @config "./plugin.js";
-
-      @tailwind utilities;
-
-      @utility custom {
-        color: red;
-      }
-    `,
-    {
-      async loadModule(id, base) {
-        return {
-          path: '',
-          base,
-          module: { prefix: 'tw' },
+  expect(
+    await compileCss(
+      css`
+        @theme prefix(wat) {
+          --color-red: #f00;
+          --color-green: #0f0;
+          --breakpoint-sm: 640px;
         }
-      },
-    },
-  )
 
-  expect(pretty(compiler.build(['wat:custom']))).toMatchInlineSnapshot(`
+        @config "./plugin.js";
+
+        @tailwind utilities;
+
+        @utility custom {
+          color: red;
+        }
+      `,
+      ['wat:custom'],
+      {
+        async loadModule(_id, base) {
+          return {
+            path: '',
+            base,
+            module: { prefix: 'tw' },
+          }
+        },
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .wat\\:custom {
       color: red;
@@ -1386,7 +1436,7 @@ test('a prefix must be letters only', async () => {
         @config "./plugin.js";
       `,
       {
-        async loadModule(id, base) {
+        async loadModule(_id, base) {
           return {
             path: '',
             base,
@@ -1401,117 +1451,142 @@ test('a prefix must be letters only', async () => {
 })
 
 test('important: `#app`', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
 
-    @utility custom {
-      color: red;
-    }
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async (_, base) => ({
-      path: '',
-      base,
-      module: { important: '#app' },
-    }),
-  })
-
-  expect(pretty(compiler.build(['underline', 'hover:line-through', 'custom'])))
-    .toMatchInlineSnapshot(`
-      "
-      #app {
-        .custom {
+        @utility custom {
           color: red;
         }
-        .underline {
-          text-decoration-line: underline;
-        }
-        .hover\\:line-through {
-          &:hover {
-            @media (hover: hover) {
-              text-decoration-line: line-through;
-            }
-          }
-        }
+      `,
+      ['underline', 'hover:line-through', 'custom'],
+      {
+        loadModule: async (_id, base) => ({
+          path: '',
+          base,
+          module: { important: '#app' },
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    #app .custom {
+      color: red;
+    }
+
+    #app .underline {
+      text-decoration-line: underline;
+    }
+
+    @media (hover: hover) {
+      #app .hover\\:line-through:hover {
+        text-decoration-line: line-through;
       }
-      "
-    `)
+    }
+    "
+  `)
 })
 
 test('important: true', async () => {
-  let input = css`
-    @tailwind utilities;
-    @config "./config.js";
+  expect(
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @config "./config.js";
 
-    @utility custom {
-      color: red;
-    }
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async (_, base) => ({
-      path: '',
-      base,
-      module: { important: true },
-    }),
-  })
-
-  expect(pretty(compiler.build(['underline', 'hover:line-through', 'custom'])))
-    .toMatchInlineSnapshot(`
-      "
-      .custom {
-        color: red !important;
-      }
-      .underline {
-        text-decoration-line: underline !important;
-      }
-      .hover\\:line-through {
-        &:hover {
-          @media (hover: hover) {
-            text-decoration-line: line-through !important;
-          }
+        @utility custom {
+          color: red;
         }
+      `,
+      ['underline', 'hover:line-through', 'custom'],
+      {
+        loadModule: async (_id, base) => ({
+          path: '',
+          base,
+          module: { important: true },
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    .custom {
+      color: red !important;
+    }
+
+    .underline {
+      text-decoration-line: underline !important;
+    }
+
+    @media (hover: hover) {
+      .hover\\:line-through:hover {
+        text-decoration-line: line-through !important;
       }
-      "
-    `)
+    }
+    "
+  `)
 })
 
 test('blocklisted candidates are not generated', async () => {
-  let compiler = await compile(
-    css`
-      @theme reference {
-        --color-white: #fff;
-        --breakpoint-md: 48rem;
-      }
-      @tailwind utilities;
-      @config "./config.js";
-    `,
-    {
-      async loadModule(id, base) {
-        return {
-          path: '',
-          base,
-          module: {
-            blocklist: ['bg-white'],
-          },
-        }
-      },
-    },
-  )
-
   // bg-white will not get generated
-  expect(compiler.build(['bg-white'])).toEqual('')
+  expect(
+    await compileCss(
+      css`
+        @theme reference {
+          --color-white: #fff;
+          --breakpoint-md: 48rem;
+        }
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['bg-white'],
+      {
+        async loadModule(_id, base) {
+          return {
+            path: '',
+            base,
+            module: {
+              blocklist: ['bg-white'],
+            },
+          }
+        },
+      },
+    ),
+  ).toEqual('')
 
   // underline will as will md:bg-white
-  expect(pretty(compiler.build(['underline', 'bg-white', 'md:bg-white']))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @theme reference {
+          --color-white: #fff;
+          --breakpoint-md: 48rem;
+        }
+        @tailwind utilities;
+        @config "./config.js";
+      `,
+      ['underline', 'bg-white', 'md:bg-white'],
+      {
+        async loadModule(_id, base) {
+          return {
+            path: '',
+            base,
+            module: {
+              blocklist: ['bg-white'],
+            },
+          }
+        },
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .underline {
       text-decoration-line: underline;
     }
-    .md\\:bg-white {
-      @media (width >= 48rem) {
+
+    @media (min-width: 48rem) {
+      .md\\:bg-white {
         background-color: var(--color-white, #fff);
       }
     }
@@ -1534,7 +1609,7 @@ test('blocklisted candidates cannot be used with `@apply`', async () => {
         }
       `,
       {
-        async loadModule(id, base) {
+        async loadModule(_id, base) {
           return {
             path: '',
             base,
@@ -1587,7 +1662,7 @@ test('old theme values are merged with their renamed counterparts in the CSS the
       @plugin "./plugin.js";
     `,
     {
-      async loadModule(id, base) {
+      async loadModule(_id, base) {
         return {
           path: '',
           base,
@@ -1675,51 +1750,55 @@ test('old theme values are merged with their renamed counterparts in the CSS the
 })
 
 test('handles setting theme keys to null', async () => {
-  let compiler = await compile(
-    css`
-      @theme default {
-        --color-red-50: oklch(0.971 0.013 17.38);
-        --color-red-100: oklch(0.936 0.032 17.717);
-      }
-      @config "./my-config.js";
-      @tailwind utilities;
-      @theme {
-        --color-red-100: oklch(0.936 0.032 17.717);
-        --color-red-200: oklch(0.885 0.062 18.334);
-      }
-    `,
-    {
-      loadModule: async () => {
-        return {
-          module: {
-            theme: {
-              extend: {
-                colors: {
-                  red: null,
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --color-red-50: oklch(0.971 0.013 17.38);
+          --color-red-100: oklch(0.936 0.032 17.717);
+        }
+        @config "./my-config.js";
+        @tailwind utilities;
+        @theme {
+          --color-red-100: oklch(0.936 0.032 17.717);
+          --color-red-200: oklch(0.885 0.062 18.334);
+        }
+      `,
+      ['bg-red-50', 'bg-red-100', 'bg-red-200'],
+      {
+        loadModule: async () => {
+          return {
+            module: {
+              theme: {
+                extend: {
+                  colors: {
+                    red: null,
+                  },
                 },
               },
             },
-          },
-          base: '/root',
-          path: '',
-        }
+            base: '/root',
+            path: '',
+          }
+        },
       },
-    },
-  )
-
-  expect(pretty(compiler.build(['bg-red-50', 'bg-red-100', 'bg-red-200']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     :root, :host {
-      --color-red-50: oklch(0.971 0.013 17.38);
-      --color-red-100: oklch(0.936 0.032 17.717);
-      --color-red-200: oklch(0.885 0.062 18.334);
+      --color-red-50: oklch(97.1% .013 17.38);
+      --color-red-100: oklch(93.6% .032 17.717);
+      --color-red-200: oklch(88.5% .062 18.334);
     }
+
     .bg-red-50 {
       background-color: var(--color-red-50);
     }
+
     .bg-red-100 {
       background-color: var(--color-red-100);
     }
+
     .bg-red-200 {
       background-color: var(--color-red-200);
     }
@@ -1728,31 +1807,32 @@ test('handles setting theme keys to null', async () => {
 })
 
 test('The theme() function does not try indexing into strings', async () => {
-  let compiler = await compile(css`
-    @theme default {
-      --color-what-50: #f00;
-      --color-what-950: #f00;
-    }
+  expect(
+    await compileCss(css`
+      @theme default {
+        --color-what-50: #f00;
+        --color-what-950: #f00;
+      }
 
-    @theme {
-      /*
+      @theme {
+        /*
        * The value of this theme variable is > 50 chars because colors.what.50 was previously
        * indexing the string: "light-dark(theme(colors.what.950), theme(colors.what.50))"
        * because the resolved config contained an object with a "what" key that was that string
        */
-      --color-what: light-dark(theme(colors.what.950), theme(colors.what.50));
-    }
+        --color-what: light-dark(theme(colors.what.950), theme(colors.what.50));
+      }
 
-    @source inline("text-what");
+      @source inline("text-what");
 
-    @tailwind utilities;
-  `)
-
-  expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+      @tailwind utilities;
+    `),
+  ).toMatchInlineSnapshot(`
     "
     :root, :host {
-      --color-what: light-dark(#f00, #f00);
+      --color-what: light-dark(red, red);
     }
+
     .text-what {
       color: var(--color-what);
     }
@@ -1761,36 +1841,16 @@ test('The theme() function does not try indexing into strings', async () => {
 })
 
 test('camel case keys are preserved', async () => {
-  let compiler = await compile(
-    css`
-      @tailwind utilities;
-      @theme {
-        --color-blue-green: slate;
-      }
-      @config "./plugin.js";
-    `,
-    {
-      loadModule: async () => {
-        return {
-          base: '/',
-          path: '',
-          module: {
-            theme: {
-              extend: {
-                backgroundColor: {
-                  lightGreen: '#c0ffee',
-                },
-              },
-            },
-          },
-        }
-      },
-    },
-  )
-
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @tailwind utilities;
+        @theme {
+          --color-blue-green: slate;
+        }
+        @config "./plugin.js";
+      `,
+      [
         // From CSS
         'bg-blue-green', // should be output
         'bg-blueGreen', // should not
@@ -1798,16 +1858,35 @@ test('camel case keys are preserved', async () => {
         // From JS config
         'bg-light-green', // should not be output
         'bg-lightGreen', // should be
-      ]),
+      ],
+      {
+        loadModule: async () => {
+          return {
+            base: '/',
+            path: '',
+            module: {
+              theme: {
+                extend: {
+                  backgroundColor: {
+                    lightGreen: '#c0ffee',
+                  },
+                },
+              },
+            },
+          }
+        },
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
     .bg-blue-green {
       background-color: var(--color-blue-green);
     }
+
     .bg-lightGreen {
       background-color: #c0ffee;
     }
+
     :root, :host {
       --color-blue-green: slate;
     }

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1286,7 +1286,7 @@ test('utilities must be prefixed', async () => {
     }
   `
 
-  let options = {
+  let options: Partial<Parameters<typeof compile>[1]> = {
     loadModule: async (_id, base) => ({
       path: '',
       base,
@@ -1516,7 +1516,7 @@ test('blocklisted candidates are not generated', async () => {
     @config "./config.js";
   `
 
-  let options = {
+  let options: Partial<Parameters<typeof compile>[1]> = {
     async loadModule(_id, base) {
       return {
         path: '',

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -229,8 +229,7 @@ test('Config files can affect the theme', async () => {
 // https://github.com/tailwindlabs/tailwindcss/issues/19091
 test('Accessing a default color if a sub-color exists via CSS should work as expected', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @tailwind utilities;
         @config "./config.js";
@@ -1342,8 +1341,7 @@ test('utilities must be prefixed', async () => {
 test('utilities used in @apply must be prefixed', async () => {
   // Prefixed utilities are generated
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @config "./config.js";
 

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1277,27 +1277,26 @@ test('merges css breakpoints with js config screens', async () => {
 })
 
 test('utilities must be prefixed', async () => {
-  // Prefixed utilities are generated
-  expect(
-    await run(
-      ['tw:underline', 'tw:hover:line-through', 'tw:custom'],
-      css`
-        @tailwind utilities;
-        @config "./config.js";
+  let input = css`
+    @tailwind utilities;
+    @config "./config.js";
 
-        @utility custom {
-          color: red;
-        }
-      `,
-      {
-        loadModule: async (_id, base) => ({
-          path: '',
-          base,
-          module: { prefix: 'tw' },
-        }),
-      },
-    ),
-  ).toMatchInlineSnapshot(`
+    @utility custom {
+      color: red;
+    }
+  `
+
+  let options = {
+    loadModule: async (_id, base) => ({
+      path: '',
+      base,
+      module: { prefix: 'tw' },
+    }),
+  }
+
+  // Prefixed utilities are generated
+  expect(await run(['tw:underline', 'tw:hover:line-through', 'tw:custom'], input, options))
+    .toMatchInlineSnapshot(`
     "
     .tw\\:custom {
       color: red;
@@ -1316,26 +1315,7 @@ test('utilities must be prefixed', async () => {
   `)
 
   // Non-prefixed utilities are ignored
-  expect(
-    await run(
-      ['underline', 'hover:line-through', 'custom'],
-      css`
-        @tailwind utilities;
-        @config "./config.js";
-
-        @utility custom {
-          color: red;
-        }
-      `,
-      {
-        loadModule: async (_id, base) => ({
-          path: '',
-          base,
-          module: { prefix: 'tw' },
-        }),
-      },
-    ),
-  ).toEqual('')
+  expect(await run(['underline', 'hover:line-through', 'custom'], input, options)).toEqual('')
 })
 
 test('utilities used in @apply must be prefixed', async () => {
@@ -1527,57 +1507,33 @@ test('important: true', async () => {
 })
 
 test('blocklisted candidates are not generated', async () => {
-  // bg-white will not get generated
-  expect(
-    await run(
-      ['bg-white'],
-      css`
-        @theme reference {
-          --color-white: #fff;
-          --breakpoint-md: 48rem;
-        }
-        @tailwind utilities;
-        @config "./config.js";
-      `,
-      {
-        async loadModule(_id, base) {
-          return {
-            path: '',
-            base,
-            module: {
-              blocklist: ['bg-white'],
-            },
-          }
+  let input = css`
+    @theme reference {
+      --color-white: #fff;
+      --breakpoint-md: 48rem;
+    }
+    @tailwind utilities;
+    @config "./config.js";
+  `
+
+  let options = {
+    async loadModule(_id, base) {
+      return {
+        path: '',
+        base,
+        module: {
+          blocklist: ['bg-white'],
         },
-      },
-    ),
-  ).toEqual('')
+      }
+    },
+  }
+
+  // bg-white will not get generated
+  expect(await run(['bg-white'], input, options)).toEqual('')
 
   // underline will as will md:bg-white
-  expect(
-    await run(
-      ['underline', 'bg-white', 'md:bg-white'],
-      css`
-        @theme reference {
-          --color-white: #fff;
-          --breakpoint-md: 48rem;
-        }
-        @tailwind utilities;
-        @config "./config.js";
-      `,
-      {
-        async loadModule(_id, base) {
-          return {
-            path: '',
-            base,
-            module: {
-              blocklist: ['bg-white'],
-            },
-          }
-        },
-      },
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(await run(['underline', 'bg-white', 'md:bg-white'], input, options))
+    .toMatchInlineSnapshot(`
     "
     .underline {
       text-decoration-line: underline;

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -1,57 +1,74 @@
 import { expect, test } from 'vitest'
-import { compile } from '..'
-import { pretty } from '../test-utils/run'
+import { compileCss } from '../test-utils/run'
 
 const css = String.raw
 
 test('creates a custom utility to extend the built-in container', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            center: true,
-            padding: '2rem',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['container'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                center: true,
+                padding: '2rem',
+              },
+            },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['container']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .container {
       width: 100%;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: 40rem;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         max-width: 64rem;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .container {
         max-width: 80rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         max-width: 96rem;
       }
     }
+
     .container {
       margin-inline: auto;
       padding-inline: 2rem;
@@ -61,63 +78,87 @@ test('creates a custom utility to extend the built-in container', async () => {
 })
 
 test('allows padding to be defined at custom breakpoints', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            padding: {
-              // The order here is messed up on purpose
-              '2xl': '3rem',
-              DEFAULT: '1rem',
-              lg: '2rem',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['container'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                padding: {
+                  // The order here is messed up on purpose
+                  '2xl': '3rem',
+                  DEFAULT: '1rem',
+                  lg: '2rem',
+                },
+              },
             },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['container']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .container {
       width: 100%;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: 40rem;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         max-width: 64rem;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .container {
         max-width: 80rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         max-width: 96rem;
       }
     }
+
     .container {
       padding-inline: 1rem;
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         padding-inline: 2rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         padding-inline: 3rem;
       }
     }
@@ -126,63 +167,87 @@ test('allows padding to be defined at custom breakpoints', async () => {
 })
 
 test('allows breakpoints to be overwritten', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            screens: {
-              xl: '1280px',
-              '2xl': '1536px',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['container'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                screens: {
+                  xl: '1280px',
+                  '2xl': '1536px',
+                },
+              },
             },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['container']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .container {
       width: 100%;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: 40rem;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         max-width: 64rem;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .container {
         max-width: 80rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         max-width: 96rem;
       }
     }
-    .container {
-      @media (width >= 40rem) {
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: none;
       }
-      @media (width >= 1280px) {
+    }
+
+    @media (min-width: 1280px) {
+      .container {
         max-width: 1280px;
       }
-      @media (width >= 1536px) {
+    }
+
+    @media (min-width: 1536px) {
+      .container {
         max-width: 1536px;
       }
     }
@@ -191,63 +256,84 @@ test('allows breakpoints to be overwritten', async () => {
 })
 
 test('padding applies to custom `container` screens', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            padding: {
-              sm: '2rem',
-              md: '3rem',
-            },
-            screens: {
-              md: '48rem',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['container'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                padding: {
+                  sm: '2rem',
+                  md: '3rem',
+                },
+                screens: {
+                  md: '48rem',
+                },
+              },
             },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['container']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .container {
       width: 100%;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: 40rem;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         max-width: 64rem;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .container {
         max-width: 80rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         max-width: 96rem;
       }
     }
-    .container {
-      @media (width >= 40rem) {
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: none;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
         padding-inline: 3rem;
       }
@@ -257,60 +343,81 @@ test('padding applies to custom `container` screens', async () => {
 })
 
 test("an empty `screen` config will undo all custom media screens and won't apply any breakpoint-specific padding", async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            padding: {
-              DEFAULT: '1rem',
-              sm: '2rem',
-              md: '3rem',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['container'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                padding: {
+                  DEFAULT: '1rem',
+                  sm: '2rem',
+                  md: '3rem',
+                },
+                screens: {},
+              },
             },
-            screens: {},
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['container']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .container {
       width: 100%;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: 40rem;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         max-width: 64rem;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .container {
         max-width: 80rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         max-width: 96rem;
       }
     }
+
     .container {
       padding-inline: 1rem;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: none;
       }
     }
@@ -319,47 +426,50 @@ test("an empty `screen` config will undo all custom media screens and won't appl
 })
 
 test('legacy container component does not interfere with new --container variables', async () => {
-  let input = css`
-    @theme default {
-      --container-3xs: 16rem;
-      --container-2xs: 18rem;
-      --container-xs: 20rem;
-      --container-sm: 24rem;
-      --container-md: 28rem;
-      --container-lg: 32rem;
-      --container-xl: 36rem;
-      --container-2xl: 42rem;
-      --container-3xl: 48rem;
-      --container-4xl: 56rem;
-      --container-5xl: 64rem;
-      --container-6xl: 72rem;
-      --container-7xl: 80rem;
-      --container-prose: 65ch;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            center: true,
-            padding: '2rem',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --container-3xs: 16rem;
+          --container-2xs: 18rem;
+          --container-xs: 20rem;
+          --container-sm: 24rem;
+          --container-md: 28rem;
+          --container-lg: 32rem;
+          --container-xl: 36rem;
+          --container-2xl: 42rem;
+          --container-3xl: 48rem;
+          --container-4xl: 56rem;
+          --container-5xl: 64rem;
+          --container-6xl: 72rem;
+          --container-7xl: 80rem;
+          --container-prose: 65ch;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['max-w-sm'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                center: true,
+                padding: '2rem',
+              },
+            },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['max-w-sm']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     :root, :host {
       --container-sm: 24rem;
     }
+
     .max-w-sm {
       max-width: var(--container-sm);
     }
@@ -368,109 +478,168 @@ test('legacy container component does not interfere with new --container variabl
 })
 
 test('combines custom padding and screen overwrites', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            center: true,
-            padding: {
-              DEFAULT: '2rem',
-              '2xl': '4rem',
-            },
-            screens: {
-              md: '48rem', // Matches a default --breakpoint
-              xl: '1280px',
-              '2xl': '1536px',
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['container', '!container'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                center: true,
+                padding: {
+                  DEFAULT: '2rem',
+                  '2xl': '4rem',
+                },
+                screens: {
+                  md: '48rem', // Matches a default --breakpoint
+                  xl: '1280px',
+                  '2xl': '1536px',
+                },
+              },
             },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['container', '!container']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .\\!container {
       width: 100% !important;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .\\!container {
         max-width: 40rem !important;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .\\!container {
         max-width: 48rem !important;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .\\!container {
         max-width: 64rem !important;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .\\!container {
         max-width: 80rem !important;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .\\!container {
         max-width: 96rem !important;
       }
     }
+
     .container {
       width: 100%;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: 40rem;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         max-width: 64rem;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .container {
         max-width: 80rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         max-width: 96rem;
       }
     }
+
     .\\!container {
       margin-inline: auto !important;
       padding-inline: 2rem !important;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .\\!container {
         max-width: none !important;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .\\!container {
         max-width: 48rem !important;
       }
-      @media (width >= 1280px) {
+    }
+
+    @media (min-width: 1280px) {
+      .\\!container {
         max-width: 1280px !important;
       }
-      @media (width >= 1536px) {
+    }
+
+    @media (min-width: 1536px) {
+      .\\!container {
         max-width: 1536px !important;
         padding-inline: 4rem !important;
       }
     }
+
     .container {
       margin-inline: auto;
       padding-inline: 2rem;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: none;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 1280px) {
+    }
+
+    @media (min-width: 1280px) {
+      .container {
         max-width: 1280px;
       }
-      @media (width >= 1536px) {
+    }
+
+    @media (min-width: 1536px) {
+      .container {
         max-width: 1536px;
         padding-inline: 4rem;
       }
@@ -480,76 +649,106 @@ test('combines custom padding and screen overwrites', async () => {
 })
 
 test('filters out complex breakpoints', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          container: {
-            center: true,
-            padding: {
-              DEFAULT: '2rem',
-              '2xl': '4rem',
-            },
-            screens: {
-              sm: '20px',
-              md: { min: '100px' },
-              lg: { max: '200px' },
-              xl: { min: '300px', max: '400px' },
-              '2xl': { raw: 'print' },
+  expect(
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['container'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              container: {
+                center: true,
+                padding: {
+                  DEFAULT: '2rem',
+                  '2xl': '4rem',
+                },
+                screens: {
+                  sm: '20px',
+                  md: { min: '100px' },
+                  lg: { max: '200px' },
+                  xl: { min: '300px', max: '400px' },
+                  '2xl': { raw: 'print' },
+                },
+              },
             },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['container']))).toMatchInlineSnapshot(`
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .container {
       width: 100%;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: 40rem;
       }
-      @media (width >= 48rem) {
+    }
+
+    @media (min-width: 48rem) {
+      .container {
         max-width: 48rem;
       }
-      @media (width >= 64rem) {
+    }
+
+    @media (min-width: 64rem) {
+      .container {
         max-width: 64rem;
       }
-      @media (width >= 80rem) {
+    }
+
+    @media (min-width: 80rem) {
+      .container {
         max-width: 80rem;
       }
-      @media (width >= 96rem) {
+    }
+
+    @media (min-width: 96rem) {
+      .container {
         max-width: 96rem;
       }
     }
+
     .container {
       margin-inline: auto;
       padding-inline: 2rem;
-      @media (width >= 40rem) {
+    }
+
+    @media (min-width: 40rem) {
+      .container {
         max-width: none;
       }
-      @media (width >= 20px) {
+    }
+
+    @media (min-width: 20px) {
+      .container {
         max-width: 20px;
       }
-      @media (width >= 100px) {
+    }
+
+    @media (min-width: 100px) {
+      .container {
         max-width: 100px;
       }
-      @media (width >= 300px) {
+    }
+
+    @media (min-width: 300px) {
+      .container {
         max-width: 300px;
       }
     }

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from 'vitest'
-import { compileCss } from '../test-utils/run'
+import { run } from '../test-utils/run'
 
 const css = String.raw
 
 test('creates a custom utility to extend the built-in container', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['container'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -17,7 +18,6 @@ test('creates a custom utility to extend the built-in container', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['container'],
       {
         loadModule: async () => ({
           module: {
@@ -79,7 +79,8 @@ test('creates a custom utility to extend the built-in container', async () => {
 
 test('allows padding to be defined at custom breakpoints', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['container'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -91,7 +92,6 @@ test('allows padding to be defined at custom breakpoints', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['container'],
       {
         loadModule: async () => ({
           module: {
@@ -168,7 +168,8 @@ test('allows padding to be defined at custom breakpoints', async () => {
 
 test('allows breakpoints to be overwritten', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['container'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -180,7 +181,6 @@ test('allows breakpoints to be overwritten', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['container'],
       {
         loadModule: async () => ({
           module: {
@@ -257,7 +257,8 @@ test('allows breakpoints to be overwritten', async () => {
 
 test('padding applies to custom `container` screens', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['container'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -269,7 +270,6 @@ test('padding applies to custom `container` screens', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['container'],
       {
         loadModule: async () => ({
           module: {
@@ -344,7 +344,8 @@ test('padding applies to custom `container` screens', async () => {
 
 test("an empty `screen` config will undo all custom media screens and won't apply any breakpoint-specific padding", async () => {
   expect(
-    await compileCss(
+    await run(
+      ['container'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -356,7 +357,6 @@ test("an empty `screen` config will undo all custom media screens and won't appl
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['container'],
       {
         loadModule: async () => ({
           module: {
@@ -427,7 +427,8 @@ test("an empty `screen` config will undo all custom media screens and won't appl
 
 test('legacy container component does not interfere with new --container variables', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['max-w-sm'],
       css`
         @theme default {
           --container-3xs: 16rem;
@@ -448,7 +449,6 @@ test('legacy container component does not interfere with new --container variabl
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['max-w-sm'],
       {
         loadModule: async () => ({
           module: {
@@ -479,7 +479,8 @@ test('legacy container component does not interfere with new --container variabl
 
 test('combines custom padding and screen overwrites', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['container', '!container'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -491,7 +492,6 @@ test('combines custom padding and screen overwrites', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['container', '!container'],
       {
         loadModule: async () => ({
           module: {
@@ -650,7 +650,8 @@ test('combines custom padding and screen overwrites', async () => {
 
 test('filters out complex breakpoints', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['container'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -662,7 +663,6 @@ test('filters out complex breakpoints', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['container'],
       {
         loadModule: async () => ({
           module: {

--- a/packages/tailwindcss/src/compat/legacy-utilities.test.ts
+++ b/packages/tailwindcss/src/compat/legacy-utilities.test.ts
@@ -1,14 +1,11 @@
 import { expect, test } from 'vitest'
-import { compileCss, run } from '../test-utils/run'
+import { run } from '../test-utils/run'
 
 const css = String.raw
 
 test('bg-gradient-*', async () => {
   expect(
-    await compileCss(
-      css`
-        @tailwind utilities;
-      `,
+    await run(
       [
         'bg-gradient-to-t',
         'bg-gradient-to-tr',
@@ -19,6 +16,9 @@ test('bg-gradient-*', async () => {
         'bg-gradient-to-l',
         'bg-gradient-to-tl',
       ],
+      css`
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -67,7 +67,14 @@ test('bg-gradient-*', async () => {
 
 test('max-w-screen', async () => {
   expect(
-    await compileCss(
+    await run(
+      [
+        'max-w-screen-sm',
+        'max-w-screen-md',
+        'max-w-screen-lg',
+        'max-w-screen-xl',
+        'max-w-screen-2xl',
+      ],
       css`
         @theme {
           --breakpoint-sm: 40rem;
@@ -78,13 +85,6 @@ test('max-w-screen', async () => {
         }
         @tailwind utilities;
       `,
-      [
-        'max-w-screen-sm',
-        'max-w-screen-md',
-        'max-w-screen-lg',
-        'max-w-screen-xl',
-        'max-w-screen-2xl',
-      ],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -226,14 +226,7 @@ test('flex-shrink', async () => {
 
 test('start', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'start-shadowned',
         'start-auto',
@@ -244,6 +237,13 @@ test('start', async () => {
         '-start-4',
         'start-[4px]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -286,14 +286,7 @@ test('start', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing: 0.25rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'start-shadow-sm',
         'start',
@@ -309,20 +302,20 @@ test('start', async () => {
         '-start-4/foo',
         'start-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing: 0.25rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('end', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'end-shadowned',
         'end-auto',
@@ -333,6 +326,13 @@ test('end', async () => {
         '-end-4',
         'end-[4px]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -375,14 +375,7 @@ test('end', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing: 0.25rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'end-shadow-sm',
         'end',
@@ -398,6 +391,13 @@ test('end', async () => {
         '-end-4/foo',
         'end-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing: 0.25rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })

--- a/packages/tailwindcss/src/compat/legacy-utilities.test.ts
+++ b/packages/tailwindcss/src/compat/legacy-utilities.test.ts
@@ -5,21 +5,16 @@ const css = String.raw
 
 test('bg-gradient-*', async () => {
   expect(
-    await run(
-      [
-        'bg-gradient-to-t',
-        'bg-gradient-to-tr',
-        'bg-gradient-to-r',
-        'bg-gradient-to-br',
-        'bg-gradient-to-b',
-        'bg-gradient-to-bl',
-        'bg-gradient-to-l',
-        'bg-gradient-to-tl',
-      ],
-      css`
-        @tailwind utilities;
-      `,
-    ),
+    await run([
+      'bg-gradient-to-t',
+      'bg-gradient-to-tr',
+      'bg-gradient-to-r',
+      'bg-gradient-to-br',
+      'bg-gradient-to-b',
+      'bg-gradient-to-bl',
+      'bg-gradient-to-l',
+      'bg-gradient-to-tl',
+    ]),
   ).toMatchInlineSnapshot(`
     "
     .bg-gradient-to-b {

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -3338,6 +3338,16 @@ describe('addUtilities()', () => {
 
 describe('matchUtilities()', () => {
   test('custom functional utility', async () => {
+    let input = css`
+      @plugin "my-plugin";
+
+      @tailwind utilities;
+
+      @theme reference {
+        --breakpoint-lg: 1024px;
+      }
+    `
+
     expect(
       await run(
         [
@@ -3347,15 +3357,7 @@ describe('matchUtilities()', () => {
           'border-block-[var(--foo)]',
           'lg:border-block-2',
         ],
-        css`
-          @plugin "my-plugin";
-
-          @tailwind utilities;
-
-          @theme reference {
-            --breakpoint-lg: 1024px;
-          }
-        `,
+        input,
         {
           async loadModule(_id, base) {
             return {
@@ -3406,15 +3408,7 @@ describe('matchUtilities()', () => {
           'border-block-unknown',
           'border-block/1',
         ],
-        css`
-          @plugin "my-plugin";
-
-          @tailwind utilities;
-
-          @theme reference {
-            --breakpoint-lg: 1024px;
-          }
-        `,
+        input,
         {
           async loadModule(_id, base) {
             return {
@@ -3568,18 +3562,20 @@ describe('matchUtilities()', () => {
   })
 
   test('custom functional utility with known modifier', async () => {
+    let input = css`
+      @plugin "my-plugin";
+
+      @tailwind utilities;
+
+      @theme reference {
+        --breakpoint-lg: 1024px;
+      }
+    `
+
     expect(
       await run(
         ['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo'],
-        css`
-          @plugin "my-plugin";
-
-          @tailwind utilities;
-
-          @theme reference {
-            --breakpoint-lg: 1024px;
-          }
-        `,
+        input,
         {
           async loadModule(_id, base) {
             return {
@@ -3628,40 +3624,28 @@ describe('matchUtilities()', () => {
     `)
 
     expect(
-      await run(
-        ['border-block/unknown', 'border-block-2/unknown'],
-        css`
-          @plugin "my-plugin";
-
-          @tailwind utilities;
-
-          @theme reference {
-            --breakpoint-lg: 1024px;
+      await run(['border-block/unknown', 'border-block-2/unknown'], input, {
+        async loadModule(_id, base) {
+          return {
+            path: '',
+            base,
+            module: ({ matchUtilities }: PluginAPI) => {
+              matchUtilities(
+                {
+                  'border-block': (value, { modifier }) => ({
+                    '--my-modifier': modifier ?? 'none',
+                    'border-block-width': value,
+                  }),
+                },
+                {
+                  values: { DEFAULT: '1px', '2': '2px' },
+                  modifiers: { foo: 'foo' },
+                },
+              )
+            },
           }
-        `,
-        {
-          async loadModule(_id, base) {
-            return {
-              path: '',
-              base,
-              module: ({ matchUtilities }: PluginAPI) => {
-                matchUtilities(
-                  {
-                    'border-block': (value, { modifier }) => ({
-                      '--my-modifier': modifier ?? 'none',
-                      'border-block-width': value,
-                    }),
-                  },
-                  {
-                    values: { DEFAULT: '1px', '2': '2px' },
-                    modifiers: { foo: 'foo' },
-                  },
-                )
-              },
-            }
-          },
         },
-      ),
+      }),
     ).toEqual('')
   })
 
@@ -3669,32 +3653,32 @@ describe('matchUtilities()', () => {
   // future don't be afraid to change what should happen in this scenario.
   describe('plugins that handle a specific arbitrary value type prevent falling through to other plugins if the result is invalid for that plugin', () => {
     test('implicit color modifier', async () => {
-      expect(
-        await run(
-          ['scrollbar-[2px]', 'scrollbar-[#08c]', 'scrollbar-[#08c]/50'],
-          css`
-            @tailwind utilities;
-            @plugin "my-plugin";
-          `,
-          {
-            async loadModule(_id, base) {
-              return {
-                path: '',
-                base,
-                module: ({ matchUtilities }: PluginAPI) => {
-                  matchUtilities(
-                    { scrollbar: (value) => ({ 'scrollbar-color': value }) },
-                    { type: ['color', 'any'] },
-                  )
-                  matchUtilities(
-                    { scrollbar: (value) => ({ 'scrollbar-width': value }) },
-                    { type: ['length'] },
-                  )
-                },
-              }
+      let input = css`
+        @tailwind utilities;
+        @plugin "my-plugin";
+      `
+
+      let options = {
+        async loadModule(_id, base) {
+          return {
+            path: '',
+            base,
+            module: ({ matchUtilities }: PluginAPI) => {
+              matchUtilities(
+                { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                { type: ['color', 'any'] },
+              )
+              matchUtilities(
+                { scrollbar: (value) => ({ 'scrollbar-width': value }) },
+                { type: ['length'] },
+              )
             },
-          },
-        ),
+          }
+        },
+      }
+
+      expect(
+        await run(['scrollbar-[2px]', 'scrollbar-[#08c]', 'scrollbar-[#08c]/50'], input, options),
       ).toMatchInlineSnapshot(`
         "
         .scrollbar-\\[2px\\] {
@@ -3710,33 +3694,7 @@ describe('matchUtilities()', () => {
         }
         "
       `)
-      expect(
-        await run(
-          ['scrollbar-[2px]/50'],
-          css`
-            @tailwind utilities;
-            @plugin "my-plugin";
-          `,
-          {
-            async loadModule(_id, base) {
-              return {
-                path: '',
-                base,
-                module: ({ matchUtilities }: PluginAPI) => {
-                  matchUtilities(
-                    { scrollbar: (value) => ({ 'scrollbar-color': value }) },
-                    { type: ['color', 'any'] },
-                  )
-                  matchUtilities(
-                    { scrollbar: (value) => ({ 'scrollbar-width': value }) },
-                    { type: ['length'] },
-                  )
-                },
-              }
-            },
-          },
-        ),
-      ).toEqual('')
+      expect(await run(['scrollbar-[2px]/50'], input, options)).toEqual('')
     })
 
     test('no modifiers are supported by the plugins', async () => {
@@ -3803,6 +3761,16 @@ describe('matchUtilities()', () => {
   })
 
   test('custom functional utilities with different types', async () => {
+    let input = css`
+      @plugin "my-plugin";
+
+      @tailwind utilities;
+
+      @theme reference {
+        --breakpoint-lg: 1024px;
+      }
+    `
+
     expect(
       await run(
         [
@@ -3818,15 +3786,7 @@ describe('matchUtilities()', () => {
           'scrollbar-[color:var(--my-color)]/50',
           'scrollbar-[length:var(--my-width)]',
         ],
-        css`
-          @plugin "my-plugin";
-
-          @tailwind utilities;
-
-          @theme reference {
-            --breakpoint-lg: 1024px;
-          }
-        `,
+        input,
         {
           async loadModule(_id, base) {
             return {
@@ -3898,15 +3858,7 @@ describe('matchUtilities()', () => {
     expect(
       await run(
         ['scrollbar-2/50', 'scrollbar-[2px]/50', 'scrollbar-[length:var(--my-width)]/50'],
-        css`
-          @plugin "my-plugin";
-
-          @tailwind utilities;
-
-          @theme reference {
-            --breakpoint-lg: 1024px;
-          }
-        `,
+        input,
         {
           async loadModule(_id, base) {
             return {

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile } from '..'
 import plugin from '../plugin'
-import { run } from '../test-utils/run'
+import { compileCss, run } from '../test-utils/run'
 import defaultTheme from './default-theme'
 import type { CssInJs, PluginAPI } from './plugin-api'
 
@@ -10,8 +10,7 @@ const css = String.raw
 describe('theme', async () => {
   test('plugin theme can contain objects', async () => {
     expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @tailwind utilities;
           @plugin "my-plugin";
@@ -78,8 +77,7 @@ describe('theme', async () => {
 
   test('keyframes added via addUtilities are appended to the AST', async () => {
     expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @tailwind utilities;
           @plugin "my-plugin";
@@ -1405,8 +1403,7 @@ describe('theme', async () => {
 describe('addBase', () => {
   test('does not create rules when imported via `@import "…" reference`', async () => {
     expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @tailwind utilities;
           @plugin "outside";
@@ -1455,8 +1452,7 @@ describe('addBase', () => {
 
   test('does not modify CSS variables', async () => {
     expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @plugin "my-plugin";
         `,

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -3658,7 +3658,7 @@ describe('matchUtilities()', () => {
         @plugin "my-plugin";
       `
 
-      let options = {
+      let options: Partial<Parameters<typeof compile>[1]> = {
         async loadModule(_id, base) {
           return {
             path: '',

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile } from '..'
 import plugin from '../plugin'
-import { compileCss } from '../test-utils/run'
+import { run } from '../test-utils/run'
 import defaultTheme from './default-theme'
 import type { CssInJs, PluginAPI } from './plugin-api'
 
@@ -10,12 +10,12 @@ const css = String.raw
 describe('theme', async () => {
   test('plugin theme can contain objects', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        [],
         {
           loadModule: async (_id, base) => {
             return {
@@ -78,12 +78,12 @@ describe('theme', async () => {
 
   test('keyframes added via addUtilities are appended to the AST', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        [],
         {
           loadModule: async (_id, base) => {
             return {
@@ -111,7 +111,8 @@ describe('theme', async () => {
 
   test('plugin theme can extend colors', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['scrollbar-red-500', 'scrollbar-russet-700'],
         css`
           @theme reference {
             --color-red-500: #ef4444;
@@ -119,7 +120,6 @@ describe('theme', async () => {
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        ['scrollbar-red-500', 'scrollbar-russet-700'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -155,12 +155,12 @@ describe('theme', async () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-duration-316'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        ['animate-duration-316'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -200,12 +200,12 @@ describe('theme', async () => {
     expect,
   }) => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-duration-316', 'animate-duration-slow'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        ['animate-duration-316', 'animate-duration-slow'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -248,7 +248,8 @@ describe('theme', async () => {
 
   test('plugin theme can have opacity modifiers', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['percentage', 'fraction', 'variable'],
         css`
           @tailwind utilities;
           @theme {
@@ -256,7 +257,6 @@ describe('theme', async () => {
           }
           @plugin "my-plugin";
         `,
-        ['percentage', 'fraction', 'variable'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -294,15 +294,7 @@ describe('theme', async () => {
 
   test('plugin theme colors can use <alpha-value>', async () => {
     expect(
-      await compileCss(
-        css`
-          @tailwind utilities;
-          @theme {
-            /* This should not work */
-            --color-custom-css: rgba(255 0 0 / <alpha-value>);
-          }
-          @plugin "my-plugin";
-        `,
+      await run(
         [
           'bg-custom',
           'css-percentage',
@@ -312,6 +304,14 @@ describe('theme', async () => {
           'js-fraction',
           'js-variable',
         ],
+        css`
+          @tailwind utilities;
+          @theme {
+            /* This should not work */
+            --color-custom-css: rgba(255 0 0 / <alpha-value>);
+          }
+          @plugin "my-plugin";
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -376,12 +376,12 @@ describe('theme', async () => {
 
   test('theme value functions are resolved correctly regardless of order', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-delay-316', 'animate-delay-slow'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        ['animate-delay-316', 'animate-delay-slow'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -427,12 +427,12 @@ describe('theme', async () => {
 
   test('plugins can override the default key', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-duration'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        ['animate-duration'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -462,7 +462,8 @@ describe('theme', async () => {
 
   test('plugins can read CSS theme keys using the old theme key notation', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animation-spin', 'animation', 'animation2', 'animation2-twist'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
@@ -471,7 +472,6 @@ describe('theme', async () => {
             --animate-spin: spin 1s linear infinite;
           }
         `,
-        ['animation-spin', 'animation', 'animation2', 'animation2-twist'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -517,7 +517,8 @@ describe('theme', async () => {
 
   test('CSS theme values are merged with JS theme values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animation', 'animation-spin', 'animation-bounce'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
@@ -526,7 +527,6 @@ describe('theme', async () => {
             --animate-spin: spin 1s linear infinite;
           }
         `,
-        ['animation', 'animation-spin', 'animation-bounce'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -564,7 +564,8 @@ describe('theme', async () => {
 
   test('CSS theme defaults take precedence over JS theme defaults', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animation'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
@@ -573,7 +574,6 @@ describe('theme', async () => {
             --animate-spin: spin 1s linear infinite;
           }
         `,
-        ['animation'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -639,11 +639,7 @@ describe('theme', async () => {
 
   test('all necessary theme keys support bare values', async () => {
     expect(
-      await compileCss(
-        css`
-          @tailwind utilities;
-          @plugin "my-plugin";
-        `,
+      await run(
         [
           'my-aspect-2/5',
           'my-backdrop-brightness-1',
@@ -688,6 +684,10 @@ describe('theme', async () => {
           'my-transition-duration-1',
           'my-z-index-1',
         ],
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -996,12 +996,12 @@ describe('theme', async () => {
 
   test('Candidates can match multiple utility definitions', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo-bar'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        ['foo-bar'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1032,11 +1032,7 @@ describe('theme', async () => {
 
   test('spreading `tailwindcss/defaultTheme` exports keeps bare values', async () => {
     expect(
-      await compileCss(
-        css`
-          @tailwind utilities;
-          @plugin "my-plugin";
-        `,
+      await run(
         [
           'my-aspect-2/5',
           // 'my-backdrop-brightness-1',
@@ -1081,6 +1077,10 @@ describe('theme', async () => {
           'my-transition-duration-1',
           'my-z-index-1',
         ],
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -1240,12 +1240,12 @@ describe('theme', async () => {
 
   test('can use escaped JS variables in theme values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['my-width-1', 'my-width-1/2', 'my-width-1.5'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
         `,
-        ['my-width-1', 'my-width-1/2', 'my-width-1.5'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1294,7 +1294,8 @@ describe('theme', async () => {
 
   test('can use escaped CSS variables in theme values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
@@ -1307,7 +1308,6 @@ describe('theme', async () => {
             --width-2_5: 0.625rem;
           }
         `,
-        ['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1346,7 +1346,8 @@ describe('theme', async () => {
 
   test('can use escaped CSS variables in referenced theme namespace', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'],
         css`
           @tailwind utilities;
           @plugin "my-plugin";
@@ -1359,7 +1360,6 @@ describe('theme', async () => {
             --width-2_5: 0.625rem;
           }
         `,
-        ['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1405,13 +1405,13 @@ describe('theme', async () => {
 describe('addBase', () => {
   test('does not create rules when imported via `@import "…" reference`', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @tailwind utilities;
           @plugin "outside";
           @import './inside.css' reference;
         `,
-        [],
         {
           loadModule: async (_id, base) => {
             if (_id === 'inside') {
@@ -1455,11 +1455,11 @@ describe('addBase', () => {
 
   test('does not modify CSS variables', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @plugin "my-plugin";
         `,
-        [],
         {
           loadModule: async () => ({
             path: '',
@@ -1487,14 +1487,14 @@ describe('addBase', () => {
 describe('addVariant', () => {
   test('addVariant with string selector', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1524,14 +1524,14 @@ describe('addVariant', () => {
 
   test('addVariant with array of selectors', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1561,14 +1561,14 @@ describe('addVariant', () => {
 
   test('addVariant with object syntax and @slot', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1601,14 +1601,14 @@ describe('addVariant', () => {
 
   test('addVariant with object syntax, media, nesting and multiple @slot', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1655,14 +1655,14 @@ describe('addVariant', () => {
 
   test('addVariant with at-rules and placeholder', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['potato:underline', 'potato:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['potato:underline', 'potato:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1699,14 +1699,14 @@ describe('addVariant', () => {
 
   test('@slot is preserved when used as a custom property value', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1742,14 +1742,14 @@ describe('addVariant', () => {
 
   test('ignores variants that use :merge(…) and ensures `peer-*` and `group-*` rules work out of the box', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['optional:flex', 'group-optional:flex', 'peer-optional:flex', 'group-optional/foo:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['optional:flex', 'group-optional:flex', 'peer-optional:flex', 'group-optional/foo:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1779,14 +1779,14 @@ describe('addVariant', () => {
 describe('matchVariant', () => {
   test('partial arbitrary variants', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1816,14 +1816,14 @@ describe('matchVariant', () => {
 
   test('partial arbitrary variants with at-rules', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1857,14 +1857,14 @@ describe('matchVariant', () => {
 
   test('partial arbitrary variants with at-rules and placeholder', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1904,14 +1904,14 @@ describe('matchVariant', () => {
 
   test('partial arbitrary variants with default values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['tooltip-bottom:underline', 'tooltip-top:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['tooltip-bottom:underline', 'tooltip-top:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -1946,19 +1946,19 @@ describe('matchVariant', () => {
 
   test('matched variant values maintain the sort order they are registered in', async () => {
     expect(
-      await compileCss(
-        css`
-          @plugin "my-plugin";
-          @layer utilities {
-            @tailwind utilities;
-          }
-        `,
+      await run(
         [
           'alphabet-c:underline',
           'alphabet-a:underline',
           'alphabet-d:underline',
           'alphabet-b:underline',
         ],
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -1991,14 +1991,14 @@ describe('matchVariant', () => {
 
   test('matchVariant can return an array of format strings from the function', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['test-[a,b,c]:underline'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['test-[a,b,c]:underline'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2026,14 +2026,14 @@ describe('matchVariant', () => {
 
   test('should be possible to sort variants', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['testmin-[600px]:flex', 'testmin-[500px]:underline', 'testmin-[700px]:italic'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['testmin-[600px]:flex', 'testmin-[500px]:underline', 'testmin-[700px]:italic'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2077,14 +2077,14 @@ describe('matchVariant', () => {
 
   test('should be possible to compare arbitrary variants and hardcoded variants', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['testmin-[700px]:italic', 'testmin-example:italic', 'testmin-[500px]:italic'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['testmin-[700px]:italic', 'testmin-example:italic', 'testmin-[500px]:italic'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2129,19 +2129,19 @@ describe('matchVariant', () => {
 
   test('should be possible to sort stacked arbitrary variants correctly', async () => {
     expect(
-      await compileCss(
-        css`
-          @plugin "my-plugin";
-          @layer utilities {
-            @tailwind utilities;
-          }
-        `,
+      await run(
         [
           'testmin-[150px]:testmax-[400px]:order-2',
           'testmin-[100px]:testmax-[350px]:order-3',
           'testmin-[100px]:testmax-[300px]:order-4',
           'testmin-[100px]:testmax-[400px]:order-1',
         ],
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -2204,17 +2204,17 @@ describe('matchVariant', () => {
   test('should maintain sort from other variants, if sort functions of arbitrary variants return 0', async () => {
     // Expect :focus to come after :hover
     expect(
-      await compileCss(
+      await run(
+        [
+          'testmin-[100px]:testmax-[200px]:focus:underline',
+          'testmin-[100px]:testmax-[200px]:hover:underline',
+        ],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        [
-          'testmin-[100px]:testmax-[200px]:focus:underline',
-          'testmin-[100px]:testmax-[200px]:hover:underline',
-        ],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2260,19 +2260,19 @@ describe('matchVariant', () => {
 
   test('should sort arbitrary variants left to right (1)', async () => {
     expect(
-      await compileCss(
-        css`
-          @plugin "my-plugin";
-          @layer utilities {
-            @tailwind utilities;
-          }
-        `,
+      await run(
         [
           'testmin-[200px]:testmax-[400px]:order-2',
           'testmin-[200px]:testmax-[300px]:order-4',
           'testmin-[100px]:testmax-[400px]:order-1',
           'testmin-[100px]:testmax-[300px]:order-3',
         ],
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -2335,19 +2335,19 @@ describe('matchVariant', () => {
 
   test('should sort arbitrary variants left to right (2)', async () => {
     expect(
-      await compileCss(
-        css`
-          @plugin "my-plugin";
-          @layer utilities {
-            @tailwind utilities;
-          }
-        `,
+      await run(
         [
           'testmax-[400px]:testmin-[200px]:underline',
           'testmax-[300px]:testmin-[200px]:underline',
           'testmax-[400px]:testmin-[100px]:underline',
           'testmax-[300px]:testmin-[100px]:underline',
         ],
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -2406,19 +2406,19 @@ describe('matchVariant', () => {
 
   test('should guarantee that we are not passing values from other variants to the wrong function', async () => {
     expect(
-      await compileCss(
-        css`
-          @plugin "my-plugin";
-          @layer utilities {
-            @tailwind utilities;
-          }
-        `,
+      await run(
         [
           'testmin-[200px]:testmax-[400px]:order-2',
           'testmin-[200px]:testmax-[300px]:order-4',
           'testmin-[100px]:testmax-[400px]:order-1',
           'testmin-[100px]:testmax-[300px]:order-3',
         ],
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -2489,14 +2489,14 @@ describe('matchVariant', () => {
 
   test('should default to the DEFAULT value for variants', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo:underline'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['foo:underline'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2524,14 +2524,14 @@ describe('matchVariant', () => {
 
   test('should not generate anything if the matchVariant does not have a DEFAULT value configured', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo:underline'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['foo:underline'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2553,14 +2553,14 @@ describe('matchVariant', () => {
 
   test('should be possible to use `null` as a DEFAULT value', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo:underline'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['foo:underline'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2588,14 +2588,14 @@ describe('matchVariant', () => {
 
   test('should be possible to use `undefined` as a DEFAULT value', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo:underline'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['foo:underline'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2623,12 +2623,12 @@ describe('matchVariant', () => {
 
   test('should be called with eventual modifiers', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['my-container-[250px]:underline', 'my-container-[250px]/placement:underline'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['my-container-[250px]:underline', 'my-container-[250px]/placement:underline'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2670,19 +2670,19 @@ describe('matchVariant', () => {
 
   test('ignores variants that use :merge(…)', async () => {
     expect(
-      await compileCss(
-        css`
-          @plugin "my-plugin";
-          @layer utilities {
-            @tailwind utilities;
-          }
-        `,
+      await run(
         [
           'optional-[test]:flex',
           'group-optional-[test]:flex',
           'peer-optional-[test]:flex',
           'group-optional-[test]/foo:flex',
         ],
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
         {
           loadModule: async (_id, base) => {
             return {
@@ -2716,14 +2716,14 @@ describe('matchVariant', () => {
 
   test('ignores variants that use unknown values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo-[test]:flex', 'foo-known:flex', 'foo-unknown:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['foo-[test]:flex', 'foo-known:flex', 'foo-unknown:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2751,14 +2751,14 @@ describe('matchVariant', () => {
 
   test('ignores variants that produce non-string values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo-[test]:flex', 'foo-string:flex', 'foo-object:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['foo-[test]:flex', 'foo-string:flex', 'foo-object:flex'],
         {
           loadModule: async (_id, base) => {
             return {
@@ -2791,7 +2791,8 @@ describe('matchVariant', () => {
 describe('addUtilities()', () => {
   test('custom static utility', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-trim', 'lg:text-trim'],
         css`
           @plugin "my-plugin";
           @layer utilities {
@@ -2802,7 +2803,6 @@ describe('addUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['text-trim', 'lg:text-trim'],
         {
           async loadModule(_id, base) {
             return {
@@ -2841,12 +2841,12 @@ describe('addUtilities()', () => {
 
   test('return multiple rule objects from a custom utility', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-trim'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['text-trim'],
         {
           async loadModule(_id, base) {
             return {
@@ -2878,12 +2878,12 @@ describe('addUtilities()', () => {
 
   test('define multiple utilities with array syntax', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-trim', 'text-trim-2'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['text-trim', 'text-trim-2'],
         {
           async loadModule(_id, base) {
             return {
@@ -2921,12 +2921,12 @@ describe('addUtilities()', () => {
 
   test('utilities can use arrays for fallback declaration values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['outlined'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['outlined'],
         {
           async loadModule(_id, base) {
             return {
@@ -2957,14 +2957,14 @@ describe('addUtilities()', () => {
 
   test('camel case properties are converted to kebab-case', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-trim'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['text-trim'],
         {
           async loadModule(_id, base) {
             return {
@@ -2998,7 +2998,8 @@ describe('addUtilities()', () => {
 
   test('custom static utilities support `@apply`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo', 'lg:foo'],
         css`
           @plugin "my-plugin";
           @layer utilities {
@@ -3009,7 +3010,6 @@ describe('addUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['foo', 'lg:foo'],
         {
           async loadModule(_id, base) {
             return {
@@ -3090,7 +3090,8 @@ describe('addUtilities()', () => {
 
   test('supports multiple selector names', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['form-input', 'lg:form-textarea'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
@@ -3099,7 +3100,6 @@ describe('addUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['form-input', 'lg:form-textarea'],
         {
           async loadModule(_id, base) {
             return {
@@ -3136,7 +3136,8 @@ describe('addUtilities()', () => {
 
   test('supports pseudo classes and pseudo elements', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['form-input', 'lg:form-textarea'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
@@ -3145,7 +3146,6 @@ describe('addUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['form-input', 'lg:form-textarea'],
         {
           async loadModule(_id, base) {
             return {
@@ -3179,14 +3179,14 @@ describe('addUtilities()', () => {
 
   test('nests complex utility names', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
         {
           async loadModule(_id, base) {
             return {
@@ -3218,7 +3218,8 @@ describe('addUtilities()', () => {
 
   test('prefixes nested class names with the configured theme prefix', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['tw:a', 'tw:b', 'tw:c', 'tw:d'],
         css`
           @plugin "my-plugin";
           @layer utilities {
@@ -3227,7 +3228,6 @@ describe('addUtilities()', () => {
           @theme prefix(tw) {
           }
         `,
-        ['tw:a', 'tw:b', 'tw:c', 'tw:d'],
         {
           async loadModule(_id, base) {
             return {
@@ -3253,7 +3253,8 @@ describe('addUtilities()', () => {
 
   test('replaces the class name with variants in nested selectors', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo', 'md:foo', 'not-hover:md:foo'],
         css`
           @plugin "my-plugin";
           @theme {
@@ -3261,7 +3262,6 @@ describe('addUtilities()', () => {
           }
           @tailwind utilities;
         `,
-        ['foo', 'md:foo', 'not-hover:md:foo'],
         {
           async loadModule(_id, base) {
             return {
@@ -3299,12 +3299,12 @@ describe('addUtilities()', () => {
 
   test('values that are `false`, `null`, or `undefined` are discarded from CSS object ASTs', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['foo'],
         {
           async loadModule(_id, base) {
             return {
@@ -3343,7 +3343,14 @@ describe('addUtilities()', () => {
 describe('matchUtilities()', () => {
   test('custom functional utility', async () => {
     expect(
-      await compileCss(
+      await run(
+        [
+          'border-block',
+          'border-block-2',
+          'border-block-[35px]',
+          'border-block-[var(--foo)]',
+          'lg:border-block-2',
+        ],
         css`
           @plugin "my-plugin";
 
@@ -3353,13 +3360,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        [
-          'border-block',
-          'border-block-2',
-          'border-block-[35px]',
-          'border-block-[var(--foo)]',
-          'lg:border-block-2',
-        ],
         {
           async loadModule(_id, base) {
             return {
@@ -3402,7 +3402,14 @@ describe('matchUtilities()', () => {
     `)
 
     expect(
-      await compileCss(
+      await run(
+        [
+          '-border-block',
+          '-border-block-2',
+          'lg:-border-block-2',
+          'border-block-unknown',
+          'border-block/1',
+        ],
         css`
           @plugin "my-plugin";
 
@@ -3412,13 +3419,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        [
-          '-border-block',
-          '-border-block-2',
-          'lg:-border-block-2',
-          'border-block-unknown',
-          'border-block/1',
-        ],
         {
           async loadModule(_id, base) {
             return {
@@ -3439,12 +3439,12 @@ describe('matchUtilities()', () => {
 
   test('custom functional utilities can start with @', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['@w-1', 'hover:@w-1'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['@w-1', 'hover:@w-1'],
         {
           async loadModule(_id, base) {
             return {
@@ -3474,12 +3474,12 @@ describe('matchUtilities()', () => {
 
   test('custom functional utilities can return an array of rules', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['all-but-order-bottom-left-radius'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['all-but-order-bottom-left-radius'],
         {
           async loadModule(_id, base) {
             return {
@@ -3515,7 +3515,8 @@ describe('matchUtilities()', () => {
 
   test('custom functional utility with any modifier', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo'],
         css`
           @plugin "my-plugin";
 
@@ -3525,7 +3526,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo'],
         {
           async loadModule(_id, base) {
             return {
@@ -3573,7 +3573,8 @@ describe('matchUtilities()', () => {
 
   test('custom functional utility with known modifier', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo'],
         css`
           @plugin "my-plugin";
 
@@ -3583,7 +3584,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo'],
         {
           async loadModule(_id, base) {
             return {
@@ -3632,7 +3632,8 @@ describe('matchUtilities()', () => {
     `)
 
     expect(
-      await compileCss(
+      await run(
+        ['border-block/unknown', 'border-block-2/unknown'],
         css`
           @plugin "my-plugin";
 
@@ -3642,7 +3643,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['border-block/unknown', 'border-block-2/unknown'],
         {
           async loadModule(_id, base) {
             return {
@@ -3674,12 +3674,12 @@ describe('matchUtilities()', () => {
   describe('plugins that handle a specific arbitrary value type prevent falling through to other plugins if the result is invalid for that plugin', () => {
     test('implicit color modifier', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['scrollbar-[2px]', 'scrollbar-[#08c]', 'scrollbar-[#08c]/50'],
           css`
             @tailwind utilities;
             @plugin "my-plugin";
           `,
-          ['scrollbar-[2px]', 'scrollbar-[#08c]', 'scrollbar-[#08c]/50'],
           {
             async loadModule(_id, base) {
               return {
@@ -3715,12 +3715,12 @@ describe('matchUtilities()', () => {
         "
       `)
       expect(
-        await compileCss(
+        await run(
+          ['scrollbar-[2px]/50'],
           css`
             @tailwind utilities;
             @plugin "my-plugin";
           `,
-          ['scrollbar-[2px]/50'],
           {
             async loadModule(_id, base) {
               return {
@@ -3745,12 +3745,12 @@ describe('matchUtilities()', () => {
 
     test('no modifiers are supported by the plugins', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['scrollbar-[2px]/50'],
           css`
             @tailwind utilities;
             @plugin "my-plugin";
           `,
-          ['scrollbar-[2px]/50'],
           {
             async loadModule(_id, base) {
               return {
@@ -3776,12 +3776,12 @@ describe('matchUtilities()', () => {
 
     test('invalid named modifier', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['scrollbar-[2px]/foo'],
           css`
             @tailwind utilities;
             @plugin "my-plugin";
           `,
-          ['scrollbar-[2px]/foo'],
           {
             async loadModule(_id, base) {
               return {
@@ -3808,16 +3808,7 @@ describe('matchUtilities()', () => {
 
   test('custom functional utilities with different types', async () => {
     expect(
-      await compileCss(
-        css`
-          @plugin "my-plugin";
-
-          @tailwind utilities;
-
-          @theme reference {
-            --breakpoint-lg: 1024px;
-          }
-        `,
+      await run(
         [
           'scrollbar-black',
           'scrollbar-black/50',
@@ -3831,6 +3822,15 @@ describe('matchUtilities()', () => {
           'scrollbar-[color:var(--my-color)]/50',
           'scrollbar-[length:var(--my-width)]',
         ],
+        css`
+          @plugin "my-plugin";
+
+          @tailwind utilities;
+
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
         {
           async loadModule(_id, base) {
             return {
@@ -3900,7 +3900,8 @@ describe('matchUtilities()', () => {
     `)
 
     expect(
-      await compileCss(
+      await run(
+        ['scrollbar-2/50', 'scrollbar-[2px]/50', 'scrollbar-[length:var(--my-width)]/50'],
         css`
           @plugin "my-plugin";
 
@@ -3910,7 +3911,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['scrollbar-2/50', 'scrollbar-[2px]/50', 'scrollbar-[length:var(--my-width)]/50'],
         {
           async loadModule(_id, base) {
             return {
@@ -3936,7 +3936,15 @@ describe('matchUtilities()', () => {
 
   test('functional utilities with `type: color` automatically support opacity', async () => {
     expect(
-      await compileCss(
+      await run(
+        [
+          'scrollbar-current',
+          'scrollbar-current/45',
+          'scrollbar-black',
+          'scrollbar-black/33',
+          'scrollbar-black/[50%]',
+          'scrollbar-[var(--my-color)]/[25%]',
+        ],
         css`
           @plugin "my-plugin";
 
@@ -3946,14 +3954,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        [
-          'scrollbar-current',
-          'scrollbar-current/45',
-          'scrollbar-black',
-          'scrollbar-black/33',
-          'scrollbar-black/[50%]',
-          'scrollbar-[var(--my-color)]/[25%]',
-        ],
         {
           async loadModule(_id, base) {
             return {
@@ -4008,7 +4008,8 @@ describe('matchUtilities()', () => {
 
   test('functional utilities with explicit modifiers', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['scrollbar-[12px]', 'scrollbar-[12px]/foo', 'scrollbar-[12px]/bar'],
         css`
           @plugin "my-plugin";
 
@@ -4019,7 +4020,6 @@ describe('matchUtilities()', () => {
             --opacity-my-opacity: 0.5;
           }
         `,
-        ['scrollbar-[12px]', 'scrollbar-[12px]/foo', 'scrollbar-[12px]/bar'],
         {
           async loadModule(_id, base) {
             return {
@@ -4057,7 +4057,8 @@ describe('matchUtilities()', () => {
 
   test('functional utilities support `@apply`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo-bar', 'lg:foo-bar', 'foo-[12px]', 'lg:foo-[12px]'],
         css`
           @plugin "my-plugin";
           @layer utilities {
@@ -4068,7 +4069,6 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-        ['foo-bar', 'lg:foo-bar', 'foo-[12px]', 'lg:foo-[12px]'],
         {
           async loadModule(_id, base) {
             return {
@@ -4149,7 +4149,8 @@ describe('matchUtilities()', () => {
 
   test('replaces the class name with variants in nested selectors', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo-red', 'md:foo-red', 'not-hover:md:foo-red'],
         css`
           @plugin "my-plugin";
           @theme {
@@ -4157,7 +4158,6 @@ describe('matchUtilities()', () => {
           }
           @tailwind utilities;
         `,
-        ['foo-red', 'md:foo-red', 'not-hover:md:foo-red'],
         {
           async loadModule(base) {
             return {
@@ -4200,12 +4200,12 @@ describe('matchUtilities()', () => {
 describe('addComponents()', () => {
   test('is an alias for addUtilities', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['btn', 'btn-blue', 'btn-red'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['btn', 'btn-blue', 'btn-red'],
         {
           async loadModule(_id, base) {
             return {
@@ -4271,12 +4271,12 @@ describe('addComponents()', () => {
 describe('matchComponents()', () => {
   test('is an alias for matchUtilities', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['prose', 'sm:prose-sm', 'hover:prose-lg'],
         css`
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['prose', 'sm:prose-sm', 'hover:prose-lg'],
         {
           async loadModule(_id, base) {
             return {
@@ -4415,11 +4415,7 @@ describe('config()', () => {
   }) => {
     // These should not crash or produce output
     expect(
-      await compileCss(
-        css`
-          @tailwind utilities;
-          @plugin "my-plugin";
-        `,
+      await run(
         [
           'test-constructor',
           'test-hasOwnProperty',
@@ -4427,6 +4423,10 @@ describe('config()', () => {
           'test-valueOf',
           'test-__proto__',
         ],
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
         {
           loadModule: async (_id, base) => {
             return {

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile } from '..'
 import plugin from '../plugin'
-import { optimizeCss, pretty } from '../test-utils/run'
+import { compileCss } from '../test-utils/run'
 import defaultTheme from './default-theme'
 import type { CssInJs, PluginAPI } from './plugin-api'
 
@@ -9,51 +9,53 @@ const css = String.raw
 
 describe('theme', async () => {
   test('plugin theme can contain objects', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ addBase, theme }) {
-              addBase({
-                '@keyframes enter': theme('keyframes.enter'),
-                '@keyframes exit': theme('keyframes.exit'),
-              })
-            },
-            {
-              theme: {
-                extend: {
-                  keyframes: {
-                    enter: {
-                      from: {
-                        opacity: 'var(--tw-enter-opacity, 1)',
-                        transform:
-                          'translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0) scale3d(var(--tw-enter-scale, 1), var(--tw-enter-scale, 1), var(--tw-enter-scale, 1)) rotate(var(--tw-enter-rotate, 0))',
-                      },
-                    },
-                    exit: {
-                      to: {
-                        opacity: 'var(--tw-exit-opacity, 1)',
-                        transform:
-                          'translate3d(var(--tw-exit-translate-x, 0), var(--tw-exit-translate-y, 0), 0) scale3d(var(--tw-exit-scale, 1), var(--tw-exit-scale, 1), var(--tw-exit-scale, 1)) rotate(var(--tw-exit-rotate, 0))',
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        [],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ addBase, theme }) {
+                  addBase({
+                    '@keyframes enter': theme('keyframes.enter'),
+                    '@keyframes exit': theme('keyframes.exit'),
+                  })
+                },
+                {
+                  theme: {
+                    extend: {
+                      keyframes: {
+                        enter: {
+                          from: {
+                            opacity: 'var(--tw-enter-opacity, 1)',
+                            transform:
+                              'translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0) scale3d(var(--tw-enter-scale, 1), var(--tw-enter-scale, 1), var(--tw-enter-scale, 1)) rotate(var(--tw-enter-rotate, 0))',
+                          },
+                        },
+                        exit: {
+                          to: {
+                            opacity: 'var(--tw-exit-opacity, 1)',
+                            transform:
+                              'translate3d(var(--tw-exit-translate-x, 0), var(--tw-exit-translate-y, 0), 0) scale3d(var(--tw-exit-scale, 1), var(--tw-exit-scale, 1), var(--tw-exit-scale, 1)) rotate(var(--tw-exit-rotate, 0))',
+                          },
+                        },
                       },
                     },
                   },
                 },
-              },
-            },
-          ),
-        }
-      },
-    })
-
-    expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer base {
         @keyframes enter {
@@ -62,6 +64,7 @@ describe('theme', async () => {
             transform: translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0) scale3d(var(--tw-enter-scale, 1), var(--tw-enter-scale, 1), var(--tw-enter-scale, 1)) rotate(var(--tw-enter-rotate, 0));
           }
         }
+
         @keyframes exit {
           to {
             opacity: var(--tw-exit-opacity, 1);
@@ -74,30 +77,28 @@ describe('theme', async () => {
   })
 
   test('keyframes added via addUtilities are appended to the AST', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ addUtilities, theme }) {
-            addUtilities({
-              '@keyframes enter': {
-                from: {
-                  opacity: 'var(--tw-enter-opacity, 1)',
-                },
-              },
-            })
-          }),
-        }
-      },
-    })
-
-    expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        [],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ addUtilities }) {
+                addUtilities({
+                  '@keyframes enter': { from: { opacity: 'var(--tw-enter-opacity, 1)' } },
+                })
+              }),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @keyframes enter {
         from {
@@ -109,101 +110,87 @@ describe('theme', async () => {
   })
 
   test('plugin theme can extend colors', async () => {
-    let input = css`
-      @theme reference {
-        --color-red-500: #ef4444;
+    expect(
+      await compileCss(
+        css`
+          @theme reference {
+            --color-red-500: #ef4444;
+          }
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        ['scrollbar-red-500', 'scrollbar-russet-700'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                    { values: theme('colors') },
+                  )
+                },
+                { theme: { extend: { colors: { 'russet-700': '#7a4724' } } } },
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .scrollbar-red-500 {
+        scrollbar-color: #ef4444;
       }
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
 
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                {
-                  scrollbar: (value) => ({ 'scrollbar-color': value }),
-                },
-                {
-                  values: theme('colors'),
-                },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  colors: {
-                    'russet-700': '#7a4724',
-                  },
-                },
-              },
-            },
-          ),
-        }
-      },
-    })
-
-    expect(pretty(compiler.build(['scrollbar-red-500', 'scrollbar-russet-700'])))
-      .toMatchInlineSnapshot(`
-        "
-        .scrollbar-red-500 {
-          scrollbar-color: #ef4444;
-        }
-        .scrollbar-russet-700 {
-          scrollbar-color: #7a4724;
-        }
-        "
-      `)
+      .scrollbar-russet-700 {
+        scrollbar-color: #7a4724;
+      }
+      "
+    `)
   })
 
   test('plugin theme values can reference legacy theme keys that have been replaced with bare value support', async ({
     expect,
   }) => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                {
-                  'animate-duration': (value) => ({ 'animation-duration': value }),
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        ['animate-duration-316'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { 'animate-duration': (value) => ({ 'animation-duration': value }) },
+                    { values: theme('animationDuration') },
+                  )
                 },
                 {
-                  values: theme('animationDuration'),
-                },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  animationDuration: ({ theme }: { theme: (path: string) => any }) => {
-                    return {
-                      ...theme('transitionDuration'),
-                    }
+                  theme: {
+                    extend: {
+                      animationDuration: ({ theme }: { theme: (path: string) => any }) => {
+                        return { ...theme('transitionDuration') }
+                      },
+                    },
                   },
                 },
-              },
-            },
-          ),
-        }
-      },
-    })
-
-    expect(pretty(compiler.build(['animate-duration-316']))).toMatchInlineSnapshot(`
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .animate-duration-316 {
-        animation-duration: 316ms;
+        animation-duration: .316s;
       }
       "
     `)
@@ -212,100 +199,92 @@ describe('theme', async () => {
   test('plugin theme values that support bare values are merged with other values for that theme key', async ({
     expect,
   }) => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                {
-                  'animate-duration': (value) => ({ 'animation-duration': value }),
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        ['animate-duration-316', 'animate-duration-slow'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { 'animate-duration': (value) => ({ 'animation-duration': value }) },
+                    { values: theme('animationDuration') },
+                  )
                 },
                 {
-                  values: theme('animationDuration'),
-                },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  transitionDuration: {
-                    slow: '800ms',
+                  theme: {
+                    extend: {
+                      transitionDuration: { slow: '800ms' },
+                      animationDuration: ({ theme }: { theme: (path: string) => any }) => ({
+                        ...theme('transitionDuration'),
+                      }),
+                    },
                   },
-
-                  animationDuration: ({ theme }: { theme: (path: string) => any }) => ({
-                    ...theme('transitionDuration'),
-                  }),
                 },
-              },
-            },
-          ),
-        }
-      },
-    })
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .animate-duration-316 {
+        animation-duration: .316s;
+      }
 
-    expect(pretty(compiler.build(['animate-duration-316', 'animate-duration-slow'])))
-      .toMatchInlineSnapshot(`
-        "
-        .animate-duration-316 {
-          animation-duration: 316ms;
-        }
-        .animate-duration-slow {
-          animation-duration: 800ms;
-        }
-        "
-      `)
+      .animate-duration-slow {
+        animation-duration: .8s;
+      }
+      "
+    `)
   })
 
   test('plugin theme can have opacity modifiers', async () => {
-    let input = css`
-      @tailwind utilities;
-      @theme {
-        --color-red-500: #ef4444;
-      }
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ addUtilities, theme }) {
-            addUtilities({
-              '.percentage': {
-                color: theme('colors.red.500 / 50%'),
-              },
-              '.fraction': {
-                color: theme('colors.red.500 / 0.5'),
-              },
-              '.variable': {
-                color: theme('colors.red.500 / var(--opacity)'),
-              },
-            })
-          }),
-        }
-      },
-    })
-
-    expect(pretty(compiler.build(['percentage', 'fraction', 'variable']))).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @theme {
+            --color-red-500: #ef4444;
+          }
+          @plugin "my-plugin";
+        `,
+        ['percentage', 'fraction', 'variable'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ addUtilities, theme }) {
+                addUtilities({
+                  '.percentage': { color: theme('colors.red.500 / 50%') },
+                  '.fraction': { color: theme('colors.red.500 / 0.5') },
+                  '.variable': { color: theme('colors.red.500 / var(--opacity)') },
+                })
+              }),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
-      .fraction {
-        color: color-mix(in oklab, #ef4444 50%, transparent);
+      .fraction, .percentage {
+        color: oklab(63.6834% .187 .088 / .5);
       }
-      .percentage {
-        color: color-mix(in oklab, #ef4444 50%, transparent);
-      }
+
       .variable {
         color: #ef4444;
-        @supports (color: color-mix(in lab, red, red)) {
+      }
+
+      @supports (color: color-mix(in lab, red, red)) {
+        .variable {
           color: color-mix(in oklab, #ef4444 var(--opacity), transparent);
         }
       }
@@ -314,59 +293,17 @@ describe('theme', async () => {
   })
 
   test('plugin theme colors can use <alpha-value>', async () => {
-    let input = css`
-      @tailwind utilities;
-      @theme {
-        /* This should not work */
-        --color-custom-css: rgba(255 0 0 / <alpha-value>);
-      }
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ addUtilities, theme }) {
-              addUtilities({
-                '.css-percentage': {
-                  color: theme('colors.custom-css / 50%'),
-                },
-                '.css-fraction': {
-                  color: theme('colors.custom-css / 0.5'),
-                },
-                '.css-variable': {
-                  color: theme('colors.custom-css / var(--opacity)'),
-                },
-                '.js-percentage': {
-                  color: theme('colors.custom-js / 50%'),
-                },
-                '.js-fraction': {
-                  color: theme('colors.custom-js / 0.5'),
-                },
-                '.js-variable': {
-                  color: theme('colors.custom-js / var(--opacity)'),
-                },
-              })
-            },
-            {
-              theme: {
-                colors: {
-                  /* This should work */
-                  'custom-js': 'rgb(255 0 0 / <alpha-value>)',
-                },
-              },
-            },
-          ),
-        }
-      },
-    })
-
     expect(
-      pretty(
-        compiler.build([
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @theme {
+            /* This should not work */
+            --color-custom-css: rgba(255 0 0 / <alpha-value>);
+          }
+          @plugin "my-plugin";
+        `,
+        [
           'bg-custom',
           'css-percentage',
           'css-fraction',
@@ -374,32 +311,63 @@ describe('theme', async () => {
           'js-percentage',
           'js-fraction',
           'js-variable',
-        ]),
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ addUtilities, theme }) {
+                  addUtilities({
+                    '.css-percentage': { color: theme('colors.custom-css / 50%') },
+                    '.css-fraction': { color: theme('colors.custom-css / 0.5') },
+                    '.css-variable': { color: theme('colors.custom-css / var(--opacity)') },
+                    '.js-percentage': { color: theme('colors.custom-js / 50%') },
+                    '.js-fraction': { color: theme('colors.custom-js / 0.5') },
+                    '.js-variable': { color: theme('colors.custom-js / var(--opacity)') },
+                  })
+                },
+                {
+                  theme: {
+                    colors: {
+                      /* This should work */
+                      'custom-js': 'rgb(255 0 0 / <alpha-value>)',
+                    },
+                  },
+                },
+              ),
+            }
+          },
+        },
       ),
     ).toMatchInlineSnapshot(`
       "
-      .css-fraction {
+      .css-fraction, .css-percentage {
         color: color-mix(in oklab, rgba(255 0 0 / <alpha-value>) 50%, transparent);
       }
-      .css-percentage {
-        color: color-mix(in oklab, rgba(255 0 0 / <alpha-value>) 50%, transparent);
-      }
+
       .css-variable {
         color: rgba(255 0 0 / <alpha-value>);
-        @supports (color: color-mix(in lab, red, red)) {
+      }
+
+      @supports (color: color-mix(in lab, red, red)) {
+        .css-variable {
           color: color-mix(in oklab, rgba(255 0 0 / <alpha-value>) var(--opacity), transparent);
         }
       }
-      .js-fraction {
-        color: color-mix(in oklab, rgb(255 0 0 / 1) 50%, transparent);
+
+      .js-fraction, .js-percentage {
+        color: oklab(62.7955% .224 .125 / .5);
       }
-      .js-percentage {
-        color: color-mix(in oklab, rgb(255 0 0 / 1) 50%, transparent);
-      }
+
       .js-variable {
-        color: rgb(255 0 0 / 1);
-        @supports (color: color-mix(in lab, red, red)) {
-          color: color-mix(in oklab, rgb(255 0 0 / 1) var(--opacity), transparent);
+        color: red;
+      }
+
+      @supports (color: color-mix(in lab, red, red)) {
+        .js-variable {
+          color: color-mix(in oklab, red var(--opacity), transparent);
         }
       }
       "
@@ -407,265 +375,224 @@ describe('theme', async () => {
   })
 
   test('theme value functions are resolved correctly regardless of order', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                {
-                  'animate-delay': (value) => ({ 'animation-delay': value }),
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        ['animate-delay-316', 'animate-delay-slow'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { 'animate-delay': (value) => ({ 'animation-delay': value }) },
+                    { values: theme('animationDelay') },
+                  )
                 },
                 {
-                  values: theme('animationDelay'),
-                },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  animationDuration: ({ theme }: { theme: (path: string) => any }) => ({
-                    ...theme('transitionDuration'),
-                  }),
-
-                  animationDelay: ({ theme }: { theme: (path: string) => any }) => ({
-                    ...theme('animationDuration'),
-                  }),
-
-                  transitionDuration: {
-                    slow: '800ms',
+                  theme: {
+                    extend: {
+                      animationDuration: ({ theme }: { theme: (path: string) => any }) => ({
+                        ...theme('transitionDuration'),
+                      }),
+                      animationDelay: ({ theme }: { theme: (path: string) => any }) => ({
+                        ...theme('animationDuration'),
+                      }),
+                      transitionDuration: { slow: '800ms' },
+                    },
                   },
                 },
-              },
-            },
-          ),
-        }
-      },
-    })
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .animate-delay-316 {
+        animation-delay: .316s;
+      }
 
-    expect(pretty(compiler.build(['animate-delay-316', 'animate-delay-slow'])))
-      .toMatchInlineSnapshot(`
-        "
-        .animate-delay-316 {
-          animation-delay: 316ms;
-        }
-        .animate-delay-slow {
-          animation-delay: 800ms;
-        }
-        "
-      `)
+      .animate-delay-slow {
+        animation-delay: .8s;
+      }
+      "
+    `)
   })
 
   test('plugins can override the default key', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                {
-                  'animate-duration': (value) => ({ 'animation-delay': value }),
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        ['animate-duration'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { 'animate-duration': (value) => ({ 'animation-delay': value }) },
+                    { values: theme('transitionDuration') },
+                  )
                 },
-                {
-                  values: theme('transitionDuration'),
-                },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  transitionDuration: {
-                    DEFAULT: '1500ms',
-                  },
-                },
-              },
-            },
-          ),
-        }
-      },
-    })
-
-    expect(pretty(compiler.build(['animate-duration']))).toMatchInlineSnapshot(`
+                { theme: { extend: { transitionDuration: { DEFAULT: '1500ms' } } } },
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .animate-duration {
-        animation-delay: 1500ms;
+        animation-delay: 1.5s;
       }
       "
     `)
   })
 
   test('plugins can read CSS theme keys using the old theme key notation', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-      @theme reference {
-        --animate: pulse 1s linear infinite;
-        --animate-spin: spin 1s linear infinite;
-      }
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ matchUtilities, theme }) {
-            matchUtilities(
-              {
-                animation: (value) => ({ animation: value }),
-              },
-              {
-                values: theme('animation'),
-              },
-            )
-
-            matchUtilities(
-              {
-                animation2: (value) => ({ animation: value }),
-              },
-              {
-                values: {
-                  DEFAULT: theme('animation.DEFAULT'),
-                  twist: theme('animation.spin'),
-                },
-              },
-            )
-          }),
-        }
-      },
-    })
-
     expect(
-      pretty(compiler.build(['animation-spin', 'animation', 'animation2', 'animation2-twist'])),
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+          @theme reference {
+            --animate: pulse 1s linear infinite;
+            --animate-spin: spin 1s linear infinite;
+          }
+        `,
+        ['animation-spin', 'animation', 'animation2', 'animation2-twist'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ matchUtilities, theme }) {
+                matchUtilities(
+                  { animation: (value) => ({ animation: value }) },
+                  { values: theme('animation') },
+                )
+
+                matchUtilities(
+                  { animation2: (value) => ({ animation: value }) },
+                  {
+                    values: { DEFAULT: theme('animation.DEFAULT'), twist: theme('animation.spin') },
+                  },
+                )
+              }),
+            }
+          },
+        },
+      ),
     ).toMatchInlineSnapshot(`
       "
       .animation {
-        animation: pulse 1s linear infinite;
+        animation: 1s linear infinite pulse;
       }
+
       .animation-spin {
-        animation: spin 1s linear infinite;
+        animation: 1s linear infinite spin;
       }
+
       .animation2 {
-        animation: pulse 1s linear infinite;
+        animation: 1s linear infinite pulse;
       }
+
       .animation2-twist {
-        animation: spin 1s linear infinite;
+        animation: 1s linear infinite spin;
       }
       "
     `)
   })
 
   test('CSS theme values are merged with JS theme values', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-      @theme reference {
-        --animate: pulse 1s linear infinite;
-        --animate-spin: spin 1s linear infinite;
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+          @theme reference {
+            --animate: pulse 1s linear infinite;
+            --animate-spin: spin 1s linear infinite;
+          }
+        `,
+        ['animation', 'animation-spin', 'animation-bounce'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { animation: (value) => ({ '--animation': value }) },
+                    { values: theme('animation') },
+                  )
+                },
+                { theme: { extend: { animation: { bounce: 'bounce 1s linear infinite' } } } },
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .animation {
+        --animation: pulse 1s linear infinite;
       }
-    `
 
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                {
-                  animation: (value) => ({ '--animation': value }),
-                },
-                {
-                  values: theme('animation'),
-                },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  animation: {
-                    bounce: 'bounce 1s linear infinite',
-                  },
-                },
-              },
-            },
-          ),
-        }
-      },
-    })
+      .animation-bounce {
+        --animation: bounce 1s linear infinite;
+      }
 
-    expect(pretty(compiler.build(['animation', 'animation-spin', 'animation-bounce'])))
-      .toMatchInlineSnapshot(`
-        "
-        .animation {
-          --animation: pulse 1s linear infinite;
-        }
-        .animation-bounce {
-          --animation: bounce 1s linear infinite;
-        }
-        .animation-spin {
-          --animation: spin 1s linear infinite;
-        }
-        "
-      `)
+      .animation-spin {
+        --animation: spin 1s linear infinite;
+      }
+      "
+    `)
   })
 
   test('CSS theme defaults take precedence over JS theme defaults', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-      @theme reference {
-        --animate: pulse 1s linear infinite;
-        --animate-spin: spin 1s linear infinite;
-      }
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                {
-                  animation: (value) => ({ '--animation': value }),
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+          @theme reference {
+            --animate: pulse 1s linear infinite;
+            --animate-spin: spin 1s linear infinite;
+          }
+        `,
+        ['animation'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { animation: (value) => ({ '--animation': value }) },
+                    { values: theme('animation') },
+                  )
                 },
-                {
-                  values: theme('animation'),
-                },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  animation: {
-                    DEFAULT: 'twist 1s linear infinite',
-                  },
-                },
-              },
-            },
-          ),
-        }
-      },
-    })
-
-    expect(pretty(compiler.build(['animation']))).toMatchInlineSnapshot(`
+                { theme: { extend: { animation: { DEFAULT: 'twist 1s linear infinite' } } } },
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .animation {
         --animation: pulse 1s linear infinite;
@@ -687,7 +614,7 @@ describe('theme', async () => {
     using fn = vi.fn()
 
     await compile(input, {
-      loadModule: async (id, base) => {
+      loadModule: async (_id, base) => {
         return {
           path: '',
           base,
@@ -696,13 +623,7 @@ describe('theme', async () => {
               fn(theme('animation.simple'))
             },
             {
-              theme: {
-                extend: {
-                  animation: {
-                    simple: 'simple 1s linear',
-                  },
-                },
-              },
+              theme: { extend: { animation: { simple: 'simple 1s linear' } } },
             },
           ),
         }
@@ -717,241 +638,218 @@ describe('theme', async () => {
   })
 
   test('all necessary theme keys support bare values', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        [
+          'my-aspect-2/5',
+          'my-backdrop-brightness-1',
+          'my-backdrop-contrast-1',
+          'my-backdrop-grayscale-1',
+          'my-backdrop-hue-rotate-1',
+          'my-backdrop-invert-1',
+          'my-backdrop-opacity-1',
+          'my-backdrop-saturate-1',
+          'my-backdrop-sepia-1',
+          'my-border-width-1',
+          'my-brightness-1',
+          'my-columns-1',
+          'my-contrast-1',
+          'my-divide-width-1',
+          'my-flex-grow-1',
+          'my-flex-shrink-1',
+          'my-gradient-color-stop-positions-1',
+          'my-grayscale-1',
+          'my-grid-row-end-1',
+          'my-grid-row-start-1',
+          'my-grid-template-columns-1',
+          'my-grid-template-rows-1',
+          'my-hue-rotate-1',
+          'my-invert-1',
+          'my-line-clamp-1',
+          'my-opacity-1',
+          'my-order-1',
+          'my-outline-offset-1',
+          'my-outline-width-1',
+          'my-ring-offset-width-1',
+          'my-ring-width-1',
+          'my-rotate-1',
+          'my-saturate-1',
+          'my-scale-1',
+          'my-sepia-1',
+          'my-skew-1',
+          'my-stroke-width-1',
+          'my-text-decoration-thickness-1',
+          'my-text-underline-offset-1',
+          'my-transition-delay-1',
+          'my-transition-duration-1',
+          'my-z-index-1',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ matchUtilities, theme }) {
+                function utility(name: string, themeKey: string) {
+                  matchUtilities(
+                    { [name]: (value) => ({ '--value': value }) },
+                    { values: theme(themeKey) },
+                  )
+                }
 
-    let { build } = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ matchUtilities, theme }) {
-            function utility(name: string, themeKey: string) {
-              matchUtilities(
-                { [name]: (value) => ({ '--value': value }) },
-                { values: theme(themeKey) },
-              )
+                utility('my-aspect', 'aspectRatio')
+                utility('my-backdrop-brightness', 'backdropBrightness')
+                utility('my-backdrop-contrast', 'backdropContrast')
+                utility('my-backdrop-grayscale', 'backdropGrayscale')
+                utility('my-backdrop-hue-rotate', 'backdropHueRotate')
+                utility('my-backdrop-invert', 'backdropInvert')
+                utility('my-backdrop-opacity', 'backdropOpacity')
+                utility('my-backdrop-saturate', 'backdropSaturate')
+                utility('my-backdrop-sepia', 'backdropSepia')
+                utility('my-border-width', 'borderWidth')
+                utility('my-brightness', 'brightness')
+                utility('my-columns', 'columns')
+                utility('my-contrast', 'contrast')
+                utility('my-divide-width', 'divideWidth')
+                utility('my-flex-grow', 'flexGrow')
+                utility('my-flex-shrink', 'flexShrink')
+                utility('my-gradient-color-stop-positions', 'gradientColorStopPositions')
+                utility('my-grayscale', 'grayscale')
+                utility('my-grid-row-end', 'gridRowEnd')
+                utility('my-grid-row-start', 'gridRowStart')
+                utility('my-grid-template-columns', 'gridTemplateColumns')
+                utility('my-grid-template-rows', 'gridTemplateRows')
+                utility('my-hue-rotate', 'hueRotate')
+                utility('my-invert', 'invert')
+                utility('my-line-clamp', 'lineClamp')
+                utility('my-opacity', 'opacity')
+                utility('my-order', 'order')
+                utility('my-outline-offset', 'outlineOffset')
+                utility('my-outline-width', 'outlineWidth')
+                utility('my-ring-offset-width', 'ringOffsetWidth')
+                utility('my-ring-width', 'ringWidth')
+                utility('my-rotate', 'rotate')
+                utility('my-saturate', 'saturate')
+                utility('my-scale', 'scale')
+                utility('my-sepia', 'sepia')
+                utility('my-skew', 'skew')
+                utility('my-stroke-width', 'strokeWidth')
+                utility('my-text-decoration-thickness', 'textDecorationThickness')
+                utility('my-text-underline-offset', 'textUnderlineOffset')
+                utility('my-transition-delay', 'transitionDelay')
+                utility('my-transition-duration', 'transitionDuration')
+                utility('my-z-index', 'zIndex')
+              }),
             }
-
-            utility('my-aspect', 'aspectRatio')
-            utility('my-backdrop-brightness', 'backdropBrightness')
-            utility('my-backdrop-contrast', 'backdropContrast')
-            utility('my-backdrop-grayscale', 'backdropGrayscale')
-            utility('my-backdrop-hue-rotate', 'backdropHueRotate')
-            utility('my-backdrop-invert', 'backdropInvert')
-            utility('my-backdrop-opacity', 'backdropOpacity')
-            utility('my-backdrop-saturate', 'backdropSaturate')
-            utility('my-backdrop-sepia', 'backdropSepia')
-            utility('my-border-width', 'borderWidth')
-            utility('my-brightness', 'brightness')
-            utility('my-columns', 'columns')
-            utility('my-contrast', 'contrast')
-            utility('my-divide-width', 'divideWidth')
-            utility('my-flex-grow', 'flexGrow')
-            utility('my-flex-shrink', 'flexShrink')
-            utility('my-gradient-color-stop-positions', 'gradientColorStopPositions')
-            utility('my-grayscale', 'grayscale')
-            utility('my-grid-row-end', 'gridRowEnd')
-            utility('my-grid-row-start', 'gridRowStart')
-            utility('my-grid-template-columns', 'gridTemplateColumns')
-            utility('my-grid-template-rows', 'gridTemplateRows')
-            utility('my-hue-rotate', 'hueRotate')
-            utility('my-invert', 'invert')
-            utility('my-line-clamp', 'lineClamp')
-            utility('my-opacity', 'opacity')
-            utility('my-order', 'order')
-            utility('my-outline-offset', 'outlineOffset')
-            utility('my-outline-width', 'outlineWidth')
-            utility('my-ring-offset-width', 'ringOffsetWidth')
-            utility('my-ring-width', 'ringWidth')
-            utility('my-rotate', 'rotate')
-            utility('my-saturate', 'saturate')
-            utility('my-scale', 'scale')
-            utility('my-sepia', 'sepia')
-            utility('my-skew', 'skew')
-            utility('my-stroke-width', 'strokeWidth')
-            utility('my-text-decoration-thickness', 'textDecorationThickness')
-            utility('my-text-underline-offset', 'textUnderlineOffset')
-            utility('my-transition-delay', 'transitionDelay')
-            utility('my-transition-duration', 'transitionDuration')
-            utility('my-z-index', 'zIndex')
-          }),
-        }
-      },
-    })
-
-    let output = build([
-      'my-aspect-2/5',
-      'my-backdrop-brightness-1',
-      'my-backdrop-contrast-1',
-      'my-backdrop-grayscale-1',
-      'my-backdrop-hue-rotate-1',
-      'my-backdrop-invert-1',
-      'my-backdrop-opacity-1',
-      'my-backdrop-saturate-1',
-      'my-backdrop-sepia-1',
-      'my-border-width-1',
-      'my-brightness-1',
-      'my-columns-1',
-      'my-contrast-1',
-      'my-divide-width-1',
-      'my-flex-grow-1',
-      'my-flex-shrink-1',
-      'my-gradient-color-stop-positions-1',
-      'my-grayscale-1',
-      'my-grid-row-end-1',
-      'my-grid-row-start-1',
-      'my-grid-template-columns-1',
-      'my-grid-template-rows-1',
-      'my-hue-rotate-1',
-      'my-invert-1',
-      'my-line-clamp-1',
-      'my-opacity-1',
-      'my-order-1',
-      'my-outline-offset-1',
-      'my-outline-width-1',
-      'my-ring-offset-width-1',
-      'my-ring-width-1',
-      'my-rotate-1',
-      'my-saturate-1',
-      'my-scale-1',
-      'my-sepia-1',
-      'my-skew-1',
-      'my-stroke-width-1',
-      'my-text-decoration-thickness-1',
-      'my-text-underline-offset-1',
-      'my-transition-delay-1',
-      'my-transition-duration-1',
-      'my-z-index-1',
-    ])
-
-    expect(pretty(output)).toMatchInlineSnapshot(`
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .my-aspect-2\\/5 {
         --value: 2/5;
       }
-      .my-backdrop-brightness-1 {
+
+      .my-backdrop-brightness-1, .my-backdrop-contrast-1, .my-backdrop-grayscale-1 {
         --value: 1%;
       }
-      .my-backdrop-contrast-1 {
-        --value: 1%;
-      }
-      .my-backdrop-grayscale-1 {
-        --value: 1%;
-      }
+
       .my-backdrop-hue-rotate-1 {
         --value: 1deg;
       }
-      .my-backdrop-invert-1 {
+
+      .my-backdrop-invert-1, .my-backdrop-opacity-1, .my-backdrop-saturate-1, .my-backdrop-sepia-1 {
         --value: 1%;
       }
-      .my-backdrop-opacity-1 {
-        --value: 1%;
-      }
-      .my-backdrop-saturate-1 {
-        --value: 1%;
-      }
-      .my-backdrop-sepia-1 {
-        --value: 1%;
-      }
+
       .my-border-width-1 {
         --value: 1px;
       }
+
       .my-brightness-1 {
         --value: 1%;
       }
+
       .my-columns-1 {
         --value: 1;
       }
+
       .my-contrast-1 {
         --value: 1%;
       }
+
       .my-divide-width-1 {
         --value: 1px;
       }
-      .my-flex-grow-1 {
+
+      .my-flex-grow-1, .my-flex-shrink-1 {
         --value: 1;
       }
-      .my-flex-shrink-1 {
-        --value: 1;
-      }
-      .my-gradient-color-stop-positions-1 {
+
+      .my-gradient-color-stop-positions-1, .my-grayscale-1 {
         --value: 1%;
       }
-      .my-grayscale-1 {
-        --value: 1%;
-      }
-      .my-grid-row-end-1 {
+
+      .my-grid-row-end-1, .my-grid-row-start-1 {
         --value: 1;
       }
-      .my-grid-row-start-1 {
-        --value: 1;
-      }
-      .my-grid-template-columns-1 {
+
+      .my-grid-template-columns-1, .my-grid-template-rows-1 {
         --value: repeat(1, minmax(0, 1fr));
       }
-      .my-grid-template-rows-1 {
-        --value: repeat(1, minmax(0, 1fr));
-      }
+
       .my-hue-rotate-1 {
         --value: 1deg;
       }
+
       .my-invert-1 {
         --value: 1%;
       }
+
       .my-line-clamp-1 {
         --value: 1;
       }
+
       .my-opacity-1 {
         --value: 1%;
       }
+
       .my-order-1 {
         --value: 1;
       }
-      .my-outline-offset-1 {
+
+      .my-outline-offset-1, .my-outline-width-1, .my-ring-offset-width-1, .my-ring-width-1 {
         --value: 1px;
       }
-      .my-outline-width-1 {
-        --value: 1px;
-      }
-      .my-ring-offset-width-1 {
-        --value: 1px;
-      }
-      .my-ring-width-1 {
-        --value: 1px;
-      }
+
       .my-rotate-1 {
         --value: 1deg;
       }
-      .my-saturate-1 {
+
+      .my-saturate-1, .my-scale-1, .my-sepia-1 {
         --value: 1%;
       }
-      .my-scale-1 {
-        --value: 1%;
-      }
-      .my-sepia-1 {
-        --value: 1%;
-      }
+
       .my-skew-1 {
         --value: 1deg;
       }
+
       .my-stroke-width-1 {
         --value: 1;
       }
-      .my-text-decoration-thickness-1 {
+
+      .my-text-decoration-thickness-1, .my-text-underline-offset-1 {
         --value: 1px;
       }
-      .my-text-underline-offset-1 {
-        --value: 1px;
-      }
-      .my-transition-delay-1 {
+
+      .my-transition-delay-1, .my-transition-duration-1 {
         --value: 1ms;
       }
-      .my-transition-duration-1 {
-        --value: 1ms;
-      }
+
       .my-z-index-1 {
         --value: 1;
       }
@@ -972,7 +870,7 @@ describe('theme', async () => {
     using fn = vi.fn()
 
     await compile(input, {
-      loadModule: async (id, base) => {
+      loadModule: async (_id, base) => {
         return {
           path: '',
           base,
@@ -1015,7 +913,7 @@ describe('theme', async () => {
     using fn = vi.fn()
 
     await compile(input, {
-      loadModule: async (id, base) => {
+      loadModule: async (_id, base) => {
         return {
           path: '',
           base,
@@ -1047,7 +945,7 @@ describe('theme', async () => {
     using fn = vi.fn()
 
     await compile(input, {
-      loadModule: async (id, base) => {
+      loadModule: async (_id, base) => {
         return {
           path: '',
           base,
@@ -1076,7 +974,7 @@ describe('theme', async () => {
     using fn = vi.fn()
 
     await compile(input, {
-      loadModule: async (id, base) => {
+      loadModule: async (_id, base) => {
         return {
           path: '',
           base,
@@ -1097,275 +995,242 @@ describe('theme', async () => {
   })
 
   test('Candidates can match multiple utility definitions', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let { build } = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(({ addUtilities, matchUtilities }) => {
-            addUtilities({
-              '.foo-bar': {
-                color: 'red',
-              },
-            })
-
-            matchUtilities(
-              {
-                foo: (value) => ({
-                  '--my-prop': value,
-                }),
-              },
-              {
-                values: {
-                  bar: 'bar-valuer',
-                  baz: 'bar-valuer',
-                },
-              },
-            )
-
-            addUtilities({
-              '.foo-bar': {
-                backgroundColor: 'red',
-              },
-            })
-          }),
-        }
-      },
-    })
-
-    expect(pretty(build(['foo-bar']))).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        ['foo-bar'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(({ addUtilities, matchUtilities }) => {
+                addUtilities({ '.foo-bar': { color: 'red' } })
+                matchUtilities(
+                  { foo: (value) => ({ '--my-prop': value }) },
+                  { values: { bar: 'bar-valuer', baz: 'bar-valuer' } },
+                )
+                addUtilities({ '.foo-bar': { backgroundColor: 'red' } })
+              }),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .foo-bar {
-        background-color: red;
-      }
-      .foo-bar {
         color: red;
-      }
-      .foo-bar {
         --my-prop: bar-valuer;
+        background-color: red;
       }
       "
     `)
   })
 
   test('spreading `tailwindcss/defaultTheme` exports keeps bare values', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        [
+          'my-aspect-2/5',
+          // 'my-backdrop-brightness-1',
+          // 'my-backdrop-contrast-1',
+          // 'my-backdrop-grayscale-1',
+          // 'my-backdrop-hue-rotate-1',
+          // 'my-backdrop-invert-1',
+          // 'my-backdrop-opacity-1',
+          // 'my-backdrop-saturate-1',
+          // 'my-backdrop-sepia-1',
+          // 'my-divide-width-1',
+          'my-border-width-1',
+          'my-brightness-1',
+          'my-columns-1',
+          'my-contrast-1',
+          'my-flex-grow-1',
+          'my-flex-shrink-1',
+          'my-gradient-color-stop-positions-1',
+          'my-grayscale-1',
+          'my-grid-row-end-1',
+          'my-grid-row-start-1',
+          'my-grid-template-columns-1',
+          'my-grid-template-rows-1',
+          'my-hue-rotate-1',
+          'my-invert-1',
+          'my-line-clamp-1',
+          'my-opacity-1',
+          'my-order-1',
+          'my-outline-offset-1',
+          'my-outline-width-1',
+          'my-ring-offset-width-1',
+          'my-ring-width-1',
+          'my-rotate-1',
+          'my-saturate-1',
+          'my-scale-1',
+          'my-sepia-1',
+          'my-skew-1',
+          'my-stroke-width-1',
+          'my-text-decoration-thickness-1',
+          'my-text-underline-offset-1',
+          'my-transition-delay-1',
+          'my-transition-duration-1',
+          'my-z-index-1',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ matchUtilities }) {
+                function utility(name: string, themeKey: string) {
+                  matchUtilities(
+                    { [name]: (value) => ({ '--value': value }) },
+                    // @ts-ignore
+                    { values: defaultTheme[themeKey] },
+                  )
+                }
 
-    let { build } = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ matchUtilities }) {
-            function utility(name: string, themeKey: string) {
-              matchUtilities(
-                { [name]: (value) => ({ '--value': value }) },
-                // @ts-ignore
-                { values: defaultTheme[themeKey] },
-              )
+                utility('my-aspect', 'aspectRatio')
+                // The following keys deliberately doesn't work as these are exported
+                // as functions from the compat config.
+                //
+                // utility('my-backdrop-brightness', 'backdropBrightness')
+                // utility('my-backdrop-contrast', 'backdropContrast')
+                // utility('my-backdrop-grayscale', 'backdropGrayscale')
+                // utility('my-backdrop-hue-rotate', 'backdropHueRotate')
+                // utility('my-backdrop-invert', 'backdropInvert')
+                // utility('my-backdrop-opacity', 'backdropOpacity')
+                // utility('my-backdrop-saturate', 'backdropSaturate')
+                // utility('my-backdrop-sepia', 'backdropSepia')
+                // utility('my-divide-width', 'divideWidth')
+                utility('my-border-width', 'borderWidth')
+                utility('my-brightness', 'brightness')
+                utility('my-columns', 'columns')
+                utility('my-contrast', 'contrast')
+                utility('my-flex-grow', 'flexGrow')
+                utility('my-flex-shrink', 'flexShrink')
+                utility('my-gradient-color-stop-positions', 'gradientColorStopPositions')
+                utility('my-grayscale', 'grayscale')
+                utility('my-grid-row-end', 'gridRowEnd')
+                utility('my-grid-row-start', 'gridRowStart')
+                utility('my-grid-template-columns', 'gridTemplateColumns')
+                utility('my-grid-template-rows', 'gridTemplateRows')
+                utility('my-hue-rotate', 'hueRotate')
+                utility('my-invert', 'invert')
+                utility('my-line-clamp', 'lineClamp')
+                utility('my-opacity', 'opacity')
+                utility('my-order', 'order')
+                utility('my-outline-offset', 'outlineOffset')
+                utility('my-outline-width', 'outlineWidth')
+                utility('my-ring-offset-width', 'ringOffsetWidth')
+                utility('my-ring-width', 'ringWidth')
+                utility('my-rotate', 'rotate')
+                utility('my-saturate', 'saturate')
+                utility('my-scale', 'scale')
+                utility('my-sepia', 'sepia')
+                utility('my-skew', 'skew')
+                utility('my-stroke-width', 'strokeWidth')
+                utility('my-text-decoration-thickness', 'textDecorationThickness')
+                utility('my-text-underline-offset', 'textUnderlineOffset')
+                utility('my-transition-delay', 'transitionDelay')
+                utility('my-transition-duration', 'transitionDuration')
+                utility('my-z-index', 'zIndex')
+              }),
             }
-
-            utility('my-aspect', 'aspectRatio')
-            // The following keys deliberately doesn't work as these are exported
-            // as functions from the compat config.
-            //
-            // utility('my-backdrop-brightness', 'backdropBrightness')
-            // utility('my-backdrop-contrast', 'backdropContrast')
-            // utility('my-backdrop-grayscale', 'backdropGrayscale')
-            // utility('my-backdrop-hue-rotate', 'backdropHueRotate')
-            // utility('my-backdrop-invert', 'backdropInvert')
-            // utility('my-backdrop-opacity', 'backdropOpacity')
-            // utility('my-backdrop-saturate', 'backdropSaturate')
-            // utility('my-backdrop-sepia', 'backdropSepia')
-            // utility('my-divide-width', 'divideWidth')
-            utility('my-border-width', 'borderWidth')
-            utility('my-brightness', 'brightness')
-            utility('my-columns', 'columns')
-            utility('my-contrast', 'contrast')
-            utility('my-flex-grow', 'flexGrow')
-            utility('my-flex-shrink', 'flexShrink')
-            utility('my-gradient-color-stop-positions', 'gradientColorStopPositions')
-            utility('my-grayscale', 'grayscale')
-            utility('my-grid-row-end', 'gridRowEnd')
-            utility('my-grid-row-start', 'gridRowStart')
-            utility('my-grid-template-columns', 'gridTemplateColumns')
-            utility('my-grid-template-rows', 'gridTemplateRows')
-            utility('my-hue-rotate', 'hueRotate')
-            utility('my-invert', 'invert')
-            utility('my-line-clamp', 'lineClamp')
-            utility('my-opacity', 'opacity')
-            utility('my-order', 'order')
-            utility('my-outline-offset', 'outlineOffset')
-            utility('my-outline-width', 'outlineWidth')
-            utility('my-ring-offset-width', 'ringOffsetWidth')
-            utility('my-ring-width', 'ringWidth')
-            utility('my-rotate', 'rotate')
-            utility('my-saturate', 'saturate')
-            utility('my-scale', 'scale')
-            utility('my-sepia', 'sepia')
-            utility('my-skew', 'skew')
-            utility('my-stroke-width', 'strokeWidth')
-            utility('my-text-decoration-thickness', 'textDecorationThickness')
-            utility('my-text-underline-offset', 'textUnderlineOffset')
-            utility('my-transition-delay', 'transitionDelay')
-            utility('my-transition-duration', 'transitionDuration')
-            utility('my-z-index', 'zIndex')
-          }),
-        }
-      },
-    })
-
-    let output = build([
-      'my-aspect-2/5',
-      // 'my-backdrop-brightness-1',
-      // 'my-backdrop-contrast-1',
-      // 'my-backdrop-grayscale-1',
-      // 'my-backdrop-hue-rotate-1',
-      // 'my-backdrop-invert-1',
-      // 'my-backdrop-opacity-1',
-      // 'my-backdrop-saturate-1',
-      // 'my-backdrop-sepia-1',
-      // 'my-divide-width-1',
-      'my-border-width-1',
-      'my-brightness-1',
-      'my-columns-1',
-      'my-contrast-1',
-      'my-flex-grow-1',
-      'my-flex-shrink-1',
-      'my-gradient-color-stop-positions-1',
-      'my-grayscale-1',
-      'my-grid-row-end-1',
-      'my-grid-row-start-1',
-      'my-grid-template-columns-1',
-      'my-grid-template-rows-1',
-      'my-hue-rotate-1',
-      'my-invert-1',
-      'my-line-clamp-1',
-      'my-opacity-1',
-      'my-order-1',
-      'my-outline-offset-1',
-      'my-outline-width-1',
-      'my-ring-offset-width-1',
-      'my-ring-width-1',
-      'my-rotate-1',
-      'my-saturate-1',
-      'my-scale-1',
-      'my-sepia-1',
-      'my-skew-1',
-      'my-stroke-width-1',
-      'my-text-decoration-thickness-1',
-      'my-text-underline-offset-1',
-      'my-transition-delay-1',
-      'my-transition-duration-1',
-      'my-z-index-1',
-    ])
-
-    expect(pretty(output)).toMatchInlineSnapshot(`
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .my-aspect-2\\/5 {
         --value: 2/5;
       }
+
       .my-border-width-1 {
         --value: 1px;
       }
+
       .my-brightness-1 {
         --value: 1%;
       }
+
       .my-columns-1 {
         --value: 1;
       }
+
       .my-contrast-1 {
         --value: 1%;
       }
-      .my-flex-grow-1 {
+
+      .my-flex-grow-1, .my-flex-shrink-1 {
         --value: 1;
       }
-      .my-flex-shrink-1 {
-        --value: 1;
-      }
-      .my-gradient-color-stop-positions-1 {
+
+      .my-gradient-color-stop-positions-1, .my-grayscale-1 {
         --value: 1%;
       }
-      .my-grayscale-1 {
-        --value: 1%;
-      }
-      .my-grid-row-end-1 {
+
+      .my-grid-row-end-1, .my-grid-row-start-1 {
         --value: 1;
       }
-      .my-grid-row-start-1 {
-        --value: 1;
-      }
-      .my-grid-template-columns-1 {
+
+      .my-grid-template-columns-1, .my-grid-template-rows-1 {
         --value: repeat(1, minmax(0, 1fr));
       }
-      .my-grid-template-rows-1 {
-        --value: repeat(1, minmax(0, 1fr));
-      }
+
       .my-hue-rotate-1 {
         --value: 1deg;
       }
+
       .my-invert-1 {
         --value: 1%;
       }
+
       .my-line-clamp-1 {
         --value: 1;
       }
+
       .my-opacity-1 {
         --value: 1%;
       }
+
       .my-order-1 {
         --value: 1;
       }
-      .my-outline-offset-1 {
+
+      .my-outline-offset-1, .my-outline-width-1, .my-ring-offset-width-1, .my-ring-width-1 {
         --value: 1px;
       }
-      .my-outline-width-1 {
-        --value: 1px;
-      }
-      .my-ring-offset-width-1 {
-        --value: 1px;
-      }
-      .my-ring-width-1 {
-        --value: 1px;
-      }
+
       .my-rotate-1 {
         --value: 1deg;
       }
-      .my-saturate-1 {
+
+      .my-saturate-1, .my-scale-1, .my-sepia-1 {
         --value: 1%;
       }
-      .my-scale-1 {
-        --value: 1%;
-      }
-      .my-sepia-1 {
-        --value: 1%;
-      }
+
       .my-skew-1 {
         --value: 1deg;
       }
+
       .my-stroke-width-1 {
         --value: 1;
       }
-      .my-text-decoration-thickness-1 {
+
+      .my-text-decoration-thickness-1, .my-text-underline-offset-1 {
         --value: 1px;
       }
-      .my-text-underline-offset-1 {
-        --value: 1px;
-      }
-      .my-transition-delay-1 {
+
+      .my-transition-delay-1, .my-transition-duration-1 {
         --value: 1ms;
       }
-      .my-transition-duration-1 {
-        --value: 1ms;
-      }
+
       .my-z-index-1 {
         --value: 1;
       }
@@ -1374,200 +1239,210 @@ describe('theme', async () => {
   })
 
   test('can use escaped JS variables in theme values', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                { 'my-width': (value) => ({ width: value }) },
-                { values: theme('width') },
-              )
-            },
-            {
-              theme: {
-                extend: {
-                  width: {
-                    '1': '0.25rem',
-                    // Purposely setting to something different from the v3 default
-                    '1/2': '60%',
-                    '1.5': '0.375rem',
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        ['my-width-1', 'my-width-1/2', 'my-width-1.5'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { 'my-width': (value) => ({ width: value }) },
+                    { values: theme('width') },
+                  )
+                },
+                {
+                  theme: {
+                    extend: {
+                      width: {
+                        '1': '0.25rem',
+                        // Purposely setting to something different from the v3 default
+                        '1/2': '60%',
+                        '1.5': '0.375rem',
+                      },
+                    },
                   },
                 },
-              },
-            },
-          ),
-        }
-      },
-    })
-
-    expect(
-      pretty(compiler.build(['my-width-1', 'my-width-1/2', 'my-width-1.5'])),
-    ).toMatchInlineSnapshot(
-      `
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .my-width-1 {
-        width: 0.25rem;
+        width: .25rem;
       }
+
       .my-width-1\\.5 {
-        width: 0.375rem;
+        width: .375rem;
       }
+
       .my-width-1\\/2 {
         width: 60%;
       }
       "
-    `,
-    )
+    `)
   })
 
   test('can use escaped CSS variables in theme values', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
 
-      @theme {
-        --width-1: 0.25rem;
-        /* Purposely setting to something different from the v3 default */
-        --width-1\/2: 60%;
-        --width-1\.5: 0.375rem;
-        --width-2_5: 0.625rem;
+          @theme {
+            --width-1: 0.25rem;
+            /* Purposely setting to something different from the v3 default */
+            --width-1\/2: 60%;
+            --width-1\.5: 0.375rem;
+            --width-2_5: 0.625rem;
+          }
+        `,
+        ['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ matchUtilities, theme }) {
+                matchUtilities(
+                  { 'my-width': (value) => ({ width: value }) },
+                  { values: theme('width') },
+                )
+              }),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .my-width-1 {
+        width: .25rem;
       }
-    `
 
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ matchUtilities, theme }) {
-            matchUtilities(
-              { 'my-width': (value) => ({ width: value }) },
-              { values: theme('width') },
-            )
-          }),
-        }
-      },
-    })
+      .my-width-1\\.5 {
+        width: .375rem;
+      }
 
-    expect(pretty(compiler.build(['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'])))
-      .toMatchInlineSnapshot(`
-        "
-        .my-width-1 {
-          width: 0.25rem;
-        }
-        .my-width-1\\.5 {
-          width: 0.375rem;
-        }
-        .my-width-1\\/2 {
-          width: 60%;
-        }
-        .my-width-2\\.5 {
-          width: 0.625rem;
-        }
-        "
-      `)
+      .my-width-1\\/2 {
+        width: 60%;
+      }
+
+      .my-width-2\\.5 {
+        width: .625rem;
+      }
+      "
+    `)
   })
 
   test('can use escaped CSS variables in referenced theme namespace', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
 
-      @theme {
-        --width-1: 0.25rem;
-        /* Purposely setting to something different from the v3 default */
-        --width-1\/2: 60%;
-        --width-1\.5: 0.375rem;
-        --width-2_5: 0.625rem;
+          @theme {
+            --width-1: 0.25rem;
+            /* Purposely setting to something different from the v3 default */
+            --width-1\/2: 60%;
+            --width-1\.5: 0.375rem;
+            --width-2_5: 0.625rem;
+          }
+        `,
+        ['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(
+                function ({ matchUtilities, theme }) {
+                  matchUtilities(
+                    { 'my-width': (value) => ({ width: value }) },
+                    { values: theme('myWidth') },
+                  )
+                },
+                {
+                  theme: { myWidth: ({ theme }) => theme('width') },
+                },
+              ),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .my-width-1 {
+        width: .25rem;
       }
-    `
 
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(
-            function ({ matchUtilities, theme }) {
-              matchUtilities(
-                { 'my-width': (value) => ({ width: value }) },
-                { values: theme('myWidth') },
-              )
-            },
-            {
-              theme: { myWidth: ({ theme }) => theme('width') },
-            },
-          ),
-        }
-      },
-    })
+      .my-width-1\\.5 {
+        width: .375rem;
+      }
 
-    expect(pretty(compiler.build(['my-width-1', 'my-width-1.5', 'my-width-1/2', 'my-width-2.5'])))
-      .toMatchInlineSnapshot(`
-        "
-        .my-width-1 {
-          width: 0.25rem;
-        }
-        .my-width-1\\.5 {
-          width: 0.375rem;
-        }
-        .my-width-1\\/2 {
-          width: 60%;
-        }
-        .my-width-2\\.5 {
-          width: 0.625rem;
-        }
-        "
-      `)
+      .my-width-1\\/2 {
+        width: 60%;
+      }
+
+      .my-width-2\\.5 {
+        width: .625rem;
+      }
+      "
+    `)
   })
 })
 
 describe('addBase', () => {
   test('does not create rules when imported via `@import "…" reference`', async () => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "outside";
-      @import './inside.css' reference;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        if (id === 'inside') {
-          return {
-            path: '',
-            base,
-            module: plugin(function ({ addBase }) {
-              addBase({ inside: { color: 'red' } })
-            }),
-          }
-        }
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ addBase }) {
-            addBase({ outside: { color: 'red' } })
-          }),
-        }
-      },
-      async loadStylesheet() {
-        return {
-          path: '',
-          base: '',
-          content: css`
-            @plugin "inside";
-          `,
-        }
-      },
-    })
-
-    expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "outside";
+          @import './inside.css' reference;
+        `,
+        [],
+        {
+          loadModule: async (_id, base) => {
+            if (_id === 'inside') {
+              return {
+                path: '',
+                base,
+                module: plugin(function ({ addBase }) {
+                  addBase({ inside: { color: 'red' } })
+                }),
+              }
+            }
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ addBase }) {
+                addBase({ outside: { color: 'red' } })
+              }),
+            }
+          },
+          async loadStylesheet() {
+            return {
+              path: '',
+              base: '',
+              content: css`
+                @plugin "inside";
+              `,
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer base {
         outside {
@@ -1579,27 +1454,23 @@ describe('addBase', () => {
   })
 
   test('does not modify CSS variables', async () => {
-    let input = css`
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        path: '',
-        base: '/root',
-        module: plugin(function ({ addBase }) {
-          addBase({
-            ':root': {
-              '--PascalCase': '1',
-              '--camelCase': '1',
-              '--UPPERCASE': '1',
-            },
-          })
-        }),
-      }),
-    })
-
-    expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+        `,
+        [],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: plugin(function ({ addBase }) {
+              addBase({ ':root': { '--PascalCase': '1', '--camelCase': '1', '--UPPERCASE': '1' } })
+            }),
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer base {
         :root {
@@ -1615,28 +1486,28 @@ describe('addBase', () => {
 
 describe('addVariant', () => {
   test('addVariant with string selector', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ addVariant }: PluginAPI) => {
-              addVariant('hocus', '&:hover, &:focus')
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ addVariant }: PluginAPI) => {
+                addVariant('hocus', '&:hover, &:focus')
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
@@ -1652,29 +1523,28 @@ describe('addVariant', () => {
   })
 
   test('addVariant with array of selectors', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ addVariant }: PluginAPI) => {
-              addVariant('hocus', ['&:hover', '&:focus'])
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ addVariant }: PluginAPI) => {
+                addVariant('hocus', ['&:hover', '&:focus'])
+              },
+            }
+          },
         },
-      },
-    )
-
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
@@ -1690,31 +1560,31 @@ describe('addVariant', () => {
   })
 
   test('addVariant with object syntax and @slot', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ addVariant }: PluginAPI) => {
-              addVariant('hocus', {
-                '&:hover': '@slot',
-                '&:focus': '@slot',
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ addVariant }: PluginAPI) => {
+                addVariant('hocus', {
+                  '&:hover': '@slot',
+                  '&:focus': '@slot',
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
@@ -1730,33 +1600,33 @@ describe('addVariant', () => {
   })
 
   test('addVariant with object syntax, media, nesting and multiple @slot', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ addVariant }: PluginAPI) => {
-              addVariant('hocus', {
-                '@media (hover: hover)': {
-                  '&:hover': '@slot',
-                },
-                '&:focus': '@slot',
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ addVariant }: PluginAPI) => {
+                addVariant('hocus', {
+                  '@media (hover: hover)': {
+                    '&:hover': '@slot',
+                  },
+                  '&:focus': '@slot',
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (hover: hover) {
@@ -1784,31 +1654,31 @@ describe('addVariant', () => {
   })
 
   test('addVariant with at-rules and placeholder', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ addVariant }: PluginAPI) => {
-              addVariant(
-                'potato',
-                '@media (max-width: 400px) { @supports (font:bold) { &:large-potato } }',
-              )
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['potato:underline', 'potato:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ addVariant }: PluginAPI) => {
+                addVariant(
+                  'potato',
+                  '@media (max-width: 400px) { @supports (font:bold) { &:large-potato } }',
+                )
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['potato:underline', 'potato:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (max-width: 400px) {
@@ -1828,34 +1698,34 @@ describe('addVariant', () => {
   })
 
   test('@slot is preserved when used as a custom property value', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ addVariant }: PluginAPI) => {
-              addVariant('hocus', {
-                '&': {
-                  '--custom-property': '@slot',
-                  '&:hover': '@slot',
-                  '&:focus': '@slot',
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['hocus:underline'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ addVariant }: PluginAPI) => {
+                addVariant('hocus', {
+                  '&': {
+                    '--custom-property': '@slot',
+                    '&:hover': '@slot',
+                    '&:focus': '@slot',
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['hocus:underline'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .hocus\\:underline {
@@ -1871,35 +1741,30 @@ describe('addVariant', () => {
   })
 
   test('ignores variants that use :merge(…) and ensures `peer-*` and `group-*` rules work out of the box', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ addVariant }: PluginAPI) => {
-              addVariant('optional', '&:optional')
-              addVariant('group-optional', { ':merge(.group):optional &': '@slot' })
-              addVariant('peer-optional', { '&': { ':merge(.peer):optional ~ &': '@slot' } })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['optional:flex', 'group-optional:flex', 'peer-optional:flex', 'group-optional/foo:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ addVariant }: PluginAPI) => {
+                addVariant('optional', '&:optional')
+                addVariant('group-optional', { ':merge(.group):optional &': '@slot' })
+                addVariant('peer-optional', { '&': { ':merge(.peer):optional ~ &': '@slot' } })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'optional:flex',
-      'group-optional:flex',
-      'peer-optional:flex',
-      'group-optional/foo:flex',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-optional\\:flex:is(:where(.group):optional *), .group-optional\\/foo\\:flex:is(:where(.group\\/foo):optional *), .peer-optional\\:flex:is(:where(.peer):optional ~ *), .optional\\:flex:optional {
@@ -1913,28 +1778,28 @@ describe('addVariant', () => {
 
 describe('matchVariant', () => {
   test('partial arbitrary variants', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('potato', (flavor) => `.potato-${flavor} &`)
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('potato', (flavor) => `.potato-${flavor} &`)
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .potato-baked .potato-\\[baked\\]\\:flex {
@@ -1950,28 +1815,28 @@ describe('matchVariant', () => {
   })
 
   test('partial arbitrary variants with at-rules', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('potato', (flavor) => `@media (potato: ${flavor})`)
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('potato', (flavor) => `@media (potato: ${flavor})`)
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (potato: baked) {
@@ -1991,32 +1856,30 @@ describe('matchVariant', () => {
   })
 
   test('partial arbitrary variants with at-rules and placeholder', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant(
-                'potato',
-                (flavor) =>
-                  `@media (potato: ${flavor}) { @supports (font:bold) { &:large-potato } }`,
-              )
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['potato-[yellow]:underline', 'potato-[baked]:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('potato', (flavor) => {
+                  return `@media (potato: ${flavor}) { @supports (font:bold) { &:large-potato } }`
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (potato: baked) {
@@ -2040,33 +1903,33 @@ describe('matchVariant', () => {
   })
 
   test('partial arbitrary variants with default values', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('tooltip', (side) => `&${side}`, {
-                values: {
-                  bottom: '[data-location="bottom"]',
-                  top: '[data-location="top"]',
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['tooltip-bottom:underline', 'tooltip-top:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('tooltip', (side) => `&${side}`, {
+                  values: {
+                    bottom: '[data-location="bottom"]',
+                    top: '[data-location="top"]',
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['tooltip-bottom:underline', 'tooltip-top:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .tooltip-bottom\\:underline[data-location="bottom"] {
@@ -2082,40 +1945,40 @@ describe('matchVariant', () => {
   })
 
   test('matched variant values maintain the sort order they are registered in', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('alphabet', (side) => `&${side}`, {
-                values: {
-                  d: '[data-order="1"]',
-                  a: '[data-order="2"]',
-                  c: '[data-order="3"]',
-                  b: '[data-order="4"]',
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        [
+          'alphabet-c:underline',
+          'alphabet-a:underline',
+          'alphabet-d:underline',
+          'alphabet-b:underline',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('alphabet', (side) => `&${side}`, {
+                  values: {
+                    d: '[data-order="1"]',
+                    a: '[data-order="2"]',
+                    c: '[data-order="3"]',
+                    b: '[data-order="4"]',
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'alphabet-c:underline',
-      'alphabet-a:underline',
-      'alphabet-d:underline',
-      'alphabet-b:underline',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .alphabet-d\\:underline[data-order="1"], .alphabet-a\\:underline[data-order="2"], .alphabet-c\\:underline[data-order="3"], .alphabet-b\\:underline[data-order="4"] {
@@ -2127,30 +1990,30 @@ describe('matchVariant', () => {
   })
 
   test('matchVariant can return an array of format strings from the function', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('test', (selector) =>
-                selector.split(',').map((selector) => `&.${selector} > *`),
-              )
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['test-[a,b,c]:underline'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('test', (selector) =>
+                  selector.split(',').map((selector) => `&.${selector} > *`),
+                )
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['test-[a,b,c]:underline'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .test-\\[a\\,b\\,c\\]\\:underline.a > *, .test-\\[a\\,b\\,c\\]\\:underline.b > *, .test-\\[a\\,b\\,c\\]\\:underline.c > * {
@@ -2162,36 +2025,32 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to sort variants', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(a.value) - parseInt(z.value)
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['testmin-[600px]:flex', 'testmin-[500px]:underline', 'testmin-[700px]:italic'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(a.value) - parseInt(z.value)
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'testmin-[600px]:flex',
-      'testmin-[500px]:underline',
-      'testmin-[700px]:italic',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (min-width: 500px) {
@@ -2217,39 +2076,33 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to compare arbitrary variants and hardcoded variants', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
-                values: {
-                  example: '600px',
-                },
-                sort(a, z) {
-                  return parseInt(a.value) - parseInt(z.value)
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['testmin-[700px]:italic', 'testmin-example:italic', 'testmin-[500px]:italic'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
+                  values: { example: '600px' },
+                  sort(a, z) {
+                    return parseInt(a.value) - parseInt(z.value)
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'testmin-[700px]:italic',
-      'testmin-example:italic',
-      'testmin-[500px]:italic',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (min-width: 500px) {
@@ -2275,44 +2128,43 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to sort stacked arbitrary variants correctly', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(a.value) - parseInt(z.value)
-                },
-              })
-
-              matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(z.value) - parseInt(a.value)
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        [
+          'testmin-[150px]:testmax-[400px]:order-2',
+          'testmin-[100px]:testmax-[350px]:order-3',
+          'testmin-[100px]:testmax-[300px]:order-4',
+          'testmin-[100px]:testmax-[400px]:order-1',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(a.value) - parseInt(z.value)
+                  },
+                })
+
+                matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(z.value) - parseInt(a.value)
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    let compiled = build([
-      'testmin-[150px]:testmax-[400px]:order-2',
-      'testmin-[100px]:testmax-[350px]:order-3',
-      'testmin-[100px]:testmax-[300px]:order-4',
-      'testmin-[100px]:testmax-[400px]:order-1',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (min-width: 100px) {
@@ -2350,42 +2202,42 @@ describe('matchVariant', () => {
   })
 
   test('should maintain sort from other variants, if sort functions of arbitrary variants return 0', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(a.value) - parseInt(z.value)
-                },
-              })
-
-              matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(z.value) - parseInt(a.value)
-                },
-              })
-            },
-          }
-        },
-      },
-    )
-    let compiled = build([
-      'testmin-[100px]:testmax-[200px]:focus:underline',
-      'testmin-[100px]:testmax-[200px]:hover:underline',
-    ])
-
     // Expect :focus to come after :hover
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        [
+          'testmin-[100px]:testmax-[200px]:focus:underline',
+          'testmin-[100px]:testmax-[200px]:hover:underline',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(a.value) - parseInt(z.value)
+                  },
+                })
+
+                matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(z.value) - parseInt(a.value)
+                  },
+                })
+              },
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (min-width: 100px) {
@@ -2407,42 +2259,42 @@ describe('matchVariant', () => {
   })
 
   test('should sort arbitrary variants left to right (1)', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(a.value) - parseInt(z.value)
-                },
-              })
-              matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(z.value) - parseInt(a.value)
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        [
+          'testmin-[200px]:testmax-[400px]:order-2',
+          'testmin-[200px]:testmax-[300px]:order-4',
+          'testmin-[100px]:testmax-[400px]:order-1',
+          'testmin-[100px]:testmax-[300px]:order-3',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(a.value) - parseInt(z.value)
+                  },
+                })
+                matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(z.value) - parseInt(a.value)
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'testmin-[200px]:testmax-[400px]:order-2',
-      'testmin-[200px]:testmax-[300px]:order-4',
-      'testmin-[100px]:testmax-[400px]:order-1',
-      'testmin-[100px]:testmax-[300px]:order-3',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (min-width: 100px) {
@@ -2482,42 +2334,42 @@ describe('matchVariant', () => {
   })
 
   test('should sort arbitrary variants left to right (2)', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(a.value) - parseInt(z.value)
-                },
-              })
-              matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
-                sort(a, z) {
-                  return parseInt(z.value) - parseInt(a.value)
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        [
+          'testmax-[400px]:testmin-[200px]:underline',
+          'testmax-[300px]:testmin-[200px]:underline',
+          'testmax-[400px]:testmin-[100px]:underline',
+          'testmax-[300px]:testmin-[100px]:underline',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(a.value) - parseInt(z.value)
+                  },
+                })
+                matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
+                  sort(a, z) {
+                    return parseInt(z.value) - parseInt(a.value)
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'testmax-[400px]:testmin-[200px]:underline',
-      'testmax-[300px]:testmin-[200px]:underline',
-      'testmax-[400px]:testmin-[100px]:underline',
-      'testmax-[300px]:testmin-[100px]:underline',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (max-width: 400px) {
@@ -2553,50 +2405,50 @@ describe('matchVariant', () => {
   })
 
   test('should guarantee that we are not passing values from other variants to the wrong function', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
-                sort(a, z) {
-                  let lookup = ['100px', '200px']
-                  if (lookup.indexOf(a.value) === -1 || lookup.indexOf(z.value) === -1) {
-                    throw new Error('We are seeing values that should not be there!')
-                  }
-                  return lookup.indexOf(a.value) - lookup.indexOf(z.value)
-                },
-              })
-              matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
-                sort(a, z) {
-                  let lookup = ['300px', '400px']
-                  if (lookup.indexOf(a.value) === -1 || lookup.indexOf(z.value) === -1) {
-                    throw new Error('We are seeing values that should not be there!')
-                  }
-                  return lookup.indexOf(z.value) - lookup.indexOf(a.value)
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        [
+          'testmin-[200px]:testmax-[400px]:order-2',
+          'testmin-[200px]:testmax-[300px]:order-4',
+          'testmin-[100px]:testmax-[400px]:order-1',
+          'testmin-[100px]:testmax-[300px]:order-3',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
+                  sort(a, z) {
+                    let lookup = ['100px', '200px']
+                    if (lookup.indexOf(a.value) === -1 || lookup.indexOf(z.value) === -1) {
+                      throw new Error('We are seeing values that should not be there!')
+                    }
+                    return lookup.indexOf(a.value) - lookup.indexOf(z.value)
+                  },
+                })
+                matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
+                  sort(a, z) {
+                    let lookup = ['300px', '400px']
+                    if (lookup.indexOf(a.value) === -1 || lookup.indexOf(z.value) === -1) {
+                      throw new Error('We are seeing values that should not be there!')
+                    }
+                    return lookup.indexOf(z.value) - lookup.indexOf(a.value)
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'testmin-[200px]:testmax-[400px]:order-2',
-      'testmin-[200px]:testmax-[300px]:order-4',
-      'testmin-[100px]:testmax-[400px]:order-1',
-      'testmin-[100px]:testmax-[300px]:order-3',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (min-width: 100px) {
@@ -2636,32 +2488,30 @@ describe('matchVariant', () => {
   })
 
   test('should default to the DEFAULT value for variants', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('foo', (value) => `.foo${value} &`, {
-                values: {
-                  DEFAULT: '.bar',
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['foo:underline'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('foo', (value) => `.foo${value} &`, {
+                  values: { DEFAULT: '.bar' },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['foo:underline'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo.bar .foo\\:underline {
@@ -2673,28 +2523,28 @@ describe('matchVariant', () => {
   })
 
   test('should not generate anything if the matchVariant does not have a DEFAULT value configured', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('foo', (value) => `.foo${value} &`)
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['foo:underline'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('foo', (value) => `.foo${value} &`)
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['foo:underline'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities;
       "
@@ -2702,30 +2552,30 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to use `null` as a DEFAULT value', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('foo', (value) => `.foo${value === null ? '-good' : '-bad'} &`, {
-                values: { DEFAULT: null },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['foo:underline'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('foo', (value) => `.foo${value === null ? '-good' : '-bad'} &`, {
+                  values: { DEFAULT: null },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['foo:underline'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo-good .foo\\:underline {
@@ -2737,30 +2587,30 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to use `undefined` as a DEFAULT value', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('foo', (value) => `.foo${value === undefined ? '-good' : '-bad'} &`, {
-                values: { DEFAULT: undefined },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['foo:underline'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('foo', (value) => `.foo${value === undefined ? '-good' : '-bad'} &`, {
+                  values: { DEFAULT: undefined },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build(['foo:underline'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo-good .foo\\:underline {
@@ -2772,38 +2622,36 @@ describe('matchVariant', () => {
   })
 
   test('should be called with eventual modifiers', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('my-container', (value, { modifier }) => {
-                function parseValue(value: string) {
-                  const numericValue = value.match(/^(\d+\.\d+|\d+|\.\d+)\D+/)?.[1] ?? null
-                  if (numericValue === null) return null
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['my-container-[250px]:underline', 'my-container-[250px]/placement:underline'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('my-container', (value, { modifier }) => {
+                  function parseValue(value: string) {
+                    const numericValue = value.match(/^(\d+\.\d+|\d+|\.\d+)\D+/)?.[1] ?? null
+                    if (numericValue === null) return null
 
-                  return parseFloat(value)
-                }
+                    return parseFloat(value)
+                  }
 
-                const parsed = parseValue(value)
-                return parsed !== null ? `@container ${modifier ?? ''} (min-width: ${value})` : []
-              })
-            },
-          }
+                  const parsed = parseValue(value)
+                  return parsed !== null ? `@container ${modifier ?? ''} (min-width: ${value})` : []
+                })
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'my-container-[250px]:underline',
-      'my-container-[250px]/placement:underline',
-    ])
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @container (min-width: 250px) {
         .my-container-\\[250px\\]\\:underline {
@@ -2821,35 +2669,41 @@ describe('matchVariant', () => {
   })
 
   test('ignores variants that use :merge(…)', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('optional', (flavor) => `&:optional:has(${flavor}) &`)
-              matchVariant('group-optional', (flavor) => `:merge(.group):optional:has(${flavor}) &`)
-              matchVariant('peer-optional', (flavor) => `:merge(.peer):optional:has(${flavor}) ~ &`)
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        [
+          'optional-[test]:flex',
+          'group-optional-[test]:flex',
+          'peer-optional-[test]:flex',
+          'group-optional-[test]/foo:flex',
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('optional', (flavor) => `&:optional:has(${flavor}) &`)
+                matchVariant(
+                  'group-optional',
+                  (flavor) => `:merge(.group):optional:has(${flavor}) &`,
+                )
+                matchVariant(
+                  'peer-optional',
+                  (flavor) => `:merge(.peer):optional:has(${flavor}) ~ &`,
+                )
+              },
+            }
+          },
         },
-      },
-    )
-    let compiled = build([
-      'optional-[test]:flex',
-      'group-optional-[test]:flex',
-      'peer-optional-[test]:flex',
-      'group-optional-[test]/foo:flex',
-    ])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-optional-\\[test\\]\\:flex:is(:where(.group):optional:has(test) :where(.group) *), .group-optional-\\[test\\]\\/foo\\:flex:is(:where(.group\\/foo):optional:has(test) :where(.group\\/foo) *), .peer-optional-\\[test\\]\\:flex:is(:where(.peer):optional:has(test) :where(.peer) ~ *), .optional-\\[test\\]\\:flex:optional:has(test) .optional-\\[test\\]\\:flex {
@@ -2861,33 +2715,30 @@ describe('matchVariant', () => {
   })
 
   test('ignores variants that use unknown values', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('foo', (flavor) => `&:is(${flavor})`, {
-                values: {
-                  known: 'known',
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['foo-[test]:flex', 'foo-known:flex', 'foo-unknown:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('foo', (flavor) => `&:is(${flavor})`, {
+                  values: { known: 'known' },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    let compiled = build(['foo-[test]:flex', 'foo-known:flex', 'foo-unknown:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo-known\\:flex:is(known), .foo-\\[test\\]\\:flex:is(test) {
@@ -2899,34 +2750,33 @@ describe('matchVariant', () => {
   })
 
   test('ignores variants that produce non-string values', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async (id, base) => {
-          return {
-            path: '',
-            base,
-            module: ({ matchVariant }: PluginAPI) => {
-              matchVariant('foo', (flavor) => `&:is(${flavor})`, {
-                values: {
-                  string: 'some string',
-                  object: { some: 'object' },
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['foo-[test]:flex', 'foo-string:flex', 'foo-object:flex'],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: ({ matchVariant }: PluginAPI) => {
+                matchVariant('foo', (flavor) => `&:is(${flavor})`, {
+                  values: {
+                    string: 'some string',
+                    object: { some: 'object' },
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    let compiled = build(['foo-[test]:flex', 'foo-string:flex', 'foo-object:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo-string\\:flex:is(some string), .foo-\\[test\\]\\:flex:is(test) {
@@ -2940,36 +2790,37 @@ describe('matchVariant', () => {
 
 describe('addUtilities()', () => {
   test('custom static utility', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-
-        @theme reference {
-          --breakpoint-lg: 1024px;
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.text-trim': {
-                  'text-box-trim': 'both',
-                  'text-box-edge': 'cap alphabetic',
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
-        },
-      },
-    )
 
-    expect(optimizeCss(compiled.build(['text-trim', 'lg:text-trim']))).toMatchInlineSnapshot(`
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
+        ['text-trim', 'lg:text-trim'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({
+                  '.text-trim': {
+                    'text-box-trim': 'both',
+                    'text-box-edge': 'cap alphabetic',
+                  },
+                })
+              },
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .text-trim {
@@ -2989,32 +2840,33 @@ describe('addUtilities()', () => {
   })
 
   test('return multiple rule objects from a custom utility', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities([
-                {
-                  '.text-trim': [
-                    { 'text-box-trim': 'both' },
-                    { 'text-box-edge': 'cap alphabetic' },
-                  ],
-                },
-              ])
-            },
-          }
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['text-trim'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities([
+                  {
+                    '.text-trim': [
+                      { 'text-box-trim': 'both' },
+                      { 'text-box-edge': 'cap alphabetic' },
+                    ],
+                  },
+                ])
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['text-trim']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .text-trim {
         text-box-trim: both;
@@ -3025,38 +2877,39 @@ describe('addUtilities()', () => {
   })
 
   test('define multiple utilities with array syntax', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities([
-                {
-                  '.text-trim': {
-                    'text-box-trim': 'both',
-                    'text-box-edge': 'cap alphabetic',
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['text-trim', 'text-trim-2'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities([
+                  {
+                    '.text-trim': {
+                      'text-box-trim': 'both',
+                      'text-box-edge': 'cap alphabetic',
+                    },
                   },
-                },
-                {
-                  '.text-trim-2': {
-                    'text-box-trim': 'both',
-                    'text-box-edge': 'cap alphabetic',
+                  {
+                    '.text-trim-2': {
+                      'text-box-trim': 'both',
+                      'text-box-edge': 'cap alphabetic',
+                    },
                   },
-                },
-              ])
-            },
-          }
+                ])
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['text-trim', 'text-trim-2']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .text-trim, .text-trim-2 {
         text-box-trim: both;
@@ -3067,31 +2920,32 @@ describe('addUtilities()', () => {
   })
 
   test('utilities can use arrays for fallback declaration values', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities([
-                {
-                  '.outlined': {
-                    outline: ['1px solid ButtonText', '1px auto -webkit-focus-ring-color'],
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['outlined'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities([
+                  {
+                    '.outlined': {
+                      outline: ['1px solid ButtonText', '1px auto -webkit-focus-ring-color'],
+                    },
                   },
-                },
-              ])
-            },
-          }
+                ])
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['outlined']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .outlined {
         outline: 1px solid buttontext;
@@ -3102,33 +2956,34 @@ describe('addUtilities()', () => {
   })
 
   test('camel case properties are converted to kebab-case', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.text-trim': {
-                  WebkitAppearance: 'none',
-                  textBoxTrim: 'both',
-                  textBoxEdge: 'cap alphabetic',
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+        `,
+        ['text-trim'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({
+                  '.text-trim': {
+                    WebkitAppearance: 'none',
+                    textBoxTrim: 'both',
+                    textBoxEdge: 'cap alphabetic',
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['text-trim']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .text-trim {
@@ -3142,35 +2997,36 @@ describe('addUtilities()', () => {
   })
 
   test('custom static utilities support `@apply`', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-
-        @theme reference {
-          --breakpoint-lg: 1024px;
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.foo': {
-                  '@apply flex dark:underline': {},
-                },
-              })
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
-        },
-      },
-    )
 
-    expect(optimizeCss(compiled.build(['foo', 'lg:foo']))).toMatchInlineSnapshot(`
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
+        ['foo', 'lg:foo'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({
+                  '.foo': {
+                    '@apply flex dark:underline': {},
+                  },
+                })
+              },
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo {
@@ -3213,7 +3069,7 @@ describe('addUtilities()', () => {
           }
         `,
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
@@ -3233,34 +3089,35 @@ describe('addUtilities()', () => {
   })
 
   test('supports multiple selector names', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
 
-        @theme reference {
-          --breakpoint-lg: 1024px;
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.form-input, .form-textarea': {
-                  appearance: 'none',
-                  'background-color': '#fff',
-                },
-              })
-            },
+          @theme reference {
+            --breakpoint-lg: 1024px;
           }
+        `,
+        ['form-input', 'lg:form-textarea'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({
+                  '.form-input, .form-textarea': {
+                    appearance: 'none',
+                    'background-color': '#fff',
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['form-input', 'lg:form-textarea']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .form-input {
         appearance: none;
@@ -3278,45 +3135,42 @@ describe('addUtilities()', () => {
   })
 
   test('supports pseudo classes and pseudo elements', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
 
-        @theme reference {
-          --breakpoint-lg: 1024px;
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.form-input, .form-input::placeholder, .form-textarea:hover:focus': {
-                  'background-color': 'red',
-                },
-              })
-            },
+          @theme reference {
+            --breakpoint-lg: 1024px;
           }
+        `,
+        ['form-input', 'lg:form-textarea'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({
+                  '.form-input, .form-input::placeholder, .form-textarea:hover:focus': {
+                    'background-color': 'red',
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(pretty(compiled.build(['form-input', 'lg:form-textarea']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
-      .form-input {
+      .form-input, .form-input::placeholder {
         background-color: red;
-        &::placeholder {
-          background-color: red;
-        }
       }
-      .lg\\:form-textarea {
-        @media (width >= 1024px) {
-          &:hover:focus {
-            background-color: red;
-          }
+
+      @media (min-width: 1024px) {
+        .lg\\:form-textarea:hover:focus {
+          background-color: red;
         }
       }
       "
@@ -3324,214 +3178,118 @@ describe('addUtilities()', () => {
   })
 
   test('nests complex utility names', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.a .b:hover .c': {
-                  color: 'red',
-                },
-                '.d > *': {
-                  color: 'red',
-                },
-                '.e .bar:not(.f):has(.g)': {
-                  color: 'red',
-                },
-                '.h~.i': {
-                  color: 'red',
-                },
-                '.j.j': {
-                  color: 'red',
-                },
-              })
-            },
-          }
-        },
-      },
-    )
-
     expect(
-      pretty(compiled.build(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])),
-    ).toMatchInlineSnapshot(
-      `
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({
+                  '.a .b:hover .c': { color: 'red' },
+                  '.d > *': { color: 'red' },
+                  '.e .bar:not(.f):has(.g)': { color: 'red' },
+                  '.h~.i': { color: 'red' },
+                  '.j.j': { color: 'red' },
+                })
+              },
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
-        .j {
-          &.j {
-            color: red;
-          }
-          .j& {
-            color: red;
-          }
-        }
-        .a {
-          & .b:hover .c {
-            color: red;
-          }
-        }
-        .b {
-          .a &:hover .c {
-            color: red;
-          }
-        }
-        .c {
-          .a .b:hover & {
-            color: red;
-          }
-        }
-        .d {
-          & > * {
-            color: red;
-          }
-        }
-        .e {
-          & .bar:not(.f):has(.g) {
-            color: red;
-          }
-        }
-        .g {
-          .e .bar:not(.f):has(&) {
-            color: red;
-          }
-        }
-        .h {
-          &~.i {
-            color: red;
-          }
-        }
-        .i {
-          .h~& {
-            color: red;
-          }
-        }
-      }
-      "
-    `,
-    )
-  })
-
-  test('prefixes nested class names with the configured theme prefix', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-        @theme prefix(tw) {
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.a .b:hover .c.d': {
-                  color: 'red',
-                },
-              })
-            },
-          }
-        },
-      },
-    )
-
-    expect(pretty(compiled.build(['tw:a', 'tw:b', 'tw:c', 'tw:d']))).toMatchInlineSnapshot(
-      `
-      "
-      @layer utilities {
-        .tw\\:a {
-          & .tw\\:b:hover .tw\\:c.tw\\:d {
-            color: red;
-          }
-        }
-        .tw\\:b {
-          .tw\\:a &:hover .tw\\:c.tw\\:d {
-            color: red;
-          }
-        }
-        .tw\\:c {
-          .tw\\:a .tw\\:b:hover &.tw\\:d {
-            color: red;
-          }
-        }
-        .tw\\:d {
-          .tw\\:a .tw\\:b:hover .tw\\:c& {
-            color: red;
-          }
-        }
-      }
-      "
-    `,
-    )
-  })
-
-  test('replaces the class name with variants in nested selectors', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @theme {
-          --breakpoint-md: 768px;
-        }
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.foo': {
-                  ':where(.foo > :first-child)': {
-                    color: 'red',
-                  },
-                },
-              })
-            },
-          }
-        },
-      },
-    )
-
-    expect(pretty(compiled.build(['foo', 'md:foo', 'not-hover:md:foo']))).toMatchInlineSnapshot(`
-      "
-      .foo {
-        :where(.foo > :first-child) {
+        .j.j, .j.j, .a .b:hover .c, .a .b:hover .c, .a .b:hover .c, .d > *, .e .bar:not(.f):has(.g), .e .bar:not(.f):has(.g), .h ~ .i, .h ~ .i {
           color: red;
         }
       }
-      .md\\:foo {
-        @media (width >= 768px) {
-          :where(.md\\:foo > :first-child) {
-            color: red;
+      "
+    `)
+  })
+
+  test('prefixes nested class names with the configured theme prefix', async () => {
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
+          @theme prefix(tw) {
+          }
+        `,
+        ['tw:a', 'tw:b', 'tw:c', 'tw:d'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({ '.a .b:hover .c.d': { color: 'red' } })
+              },
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      @layer utilities {
+        .tw\\:a .tw\\:b:hover .tw\\:c.tw\\:d {
+          color: red;
         }
       }
-      .not-hover\\:md\\:foo {
-        &:not(*:hover) {
-          @media (width >= 768px) {
-            :where(.not-hover\\:md\\:foo > :first-child) {
-              color: red;
-            }
+      "
+    `)
+  })
+
+  test('replaces the class name with variants in nested selectors', async () => {
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @theme {
+            --breakpoint-md: 768px;
           }
-        }
-        @media not (hover: hover) {
-          @media (width >= 768px) {
-            :where(.not-hover\\:md\\:foo > :first-child) {
-              color: red;
+          @tailwind utilities;
+        `,
+        ['foo', 'md:foo', 'not-hover:md:foo'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({ '.foo': { ':where(.foo > :first-child)': { color: 'red' } } })
+              },
             }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .foo :where(.foo > :first-child) {
+        color: red;
+      }
+
+      @media (min-width: 768px) {
+        .md\\:foo :where(.md\\:foo > :first-child), .not-hover\\:md\\:foo:not(:hover) :where(.not-hover\\:md\\:foo > :first-child) {
+          color: red;
+        }
+      }
+
+      @media not all and (hover: hover) {
+        @media (min-width: 768px) {
+          .not-hover\\:md\\:foo :where(.not-hover\\:md\\:foo > :first-child) {
+            color: red;
           }
         }
       }
@@ -3540,37 +3298,38 @@ describe('addUtilities()', () => {
   })
 
   test('values that are `false`, `null`, or `undefined` are discarded from CSS object ASTs', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addUtilities }: PluginAPI) => {
-              addUtilities({
-                '.foo': {
-                  a: 'red',
-                  // @ts-ignore: While this isn't valid per the types this did work in v3
-                  'z-index': 0,
-                  // @ts-ignore
-                  '.bar': false,
-                  // @ts-ignore
-                  '.baz': null,
-                  // @ts-ignore
-                  '.qux': undefined,
-                },
-              })
-            },
-          }
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['foo'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addUtilities }: PluginAPI) => {
+                addUtilities({
+                  '.foo': {
+                    a: 'red',
+                    // @ts-ignore: While this isn't valid per the types this did work in v3
+                    'z-index': 0,
+                    // @ts-ignore
+                    '.bar': false,
+                    // @ts-ignore
+                    '.baz': null,
+                    // @ts-ignore
+                    '.qux': undefined,
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(pretty(compiled.build(['foo']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .foo {
         a: red;
@@ -3583,8 +3342,8 @@ describe('addUtilities()', () => {
 
 describe('matchUtilities()', () => {
   test('custom functional utility', async () => {
-    async function run(candidates: string[]) {
-      let compiled = await compile(
+    expect(
+      await compileCss(
         css`
           @plugin "my-plugin";
 
@@ -3594,42 +3353,27 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-
-        {
-          async loadModule(id, base) {
-            return {
-              path: '',
-              base,
-              module: ({ matchUtilities }: PluginAPI) => {
-                matchUtilities(
-                  {
-                    'border-block': (value) => ({ 'border-block-width': value }),
-                  },
-                  {
-                    values: {
-                      DEFAULT: '1px',
-                      '2': '2px',
-                    },
-                  },
-                )
-              },
-            }
-          },
-        },
-      )
-
-      return compiled.build(candidates)
-    }
-
-    expect(
-      optimizeCss(
-        await run([
+        [
           'border-block',
           'border-block-2',
           'border-block-[35px]',
           'border-block-[var(--foo)]',
           'lg:border-block-2',
-        ]),
+        ],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchUtilities }: PluginAPI) => {
+                matchUtilities(
+                  { 'border-block': (value) => ({ 'border-block-width': value }) },
+                  { values: { DEFAULT: '1px', '2': '2px' } },
+                )
+              },
+            }
+          },
+        },
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3658,50 +3402,62 @@ describe('matchUtilities()', () => {
     `)
 
     expect(
-      optimizeCss(
-        await run([
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+
+          @tailwind utilities;
+
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
+        [
           '-border-block',
           '-border-block-2',
           'lg:-border-block-2',
           'border-block-unknown',
           'border-block/1',
-        ]),
-      ),
-    ).toEqual('')
-  })
-
-  test('custom functional utilities can start with @', async () => {
-    async function run(candidates: string[]) {
-      let compiled = await compile(
-        css`
-          @plugin "my-plugin";
-          @tailwind utilities;
-        `,
-
+        ],
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
-                  { '@w': (value) => ({ width: value }) },
-                  {
-                    values: {
-                      1: '1px',
-                    },
-                  },
+                  { 'border-block': (value) => ({ 'border-block-width': value }) },
+                  { values: { DEFAULT: '1px', '2': '2px' } },
                 )
               },
             }
           },
         },
-      )
+      ),
+    ).toEqual('')
+  })
 
-      return compiled.build(candidates)
-    }
-
-    expect(optimizeCss(await run(['@w-1', 'hover:@w-1']))).toMatchInlineSnapshot(`
+  test('custom functional utilities can start with @', async () => {
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['@w-1', 'hover:@w-1'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchUtilities }: PluginAPI) => {
+                matchUtilities({ '@w': (value) => ({ width: value }) }, { values: { 1: '1px' } })
+              },
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .\\@w-1 {
         width: 1px;
@@ -3717,53 +3473,49 @@ describe('matchUtilities()', () => {
   })
 
   test('custom functional utilities can return an array of rules', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ matchUtilities }: PluginAPI) => {
-              matchUtilities(
-                {
-                  'all-but-order-bottom-left-radius': (value) =>
-                    [
-                      { 'border-top-left-radius': value },
-                      { 'border-top-right-radius': value },
-                      { 'border-bottom-right-radius': value },
-                    ] as CssInJs[],
-                },
-                {
-                  values: {
-                    DEFAULT: '1px',
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['all-but-order-bottom-left-radius'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchUtilities }: PluginAPI) => {
+                matchUtilities(
+                  {
+                    'all-but-order-bottom-left-radius': (value) =>
+                      [
+                        { 'border-top-left-radius': value },
+                        { 'border-top-right-radius': value },
+                        { 'border-bottom-right-radius': value },
+                      ] as CssInJs[],
                   },
-                },
-              )
-            },
-          }
+                  { values: { DEFAULT: '1px' } },
+                )
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['all-but-order-bottom-left-radius'])))
-      .toMatchInlineSnapshot(`
-        "
-        .all-but-order-bottom-left-radius {
-          border-top-left-radius: 1px;
-          border-top-right-radius: 1px;
-          border-bottom-right-radius: 1px;
-        }
-        "
-      `)
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .all-but-order-bottom-left-radius {
+        border-top-left-radius: 1px;
+        border-top-right-radius: 1px;
+        border-bottom-right-radius: 1px;
+      }
+      "
+    `)
   })
 
   test('custom functional utility with any modifier', async () => {
-    async function run(candidates: string[]) {
-      let compiled = await compile(
+    expect(
+      await compileCss(
         css`
           @plugin "my-plugin";
 
@@ -3773,9 +3525,9 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-
+        ['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo'],
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
@@ -3787,27 +3539,12 @@ describe('matchUtilities()', () => {
                       'border-block-width': value,
                     }),
                   },
-                  {
-                    values: {
-                      DEFAULT: '1px',
-                      '2': '2px',
-                    },
-
-                    modifiers: 'any',
-                  },
+                  { values: { DEFAULT: '1px', '2': '2px' }, modifiers: 'any' },
                 )
               },
             }
           },
         },
-      )
-
-      return compiled.build(candidates)
-    }
-
-    expect(
-      optimizeCss(
-        await run(['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo']),
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3835,8 +3572,8 @@ describe('matchUtilities()', () => {
   })
 
   test('custom functional utility with known modifier', async () => {
-    async function run(candidates: string[]) {
-      let compiled = await compile(
+    expect(
+      await compileCss(
         css`
           @plugin "my-plugin";
 
@@ -3846,9 +3583,9 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-
+        ['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo'],
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
@@ -3861,28 +3598,14 @@ describe('matchUtilities()', () => {
                     }),
                   },
                   {
-                    values: {
-                      DEFAULT: '1px',
-                      '2': '2px',
-                    },
-
-                    modifiers: {
-                      foo: 'foo',
-                    },
+                    values: { DEFAULT: '1px', '2': '2px' },
+                    modifiers: { foo: 'foo' },
                   },
                 )
               },
             }
           },
         },
-      )
-
-      return compiled.build(candidates)
-    }
-
-    expect(
-      optimizeCss(
-        await run(['border-block', 'border-block-2', 'border-block/foo', 'border-block-2/foo']),
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3908,149 +3631,8 @@ describe('matchUtilities()', () => {
       "
     `)
 
-    expect(optimizeCss(await run(['border-block/unknown', 'border-block-2/unknown']))).toEqual('')
-  })
-
-  // We're not married to this behavior — if there's a good reason to do this differently in the
-  // future don't be afraid to change what should happen in this scenario.
-  describe('plugins that handle a specific arbitrary value type prevent falling through to other plugins if the result is invalid for that plugin', () => {
-    test('implicit color modifier', async () => {
-      async function run(candidates: string[]) {
-        let compiled = await compile(
-          css`
-            @tailwind utilities;
-            @plugin "my-plugin";
-          `,
-
-          {
-            async loadModule(id, base) {
-              return {
-                path: '',
-                base,
-                module: ({ matchUtilities }: PluginAPI) => {
-                  matchUtilities(
-                    {
-                      scrollbar: (value) => ({ 'scrollbar-color': value }),
-                    },
-                    { type: ['color', 'any'] },
-                  )
-
-                  matchUtilities(
-                    {
-                      scrollbar: (value) => ({ 'scrollbar-width': value }),
-                    },
-                    { type: ['length'] },
-                  )
-                },
-              }
-            },
-          },
-        )
-
-        return compiled.build(candidates)
-      }
-
-      expect(optimizeCss(await run(['scrollbar-[2px]', 'scrollbar-[#08c]', 'scrollbar-[#08c]/50'])))
-        .toMatchInlineSnapshot(`
-          "
-          .scrollbar-\\[2px\\] {
-            scrollbar-width: 2px;
-          }
-
-          .scrollbar-\\[\\#08c\\] {
-            scrollbar-color: #08c;
-          }
-
-          .scrollbar-\\[\\#08c\\]\\/50 {
-            scrollbar-color: oklab(59.9824% -.067 -.124 / .5);
-          }
-          "
-        `)
-      expect(optimizeCss(await run(['scrollbar-[2px]/50']))).toEqual('')
-    })
-
-    test('no modifiers are supported by the plugins', async () => {
-      async function run(candidates: string[]) {
-        let compiled = await compile(
-          css`
-            @tailwind utilities;
-            @plugin "my-plugin";
-          `,
-
-          {
-            async loadModule(id, base) {
-              return {
-                path: '',
-                base,
-                module: ({ matchUtilities }: PluginAPI) => {
-                  matchUtilities(
-                    {
-                      scrollbar: (value) => ({ '--scrollbar-angle': value }),
-                    },
-                    { type: ['angle', 'any'] },
-                  )
-
-                  matchUtilities(
-                    {
-                      scrollbar: (value) => ({ '--scrollbar-width': value }),
-                    },
-                    { type: ['length'] },
-                  )
-                },
-              }
-            },
-          },
-        )
-
-        return compiled.build(candidates)
-      }
-
-      expect(optimizeCss(await run(['scrollbar-[2px]/50']))).toEqual('')
-    })
-
-    test('invalid named modifier', async () => {
-      async function run(candidates: string[]) {
-        let compiled = await compile(
-          css`
-            @tailwind utilities;
-            @plugin "my-plugin";
-          `,
-
-          {
-            async loadModule(id, base) {
-              return {
-                path: '',
-                base,
-                module: ({ matchUtilities }: PluginAPI) => {
-                  matchUtilities(
-                    {
-                      scrollbar: (value) => ({ 'scrollbar-color': value }),
-                    },
-                    { type: ['color', 'any'], modifiers: { foo: 'foo' } },
-                  )
-
-                  matchUtilities(
-                    {
-                      scrollbar: (value) => ({ 'scrollbar-width': value }),
-                    },
-                    { type: ['length'], modifiers: { bar: 'bar' } },
-                  )
-                },
-              }
-            },
-          },
-        )
-
-        return compiled.build(candidates)
-      }
-
-      expect(optimizeCss(await run(['scrollbar-[2px]/foo']))).toEqual('')
-    })
-  })
-
-  test('custom functional utilities with different types', async () => {
-    async function run(candidates: string[]) {
-      let compiled = await compile(
+    expect(
+      await compileCss(
         css`
           @plugin "my-plugin";
 
@@ -4060,48 +3642,183 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-
+        ['border-block/unknown', 'border-block-2/unknown'],
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
                   {
-                    scrollbar: (value) => ({ 'scrollbar-color': value }),
+                    'border-block': (value, { modifier }) => ({
+                      '--my-modifier': modifier ?? 'none',
+                      'border-block-width': value,
+                    }),
                   },
                   {
-                    type: ['color', 'any'],
-                    values: {
-                      black: 'black',
-                    },
-                  },
-                )
-
-                matchUtilities(
-                  {
-                    scrollbar: (value) => ({ 'scrollbar-width': value }),
-                  },
-                  {
-                    type: ['length'],
-                    values: {
-                      2: '2px',
-                    },
+                    values: { DEFAULT: '1px', '2': '2px' },
+                    modifiers: { foo: 'foo' },
                   },
                 )
               },
             }
           },
         },
-      )
+      ),
+    ).toEqual('')
+  })
 
-      return compiled.build(candidates)
-    }
+  // We're not married to this behavior — if there's a good reason to do this differently in the
+  // future don't be afraid to change what should happen in this scenario.
+  describe('plugins that handle a specific arbitrary value type prevent falling through to other plugins if the result is invalid for that plugin', () => {
+    test('implicit color modifier', async () => {
+      expect(
+        await compileCss(
+          css`
+            @tailwind utilities;
+            @plugin "my-plugin";
+          `,
+          ['scrollbar-[2px]', 'scrollbar-[#08c]', 'scrollbar-[#08c]/50'],
+          {
+            async loadModule(_id, base) {
+              return {
+                path: '',
+                base,
+                module: ({ matchUtilities }: PluginAPI) => {
+                  matchUtilities(
+                    { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                    { type: ['color', 'any'] },
+                  )
+                  matchUtilities(
+                    { scrollbar: (value) => ({ 'scrollbar-width': value }) },
+                    { type: ['length'] },
+                  )
+                },
+              }
+            },
+          },
+        ),
+      ).toMatchInlineSnapshot(`
+        "
+        .scrollbar-\\[2px\\] {
+          scrollbar-width: 2px;
+        }
 
+        .scrollbar-\\[\\#08c\\] {
+          scrollbar-color: #08c;
+        }
+
+        .scrollbar-\\[\\#08c\\]\\/50 {
+          scrollbar-color: oklab(59.9824% -.067 -.124 / .5);
+        }
+        "
+      `)
+      expect(
+        await compileCss(
+          css`
+            @tailwind utilities;
+            @plugin "my-plugin";
+          `,
+          ['scrollbar-[2px]/50'],
+          {
+            async loadModule(_id, base) {
+              return {
+                path: '',
+                base,
+                module: ({ matchUtilities }: PluginAPI) => {
+                  matchUtilities(
+                    { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                    { type: ['color', 'any'] },
+                  )
+                  matchUtilities(
+                    { scrollbar: (value) => ({ 'scrollbar-width': value }) },
+                    { type: ['length'] },
+                  )
+                },
+              }
+            },
+          },
+        ),
+      ).toEqual('')
+    })
+
+    test('no modifiers are supported by the plugins', async () => {
+      expect(
+        await compileCss(
+          css`
+            @tailwind utilities;
+            @plugin "my-plugin";
+          `,
+          ['scrollbar-[2px]/50'],
+          {
+            async loadModule(_id, base) {
+              return {
+                path: '',
+                base,
+                module: ({ matchUtilities }: PluginAPI) => {
+                  matchUtilities(
+                    { scrollbar: (value) => ({ '--scrollbar-angle': value }) },
+                    { type: ['angle', 'any'] },
+                  )
+
+                  matchUtilities(
+                    { scrollbar: (value) => ({ '--scrollbar-width': value }) },
+                    { type: ['length'] },
+                  )
+                },
+              }
+            },
+          },
+        ),
+      ).toEqual('')
+    })
+
+    test('invalid named modifier', async () => {
+      expect(
+        await compileCss(
+          css`
+            @tailwind utilities;
+            @plugin "my-plugin";
+          `,
+          ['scrollbar-[2px]/foo'],
+          {
+            async loadModule(_id, base) {
+              return {
+                path: '',
+                base,
+                module: ({ matchUtilities }: PluginAPI) => {
+                  matchUtilities(
+                    { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                    { type: ['color', 'any'], modifiers: { foo: 'foo' } },
+                  )
+
+                  matchUtilities(
+                    { scrollbar: (value) => ({ 'scrollbar-width': value }) },
+                    { type: ['length'], modifiers: { bar: 'bar' } },
+                  )
+                },
+              }
+            },
+          },
+        ),
+      ).toEqual('')
+    })
+  })
+
+  test('custom functional utilities with different types', async () => {
     expect(
-      optimizeCss(
-        await run([
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+
+          @tailwind utilities;
+
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
+        [
           'scrollbar-black',
           'scrollbar-black/50',
           'scrollbar-2',
@@ -4113,7 +3830,26 @@ describe('matchUtilities()', () => {
           'scrollbar-[color:var(--my-color)]',
           'scrollbar-[color:var(--my-color)]/50',
           'scrollbar-[length:var(--my-width)]',
-        ]),
+        ],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchUtilities }: PluginAPI) => {
+                matchUtilities(
+                  { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                  { type: ['color', 'any'], values: { black: 'black' } },
+                )
+
+                matchUtilities(
+                  { scrollbar: (value) => ({ 'scrollbar-width': value }) },
+                  { type: ['length'], values: { 2: '2px' } },
+                )
+              },
+            }
+          },
+        },
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4164,19 +3900,7 @@ describe('matchUtilities()', () => {
     `)
 
     expect(
-      optimizeCss(
-        await run([
-          'scrollbar-2/50',
-          'scrollbar-[2px]/50',
-          'scrollbar-[length:var(--my-width)]/50',
-        ]),
-      ),
-    ).toEqual('')
-  })
-
-  test('functional utilities with `type: color` automatically support opacity', async () => {
-    async function run(candidates: string[]) {
-      let compiled = await compile(
+      await compileCss(
         css`
           @plugin "my-plugin";
 
@@ -4186,43 +3910,64 @@ describe('matchUtilities()', () => {
             --breakpoint-lg: 1024px;
           }
         `,
-
+        ['scrollbar-2/50', 'scrollbar-[2px]/50', 'scrollbar-[length:var(--my-width)]/50'],
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
-                  {
-                    scrollbar: (value) => ({ 'scrollbar-color': value }),
-                  },
-                  {
-                    type: ['color', 'any'],
-                    values: {
-                      black: 'black',
-                    },
-                  },
+                  { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                  { type: ['color', 'any'], values: { black: 'black' } },
+                )
+
+                matchUtilities(
+                  { scrollbar: (value) => ({ 'scrollbar-width': value }) },
+                  { type: ['length'], values: { 2: '2px' } },
                 )
               },
             }
           },
         },
-      )
+      ),
+    ).toEqual('')
+  })
 
-      return compiled.build(candidates)
-    }
-
+  test('functional utilities with `type: color` automatically support opacity', async () => {
     expect(
-      optimizeCss(
-        await run([
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+
+          @tailwind utilities;
+
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
+        [
           'scrollbar-current',
           'scrollbar-current/45',
           'scrollbar-black',
           'scrollbar-black/33',
           'scrollbar-black/[50%]',
           'scrollbar-[var(--my-color)]/[25%]',
-        ]),
+        ],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchUtilities }: PluginAPI) => {
+                matchUtilities(
+                  { scrollbar: (value) => ({ 'scrollbar-color': value }) },
+                  { type: ['color', 'any'], values: { black: 'black' } },
+                )
+              },
+            }
+          },
+        },
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4262,8 +4007,8 @@ describe('matchUtilities()', () => {
   })
 
   test('functional utilities with explicit modifiers', async () => {
-    async function run(candidates: string[]) {
-      let compiled = await compile(
+    expect(
+      await compileCss(
         css`
           @plugin "my-plugin";
 
@@ -4274,9 +4019,9 @@ describe('matchUtilities()', () => {
             --opacity-my-opacity: 0.5;
           }
         `,
-
+        ['scrollbar-[12px]', 'scrollbar-[12px]/foo', 'scrollbar-[12px]/bar'],
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
@@ -4288,25 +4033,13 @@ describe('matchUtilities()', () => {
                       'scrollbar-width': value,
                     }),
                   },
-                  {
-                    type: ['any'],
-                    values: {},
-                    modifiers: {
-                      foo: 'foo',
-                    },
-                  },
+                  { type: ['any'], values: {}, modifiers: { foo: 'foo' } },
                 )
               },
             }
           },
         },
-      )
-
-      return compiled.build(candidates)
-    }
-
-    expect(
-      optimizeCss(await run(['scrollbar-[12px]', 'scrollbar-[12px]/foo', 'scrollbar-[12px]/bar'])),
+      ),
     ).toMatchInlineSnapshot(`
       "
       .scrollbar-\\[12px\\] {
@@ -4323,70 +4056,61 @@ describe('matchUtilities()', () => {
   })
 
   test('functional utilities support `@apply`', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-
-        @theme reference {
-          --breakpoint-lg: 1024px;
-        }
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ matchUtilities }: PluginAPI) => {
-              matchUtilities(
-                {
-                  foo: (value) => ({
-                    '--foo': value,
-                    [`@apply flex`]: {},
-                  }),
-                },
-                {
-                  values: {
-                    bar: 'bar',
-                  },
-                },
-              )
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
           }
-        },
-      },
-    )
 
-    expect(optimizeCss(compiled.build(['foo-bar', 'lg:foo-bar', 'foo-[12px]', 'lg:foo-[12px]'])))
-      .toMatchInlineSnapshot(`
-        "
-        @layer utilities {
-          .foo-\\[12px\\] {
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
+        ['foo-bar', 'lg:foo-bar', 'foo-[12px]', 'lg:foo-[12px]'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchUtilities }: PluginAPI) => {
+                matchUtilities(
+                  { foo: (value) => ({ '--foo': value, [`@apply flex`]: {} }) },
+                  { values: { bar: 'bar' } },
+                )
+              },
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      @layer utilities {
+        .foo-\\[12px\\] {
+          --foo: 12px;
+          display: flex;
+        }
+
+        .foo-bar {
+          --foo: bar;
+          display: flex;
+        }
+
+        @media (min-width: 1024px) {
+          .lg\\:foo-\\[12px\\] {
             --foo: 12px;
             display: flex;
           }
 
-          .foo-bar {
+          .lg\\:foo-bar {
             --foo: bar;
             display: flex;
           }
-
-          @media (min-width: 1024px) {
-            .lg\\:foo-\\[12px\\] {
-              --foo: 12px;
-              display: flex;
-            }
-
-            .lg\\:foo-bar {
-              --foo: bar;
-              display: flex;
-            }
-          }
         }
-        "
-      `)
+      }
+      "
+    `)
   })
 
   test('throws on custom utilities with an invalid name', async () => {
@@ -4404,7 +4128,7 @@ describe('matchUtilities()', () => {
         `,
 
         {
-          async loadModule(id, base) {
+          async loadModule(_id, base) {
             return {
               path: '',
               base,
@@ -4424,117 +4148,97 @@ describe('matchUtilities()', () => {
   })
 
   test('replaces the class name with variants in nested selectors', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @theme {
-          --breakpoint-md: 768px;
-        }
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(base) {
-          return {
-            path: '',
-            base,
-            module: ({ matchUtilities }: PluginAPI) => {
-              matchUtilities(
-                {
-                  foo: (value) => ({
-                    ':where(.foo > :first-child)': {
-                      color: value,
-                    },
-                  }),
-                },
-                {
-                  values: {
-                    red: 'red',
-                  },
-                },
-              )
-            },
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @theme {
+            --breakpoint-md: 768px;
           }
+          @tailwind utilities;
+        `,
+        ['foo-red', 'md:foo-red', 'not-hover:md:foo-red'],
+        {
+          async loadModule(base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchUtilities }: PluginAPI) => {
+                matchUtilities(
+                  { foo: (value) => ({ ':where(.foo > :first-child)': { color: value } }) },
+                  { values: { red: 'red' } },
+                )
+              },
+            }
+          },
         },
-      },
-    )
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .foo-red :where(.foo-red > :first-child) {
+        color: red;
+      }
 
-    expect(pretty(compiled.build(['foo-red', 'md:foo-red', 'not-hover:md:foo-red'])))
-      .toMatchInlineSnapshot(`
-        "
-        .foo-red {
-          :where(.foo-red > :first-child) {
+      @media (min-width: 768px) {
+        .md\\:foo-red :where(.md\\:foo-red > :first-child), .not-hover\\:md\\:foo-red:not(:hover) :where(.not-hover\\:md\\:foo-red > :first-child) {
+          color: red;
+        }
+      }
+
+      @media not all and (hover: hover) {
+        @media (min-width: 768px) {
+          .not-hover\\:md\\:foo-red :where(.not-hover\\:md\\:foo-red > :first-child) {
             color: red;
           }
         }
-        .md\\:foo-red {
-          @media (width >= 768px) {
-            :where(.md\\:foo-red > :first-child) {
-              color: red;
-            }
-          }
-        }
-        .not-hover\\:md\\:foo-red {
-          &:not(*:hover) {
-            @media (width >= 768px) {
-              :where(.not-hover\\:md\\:foo-red > :first-child) {
-                color: red;
-              }
-            }
-          }
-          @media not (hover: hover) {
-            @media (width >= 768px) {
-              :where(.not-hover\\:md\\:foo-red > :first-child) {
-                color: red;
-              }
-            }
-          }
-        }
-        "
-      `)
+      }
+      "
+    `)
   })
 })
 
 describe('addComponents()', () => {
   test('is an alias for addUtilities', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ addComponents }: PluginAPI) => {
-              addComponents({
-                '.btn': {
-                  padding: '.5rem 1rem',
-                  borderRadius: '.25rem',
-                  fontWeight: '600',
-                },
-                '.btn-blue': {
-                  backgroundColor: '#3490dc',
-                  color: '#fff',
-                  '&:hover': {
-                    backgroundColor: '#2779bd',
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['btn', 'btn-blue', 'btn-red'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addComponents }: PluginAPI) => {
+                addComponents({
+                  '.btn': {
+                    padding: '.5rem 1rem',
+                    borderRadius: '.25rem',
+                    fontWeight: '600',
                   },
-                },
-                '.btn-red': {
-                  backgroundColor: '#e3342f',
-                  color: '#fff',
-                  '&:hover': {
-                    backgroundColor: '#cc1f1a',
+                  '.btn-blue': {
+                    backgroundColor: '#3490dc',
+                    color: '#fff',
+                    '&:hover': {
+                      backgroundColor: '#2779bd',
+                    },
                   },
-                },
-              })
-            },
-          }
+                  '.btn-red': {
+                    backgroundColor: '#e3342f',
+                    color: '#fff',
+                    '&:hover': {
+                      backgroundColor: '#cc1f1a',
+                    },
+                  },
+                })
+              },
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['btn', 'btn-blue', 'btn-red']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .btn {
         border-radius: .25rem;
@@ -4566,49 +4270,41 @@ describe('addComponents()', () => {
 
 describe('matchComponents()', () => {
   test('is an alias for matchUtilities', async () => {
-    let compiled = await compile(
-      css`
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        async loadModule(id, base) {
-          return {
-            path: '',
-            base,
-            module: ({ matchComponents }: PluginAPI) => {
-              matchComponents(
-                {
-                  prose: (value) => ({ '--container-size': value }),
-                },
-                {
-                  values: {
-                    DEFAULT: 'normal',
-                    sm: 'sm',
-                    lg: 'lg',
-                  },
-                },
-              )
-            },
-          }
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['prose', 'sm:prose-sm', 'hover:prose-lg'],
+        {
+          async loadModule(_id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchComponents }: PluginAPI) => {
+                matchComponents(
+                  { prose: (value) => ({ '--container-size': value }) },
+                  { values: { DEFAULT: 'normal', sm: 'sm', lg: 'lg' } },
+                )
+              },
+            }
+          },
         },
-      },
-    )
+      ),
+    ).toMatchInlineSnapshot(`
+      "
+      .prose {
+        --container-size: normal;
+      }
 
-    expect(optimizeCss(compiled.build(['prose', 'sm:prose-sm', 'hover:prose-lg'])))
-      .toMatchInlineSnapshot(`
-        "
-        .prose {
-          --container-size: normal;
+      @media (hover: hover) {
+        .hover\\:prose-lg:hover {
+          --container-size: lg;
         }
-
-        @media (hover: hover) {
-          .hover\\:prose-lg:hover {
-            --container-size: lg;
-          }
-        }
-        "
-      `)
+      }
+      "
+    `)
   })
 })
 
@@ -4620,7 +4316,7 @@ describe('prefix()', () => {
         @plugin "my-plugin";
       `,
       {
-        async loadModule(id, base) {
+        async loadModule(_id, base) {
           return {
             path: '',
             base,
@@ -4644,7 +4340,7 @@ describe('config()', () => {
         @plugin "my-plugin";
       `,
       {
-        async loadModule(id, base) {
+        async loadModule(_id, base) {
           return {
             path: '',
             base,
@@ -4672,7 +4368,7 @@ describe('config()', () => {
         @plugin "my-plugin";
       `,
       {
-        async loadModule(id, base) {
+        async loadModule(_id, base) {
           return {
             path: '',
             base,
@@ -4698,7 +4394,7 @@ describe('config()', () => {
         @plugin "my-plugin";
       `,
       {
-        async loadModule(id, base) {
+        async loadModule(_id, base) {
           return {
             path: '',
             base,
@@ -4717,42 +4413,34 @@ describe('config()', () => {
   test('matchUtilities does not match Object.prototype properties as values', async ({
     expect,
   }) => {
-    let input = css`
-      @tailwind utilities;
-      @plugin "my-plugin";
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async (id, base) => {
-        return {
-          path: '',
-          base,
-          module: plugin(function ({ matchUtilities }) {
-            matchUtilities(
-              {
-                test: (value) => ({ '--test': value }),
-              },
-              {
-                values: {
-                  foo: 'bar',
-                },
-              },
-            )
-          }),
-        }
-      },
-    })
-
     // These should not crash or produce output
     expect(
-      optimizeCss(
-        compiler.build([
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin";
+        `,
+        [
           'test-constructor',
           'test-hasOwnProperty',
           'test-toString',
           'test-valueOf',
           'test-__proto__',
-        ]),
+        ],
+        {
+          loadModule: async (_id, base) => {
+            return {
+              path: '',
+              base,
+              module: plugin(function ({ matchUtilities }) {
+                matchUtilities(
+                  { test: (value) => ({ '--test': value }) },
+                  { values: { foo: 'bar' } },
+                )
+              }),
+            }
+          },
+        },
       ),
     ).toEqual('')
   })

--- a/packages/tailwindcss/src/compat/screens-config.test.ts
+++ b/packages/tailwindcss/src/compat/screens-config.test.ts
@@ -354,31 +354,29 @@ test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
 })
 
 test('JS config with `theme: { extends }` should not include the `default-config` values', async () => {
+  let input = css`
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
   expect(
-    await run(
-      ['sm:flex', 'md:flex', 'min-md:max-lg:underline', 'min-sm:max-md:underline'],
-      css`
-        @config "./config.js";
-        @tailwind utilities;
-      `,
-      {
-        loadModule: async () => ({
-          module: {
-            theme: {
-              extend: {
-                screens: {
-                  mini: '40rem',
-                  midi: '48rem',
-                  maxi: '64rem',
-                },
+    await run(['sm:flex', 'md:flex', 'min-md:max-lg:underline', 'min-sm:max-md:underline'], input, {
+      loadModule: async () => ({
+        module: {
+          theme: {
+            extend: {
+              screens: {
+                mini: '40rem',
+                midi: '48rem',
+                maxi: '64rem',
               },
             },
           },
-          base: '/root',
-          path: '',
-        }),
-      },
-    ),
+        },
+        base: '/root',
+        path: '',
+      }),
+    }),
   ).toBe('')
 
   expect(
@@ -393,10 +391,7 @@ test('JS config with `theme: { extends }` should not include the `default-config
         // Ensure other core variants appear at the end
         'print:items-end',
       ],
-      css`
-        @config "./config.js";
-        @tailwind utilities;
-      `,
+      input,
       {
         loadModule: async () => ({
           module: {
@@ -458,37 +453,35 @@ test('JS config with `theme: { extends }` should not include the `default-config
 
 describe('complex screen configs', () => {
   test('generates utilities', async () => {
+    let input = css`
+      @config "./config.js";
+      @tailwind utilities;
+    `
+
     expect(
-      await run(
-        ['min-sm:flex', 'min-md:flex', 'min-xl:flex', 'min-tall:flex'],
-        css`
-          @config "./config.js";
-          @tailwind utilities;
-        `,
-        {
-          loadModule: async () => ({
-            module: {
-              theme: {
-                extend: {
-                  screens: {
-                    sm: { max: '639px' },
-                    md: [
-                      //
-                      { min: '668px', max: '767px' },
-                      '868px',
-                    ],
-                    lg: { min: '868px' },
-                    xl: { min: '1024px', max: '1279px' },
-                    tall: { raw: '(min-height: 800px)' },
-                  },
+      await run(['min-sm:flex', 'min-md:flex', 'min-xl:flex', 'min-tall:flex'], input, {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                screens: {
+                  sm: { max: '639px' },
+                  md: [
+                    //
+                    { min: '668px', max: '767px' },
+                    '868px',
+                  ],
+                  lg: { min: '868px' },
+                  xl: { min: '1024px', max: '1279px' },
+                  tall: { raw: '(min-height: 800px)' },
                 },
               },
             },
-            base: '/root',
-            path: '',
-          }),
-        },
-      ),
+          },
+          base: '/root',
+          path: '',
+        }),
+      }),
     ).toBe('')
 
     expect(
@@ -504,10 +497,7 @@ describe('complex screen configs', () => {
           // Ensure other core variants appear at the end
           'print:items-end',
         ],
-        css`
-          @config "./config.js";
-          @tailwind utilities;
-        `,
+        input,
         {
           loadModule: async () => ({
             module: {

--- a/packages/tailwindcss/src/compat/screens-config.test.ts
+++ b/packages/tailwindcss/src/compat/screens-config.test.ts
@@ -1,44 +1,26 @@
 import { describe, expect, test } from 'vitest'
-import { compile } from '..'
-import { pretty } from '../test-utils/run'
+import { compileCss } from '../test-utils/run'
 
 const css = String.raw
 
 test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @theme {
-      --breakpoint-md: 50rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          extend: {
-            screens: {
-              sm: '44rem',
-            },
-          },
-        },
-      },
-      base: '/root',
-      path: '',
-    }),
-  })
-
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @theme {
+          --breakpoint-md: 50rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      [
         'sm:flex',
         'md:flex',
         'lg:flex',
@@ -47,44 +29,61 @@ test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
         'max-w-screen-sm',
         // Ensure other core variants appear at the end
         'print:items-end',
-      ]),
+      ],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                screens: {
+                  sm: '44rem',
+                },
+              },
+            },
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
     .max-w-screen-sm {
       max-width: 44rem;
     }
-    .sm\\:flex {
-      @media (width >= 44rem) {
+
+    @media (min-width: 44rem) {
+      .sm\\:flex {
         display: flex;
       }
-    }
-    .min-sm\\:max-md\\:underline {
-      @media (width >= 44rem) {
-        @media (width < 50rem) {
+
+      @media not all and (min-width: 50rem) {
+        .min-sm\\:max-md\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .md\\:flex {
-      @media (width >= 50rem) {
+
+    @media (min-width: 50rem) {
+      .md\\:flex {
         display: flex;
       }
-    }
-    .min-md\\:max-lg\\:underline {
-      @media (width >= 50rem) {
-        @media (width < 64rem) {
+
+      @media not all and (min-width: 64rem) {
+        .min-md\\:max-lg\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .lg\\:flex {
-      @media (width >= 64rem) {
+
+    @media (min-width: 64rem) {
+      .lg\\:flex {
         display: flex;
       }
     }
-    .print\\:items-end {
-      @media print {
+
+    @media print {
+      .print\\:items-end {
         align-items: flex-end;
       }
     }
@@ -93,40 +92,20 @@ test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
 })
 
 test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-xs: 39rem;
-      --breakpoint-md: 49rem;
-    }
-    @theme {
-      --breakpoint-md: 50rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          extend: {
-            screens: {
-              xs: '30rem',
-              sm: '40rem',
-              md: '48rem',
-              lg: '60rem',
-            },
-          },
-        },
-      },
-      base: '/root',
-      path: '',
-    }),
-  })
-
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-xs: 39rem;
+          --breakpoint-md: 49rem;
+        }
+        @theme {
+          --breakpoint-md: 50rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      [
         // Order is messed up on purpose
         'md:flex',
         'sm:flex',
@@ -139,58 +118,72 @@ test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
 
         // Ensure other core variants appear at the end
         'print:items-end',
-      ]),
+      ],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                screens: {
+                  xs: '30rem',
+                  sm: '40rem',
+                  md: '48rem',
+                  lg: '60rem',
+                },
+              },
+            },
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
-    .min-xs\\:flex {
-      @media (width >= 30rem) {
+    @media (min-width: 30rem) {
+      .min-xs\\:flex, .xs\\:flex {
         display: flex;
       }
-    }
-    .xs\\:flex {
-      @media (width >= 30rem) {
-        display: flex;
-      }
-    }
-    .min-xs\\:max-md\\:underline {
-      @media (width >= 30rem) {
-        @media (width < 50rem) {
+
+      @media not all and (min-width: 50rem) {
+        .min-xs\\:max-md\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .sm\\:flex {
-      @media (width >= 40rem) {
+
+    @media (min-width: 40rem) {
+      .sm\\:flex {
         display: flex;
       }
-    }
-    .min-sm\\:max-md\\:underline {
-      @media (width >= 40rem) {
-        @media (width < 50rem) {
+
+      @media not all and (min-width: 50rem) {
+        .min-sm\\:max-md\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .md\\:flex {
-      @media (width >= 50rem) {
+
+    @media (min-width: 50rem) {
+      .md\\:flex {
         display: flex;
       }
-    }
-    .min-md\\:max-lg\\:underline {
-      @media (width >= 50rem) {
-        @media (width < 60rem) {
+
+      @media not all and (min-width: 60rem) {
+        .min-md\\:max-lg\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .lg\\:flex {
-      @media (width >= 60rem) {
+
+    @media (min-width: 60rem) {
+      .lg\\:flex {
         display: flex;
       }
     }
-    .print\\:items-end {
-      @media print {
+
+    @media print {
+      .print\\:items-end {
         align-items: flex-end;
       }
     }
@@ -199,30 +192,13 @@ test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
 })
 
 test('JS config `screens` only setup, even if those match the default-theme export', async () => {
-  let input = css`
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          screens: {
-            sm: '40rem',
-            md: '48rem',
-            lg: '64rem',
-          },
-        },
-      },
-      base: '/root',
-      path: '',
-    }),
-  })
-
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      [
         // Order is messed up on purpose
         'md:flex',
         'sm:flex',
@@ -232,41 +208,57 @@ test('JS config `screens` only setup, even if those match the default-theme expo
 
         // Ensure other core variants appear at the end
         'print:items-end',
-      ]),
+      ],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              screens: {
+                sm: '40rem',
+                md: '48rem',
+                lg: '64rem',
+              },
+            },
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
-    .sm\\:flex {
-      @media (width >= 40rem) {
+    @media (min-width: 40rem) {
+      .sm\\:flex {
         display: flex;
       }
-    }
-    .min-sm\\:max-md\\:underline {
-      @media (width >= 40rem) {
-        @media (width < 48rem) {
+
+      @media not all and (min-width: 48rem) {
+        .min-sm\\:max-md\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .md\\:flex {
-      @media (width >= 48rem) {
+
+    @media (min-width: 48rem) {
+      .md\\:flex {
         display: flex;
       }
-    }
-    .min-md\\:max-lg\\:underline {
-      @media (width >= 48rem) {
-        @media (width < 64rem) {
+
+      @media not all and (min-width: 64rem) {
+        .min-md\\:max-lg\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .lg\\:flex {
-      @media (width >= 64rem) {
+
+    @media (min-width: 64rem) {
+      .lg\\:flex {
         display: flex;
       }
     }
-    .print\\:items-end {
-      @media print {
+
+    @media print {
+      .print\\:items-end {
         align-items: flex-end;
       }
     }
@@ -275,39 +267,20 @@ test('JS config `screens` only setup, even if those match the default-theme expo
 })
 
 test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          extend: {
-            screens: {
-              mini: '40rem',
-              midi: '48rem',
-              maxi: '64rem',
-            },
-          },
-        },
-      },
-      base: '/root',
-      path: '',
-    }),
-  })
-
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      [
         'sm:flex',
         'md:flex',
         'mini:flex',
@@ -320,65 +293,59 @@ test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
 
         // Ensure other core variants appear at the end
         'print:items-end',
-      ]),
+      ],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                screens: {
+                  mini: '40rem',
+                  midi: '48rem',
+                  maxi: '64rem',
+                },
+              },
+            },
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
-    .mini\\:flex {
-      @media (width >= 40rem) {
+    @media (min-width: 40rem) {
+      .mini\\:flex, .sm\\:flex {
         display: flex;
       }
-    }
-    .sm\\:flex {
-      @media (width >= 40rem) {
-        display: flex;
-      }
-    }
-    .min-mini\\:max-midi\\:underline {
-      @media (width >= 40rem) {
-        @media (width < 48rem) {
+
+      @media not all and (min-width: 48rem) {
+        .min-mini\\:max-midi\\:underline, .min-sm\\:max-md\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .min-sm\\:max-md\\:underline {
-      @media (width >= 40rem) {
-        @media (width < 48rem) {
+
+    @media (min-width: 48rem) {
+      .md\\:flex, .midi\\:flex {
+        display: flex;
+      }
+
+      @media not all and (min-width: 64rem) {
+        .min-md\\:max-lg\\:underline, .min-midi\\:max-maxi\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .md\\:flex {
-      @media (width >= 48rem) {
+
+    @media (min-width: 64rem) {
+      .maxi\\:flex {
         display: flex;
       }
     }
-    .midi\\:flex {
-      @media (width >= 48rem) {
-        display: flex;
-      }
-    }
-    .min-md\\:max-lg\\:underline {
-      @media (width >= 48rem) {
-        @media (width < 64rem) {
-          text-decoration-line: underline;
-        }
-      }
-    }
-    .min-midi\\:max-maxi\\:underline {
-      @media (width >= 48rem) {
-        @media (width < 64rem) {
-          text-decoration-line: underline;
-        }
-      }
-    }
-    .maxi\\:flex {
-      @media (width >= 64rem) {
-        display: flex;
-      }
-    }
-    .print\\:items-end {
-      @media print {
+
+    @media print {
+      .print\\:items-end {
         align-items: flex-end;
       }
     }
@@ -387,36 +354,40 @@ test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
 })
 
 test('JS config with `theme: { extends }` should not include the `default-config` values', async () => {
-  let input = css`
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          extend: {
-            screens: {
-              mini: '40rem',
-              midi: '48rem',
-              maxi: '64rem',
+  expect(
+    await compileCss(
+      css`
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['sm:flex', 'md:flex', 'min-md:max-lg:underline', 'min-sm:max-md:underline'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                screens: {
+                  mini: '40rem',
+                  midi: '48rem',
+                  maxi: '64rem',
+                },
+              },
             },
           },
-        },
+          base: '/root',
+          path: '',
+        }),
       },
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(
-    compiler.build(['sm:flex', 'md:flex', 'min-md:max-lg:underline', 'min-sm:max-md:underline']),
+    ),
   ).toBe('')
 
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      [
         'mini:flex',
         'midi:flex',
         'maxi:flex',
@@ -425,41 +396,59 @@ test('JS config with `theme: { extends }` should not include the `default-config
 
         // Ensure other core variants appear at the end
         'print:items-end',
-      ]),
+      ],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              extend: {
+                screens: {
+                  mini: '40rem',
+                  midi: '48rem',
+                  maxi: '64rem',
+                },
+              },
+            },
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
-    .mini\\:flex {
-      @media (width >= 40rem) {
+    @media (min-width: 40rem) {
+      .mini\\:flex {
         display: flex;
       }
-    }
-    .min-mini\\:max-midi\\:underline {
-      @media (width >= 40rem) {
-        @media (width < 48rem) {
+
+      @media not all and (min-width: 48rem) {
+        .min-mini\\:max-midi\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .midi\\:flex {
-      @media (width >= 48rem) {
+
+    @media (min-width: 48rem) {
+      .midi\\:flex {
         display: flex;
       }
-    }
-    .min-midi\\:max-maxi\\:underline {
-      @media (width >= 48rem) {
-        @media (width < 64rem) {
+
+      @media not all and (min-width: 64rem) {
+        .min-midi\\:max-maxi\\:underline {
           text-decoration-line: underline;
         }
       }
     }
-    .maxi\\:flex {
-      @media (width >= 64rem) {
+
+    @media (min-width: 64rem) {
+      .maxi\\:flex {
         display: flex;
       }
     }
-    .print\\:items-end {
-      @media print {
+
+    @media print {
+      .print\\:items-end {
         align-items: flex-end;
       }
     }
@@ -469,40 +458,46 @@ test('JS config with `theme: { extends }` should not include the `default-config
 
 describe('complex screen configs', () => {
   test('generates utilities', async () => {
-    let input = css`
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            extend: {
-              screens: {
-                sm: { max: '639px' },
-                md: [
-                  //
-                  { min: '668px', max: '767px' },
-                  '868px',
-                ],
-                lg: { min: '868px' },
-                xl: { min: '1024px', max: '1279px' },
-                tall: { raw: '(min-height: 800px)' },
+    expect(
+      await compileCss(
+        css`
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        ['min-sm:flex', 'min-md:flex', 'min-xl:flex', 'min-tall:flex'],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                extend: {
+                  screens: {
+                    sm: { max: '639px' },
+                    md: [
+                      //
+                      { min: '668px', max: '767px' },
+                      '868px',
+                    ],
+                    lg: { min: '868px' },
+                    xl: { min: '1024px', max: '1279px' },
+                    tall: { raw: '(min-height: 800px)' },
+                  },
+                },
               },
             },
-          },
+            base: '/root',
+            path: '',
+          }),
         },
-        base: '/root',
-        path: '',
-      }),
-    })
-
-    expect(compiler.build(['min-sm:flex', 'min-md:flex', 'min-xl:flex', 'min-tall:flex'])).toBe('')
+      ),
+    ).toBe('')
 
     expect(
-      pretty(
-        compiler.build([
+      await compileCss(
+        css`
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        [
           'sm:flex',
           'md:flex',
           'lg:flex',
@@ -512,42 +507,65 @@ describe('complex screen configs', () => {
 
           // Ensure other core variants appear at the end
           'print:items-end',
-        ]),
+        ],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                extend: {
+                  screens: {
+                    sm: { max: '639px' },
+                    md: [
+                      //
+                      { min: '668px', max: '767px' },
+                      '868px',
+                    ],
+                    lg: { min: '868px' },
+                    xl: { min: '1024px', max: '1279px' },
+                    tall: { raw: '(min-height: 800px)' },
+                  },
+                },
+              },
+            },
+            base: '/root',
+            path: '',
+          }),
+        },
       ),
     ).toMatchInlineSnapshot(`
       "
-      .lg\\:flex {
-        @media (width >= 868px) {
+      @media (min-width: 868px) {
+        .lg\\:flex, .min-lg\\:flex {
           display: flex;
         }
       }
-      .min-lg\\:flex {
-        @media (width >= 868px) {
+
+      @media (max-width: 639px) {
+        .sm\\:flex {
           display: flex;
         }
       }
-      .sm\\:flex {
-        @media (639px >= width) {
+
+      @media (max-width: 767px) and (min-width: 668px), (min-width: 868px) {
+        .md\\:flex {
           display: flex;
         }
       }
-      .md\\:flex {
-        @media (767px >= width >= 668px), (width >= 868px) {
+
+      @media (max-width: 1279px) and (min-width: 1024px) {
+        .xl\\:flex {
           display: flex;
         }
       }
-      .xl\\:flex {
-        @media (1279px >= width >= 1024px) {
+
+      @media (min-height: 800px) {
+        .tall\\:flex {
           display: flex;
         }
       }
-      .tall\\:flex {
-        @media (min-height: 800px) {
-          display: flex;
-        }
-      }
-      .print\\:items-end {
-        @media print {
+
+      @media print {
+        .print\\:items-end {
           align-items: flex-end;
         }
       }
@@ -556,35 +574,17 @@ describe('complex screen configs', () => {
   })
 
   test("don't interfere with `min-*` and `max-*` variants of non-complex screen configs", async () => {
-    let input = css`
-      @theme default {
-        --breakpoint-sm: 39rem;
-        --breakpoint-md: 48rem;
-      }
-      @config "./config.js";
-      @tailwind utilities;
-    `
-
-    let compiler = await compile(input, {
-      loadModule: async () => ({
-        module: {
-          theme: {
-            extend: {
-              screens: {
-                sm: '40rem',
-                portrait: { raw: 'screen and (orientation: portrait)' },
-              },
-            },
-          },
-        },
-        base: '/root',
-        path: '',
-      }),
-    })
-
     expect(
-      pretty(
-        compiler.build([
+      await compileCss(
+        css`
+          @theme default {
+            --breakpoint-sm: 39rem;
+            --breakpoint-md: 48rem;
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
+        [
           'sm:flex',
           'md:flex',
           'portrait:flex',
@@ -593,37 +593,46 @@ describe('complex screen configs', () => {
           'min-portrait:flex',
           // Ensure other core variants appear at the end
           'print:items-end',
-        ]),
+        ],
+        {
+          loadModule: async () => ({
+            module: {
+              theme: {
+                extend: {
+                  screens: {
+                    sm: '40rem',
+                    portrait: { raw: 'screen and (orientation: portrait)' },
+                  },
+                },
+              },
+            },
+            base: '/root',
+            path: '',
+          }),
+        },
       ),
     ).toMatchInlineSnapshot(`
       "
-      .min-sm\\:flex {
-        @media (width >= 40rem) {
+      @media (min-width: 40rem) {
+        .min-sm\\:flex, .sm\\:flex {
           display: flex;
         }
       }
-      .sm\\:flex {
-        @media (width >= 40rem) {
+
+      @media (min-width: 48rem) {
+        .md\\:flex, .min-md\\:flex {
           display: flex;
         }
       }
-      .md\\:flex {
-        @media (width >= 48rem) {
+
+      @media screen and (orientation: portrait) {
+        .portrait\\:flex {
           display: flex;
         }
       }
-      .min-md\\:flex {
-        @media (width >= 48rem) {
-          display: flex;
-        }
-      }
-      .portrait\\:flex {
-        @media screen and (orientation: portrait) {
-          display: flex;
-        }
-      }
-      .print\\:items-end {
-        @media print {
+
+      @media print {
+        .print\\:items-end {
           align-items: flex-end;
         }
       }
@@ -633,38 +642,38 @@ describe('complex screen configs', () => {
 })
 
 test('JS config `screens` can overwrite default CSS `--breakpoint-*`', async () => {
-  let input = css`
-    @theme default {
-      --breakpoint-sm: 40rem;
-      --breakpoint-md: 48rem;
-      --breakpoint-lg: 64rem;
-      --breakpoint-xl: 80rem;
-      --breakpoint-2xl: 96rem;
-    }
-    @config "./config.js";
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: {
-        theme: {
-          screens: {
-            mini: '40rem',
-            midi: '48rem',
-            maxi: '64rem',
-          },
-        },
-      },
-      base: '/root',
-      path: '',
-    }),
-  })
-
   // Note: The `sm`, `md`, and other variants are still there because they are
   // created before the compat layer can intercept. We do not remove them
   // currently.
   expect(
-    compiler.build(['min-sm:flex', 'min-md:flex', 'min-lg:flex', 'min-xl:flex', 'min-2xl:flex']),
+    await compileCss(
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
+      ['min-sm:flex', 'min-md:flex', 'min-lg:flex', 'min-xl:flex', 'min-2xl:flex'],
+      {
+        loadModule: async () => ({
+          module: {
+            theme: {
+              screens: {
+                mini: '40rem',
+                midi: '48rem',
+                maxi: '64rem',
+              },
+            },
+          },
+          base: '/root',
+          path: '',
+        }),
+      },
+    ),
   ).toEqual('')
 })

--- a/packages/tailwindcss/src/compat/screens-config.test.ts
+++ b/packages/tailwindcss/src/compat/screens-config.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, test } from 'vitest'
-import { compileCss } from '../test-utils/run'
+import { run } from '../test-utils/run'
 
 const css = String.raw
 
 test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
   expect(
-    await compileCss(
+    await run(
+      [
+        'sm:flex',
+        'md:flex',
+        'lg:flex',
+        'min-sm:max-md:underline',
+        'min-md:max-lg:underline',
+        'max-w-screen-sm',
+        // Ensure other core variants appear at the end
+        'print:items-end',
+      ],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -20,16 +30,6 @@ test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
         @config "./config.js";
         @tailwind utilities;
       `,
-      [
-        'sm:flex',
-        'md:flex',
-        'lg:flex',
-        'min-sm:max-md:underline',
-        'min-md:max-lg:underline',
-        'max-w-screen-sm',
-        // Ensure other core variants appear at the end
-        'print:items-end',
-      ],
       {
         loadModule: async () => ({
           module: {
@@ -93,18 +93,7 @@ test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
 
 test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme default {
-          --breakpoint-xs: 39rem;
-          --breakpoint-md: 49rem;
-        }
-        @theme {
-          --breakpoint-md: 50rem;
-        }
-        @config "./config.js";
-        @tailwind utilities;
-      `,
+    await run(
       [
         // Order is messed up on purpose
         'md:flex',
@@ -119,6 +108,17 @@ test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
         // Ensure other core variants appear at the end
         'print:items-end',
       ],
+      css`
+        @theme default {
+          --breakpoint-xs: 39rem;
+          --breakpoint-md: 49rem;
+        }
+        @theme {
+          --breakpoint-md: 50rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
       {
         loadModule: async () => ({
           module: {
@@ -193,11 +193,7 @@ test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
 
 test('JS config `screens` only setup, even if those match the default-theme export', async () => {
   expect(
-    await compileCss(
-      css`
-        @config "./config.js";
-        @tailwind utilities;
-      `,
+    await run(
       [
         // Order is messed up on purpose
         'md:flex',
@@ -209,6 +205,10 @@ test('JS config `screens` only setup, even if those match the default-theme expo
         // Ensure other core variants appear at the end
         'print:items-end',
       ],
+      css`
+        @config "./config.js";
+        @tailwind utilities;
+      `,
       {
         loadModule: async () => ({
           module: {
@@ -268,18 +268,7 @@ test('JS config `screens` only setup, even if those match the default-theme expo
 
 test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme default {
-          --breakpoint-sm: 40rem;
-          --breakpoint-md: 48rem;
-          --breakpoint-lg: 64rem;
-          --breakpoint-xl: 80rem;
-          --breakpoint-2xl: 96rem;
-        }
-        @config "./config.js";
-        @tailwind utilities;
-      `,
+    await run(
       [
         'sm:flex',
         'md:flex',
@@ -294,6 +283,17 @@ test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
         // Ensure other core variants appear at the end
         'print:items-end',
       ],
+      css`
+        @theme default {
+          --breakpoint-sm: 40rem;
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+          --breakpoint-xl: 80rem;
+          --breakpoint-2xl: 96rem;
+        }
+        @config "./config.js";
+        @tailwind utilities;
+      `,
       {
         loadModule: async () => ({
           module: {
@@ -355,12 +355,12 @@ test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
 
 test('JS config with `theme: { extends }` should not include the `default-config` values', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['sm:flex', 'md:flex', 'min-md:max-lg:underline', 'min-sm:max-md:underline'],
       css`
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['sm:flex', 'md:flex', 'min-md:max-lg:underline', 'min-sm:max-md:underline'],
       {
         loadModule: async () => ({
           module: {
@@ -382,11 +382,7 @@ test('JS config with `theme: { extends }` should not include the `default-config
   ).toBe('')
 
   expect(
-    await compileCss(
-      css`
-        @config "./config.js";
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mini:flex',
         'midi:flex',
@@ -397,6 +393,10 @@ test('JS config with `theme: { extends }` should not include the `default-config
         // Ensure other core variants appear at the end
         'print:items-end',
       ],
+      css`
+        @config "./config.js";
+        @tailwind utilities;
+      `,
       {
         loadModule: async () => ({
           module: {
@@ -459,12 +459,12 @@ test('JS config with `theme: { extends }` should not include the `default-config
 describe('complex screen configs', () => {
   test('generates utilities', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['min-sm:flex', 'min-md:flex', 'min-xl:flex', 'min-tall:flex'],
         css`
           @config "./config.js";
           @tailwind utilities;
         `,
-        ['min-sm:flex', 'min-md:flex', 'min-xl:flex', 'min-tall:flex'],
         {
           loadModule: async () => ({
             module: {
@@ -492,11 +492,7 @@ describe('complex screen configs', () => {
     ).toBe('')
 
     expect(
-      await compileCss(
-        css`
-          @config "./config.js";
-          @tailwind utilities;
-        `,
+      await run(
         [
           'sm:flex',
           'md:flex',
@@ -508,6 +504,10 @@ describe('complex screen configs', () => {
           // Ensure other core variants appear at the end
           'print:items-end',
         ],
+        css`
+          @config "./config.js";
+          @tailwind utilities;
+        `,
         {
           loadModule: async () => ({
             module: {
@@ -575,15 +575,7 @@ describe('complex screen configs', () => {
 
   test("don't interfere with `min-*` and `max-*` variants of non-complex screen configs", async () => {
     expect(
-      await compileCss(
-        css`
-          @theme default {
-            --breakpoint-sm: 39rem;
-            --breakpoint-md: 48rem;
-          }
-          @config "./config.js";
-          @tailwind utilities;
-        `,
+      await run(
         [
           'sm:flex',
           'md:flex',
@@ -594,6 +586,14 @@ describe('complex screen configs', () => {
           // Ensure other core variants appear at the end
           'print:items-end',
         ],
+        css`
+          @theme default {
+            --breakpoint-sm: 39rem;
+            --breakpoint-md: 48rem;
+          }
+          @config "./config.js";
+          @tailwind utilities;
+        `,
         {
           loadModule: async () => ({
             module: {
@@ -646,7 +646,8 @@ test('JS config `screens` can overwrite default CSS `--breakpoint-*`', async () 
   // created before the compat layer can intercept. We do not remove them
   // currently.
   expect(
-    await compileCss(
+    await run(
+      ['min-sm:flex', 'min-md:flex', 'min-lg:flex', 'min-xl:flex', 'min-2xl:flex'],
       css`
         @theme default {
           --breakpoint-sm: 40rem;
@@ -658,7 +659,6 @@ test('JS config `screens` can overwrite default CSS `--breakpoint-*`', async () 
         @config "./config.js";
         @tailwind utilities;
       `,
-      ['min-sm:flex', 'min-md:flex', 'min-lg:flex', 'min-xl:flex', 'min-2xl:flex'],
       {
         loadModule: async () => ({
           module: {

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import plugin from './plugin'
-import { compileCss } from './test-utils/run'
+import { compileCss, run } from './test-utils/run'
 
 const css = String.raw
 
@@ -315,7 +315,8 @@ describe('--theme(…)', () => {
 
   test('--theme(…) does not inject the fallback if the fallback is `initial`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['tw:font-sans'],
         css`
           @theme prefix(tw) {
             --font-sans:
@@ -330,7 +331,6 @@ describe('--theme(…)', () => {
           }
           @tailwind utilities;
         `,
-        ['tw:font-sans'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -419,7 +419,8 @@ describe('--theme(…)', () => {
 
   test('--theme(…) function still works as expected, even when a plugin is imported', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @layer base {
             html,
@@ -435,7 +436,6 @@ describe('--theme(…)', () => {
           }
           @plugin "my-plugin.js";
         `,
-        [],
         {
           loadModule: async () => ({
             path: '',
@@ -829,14 +829,14 @@ describe('theme(…)', () => {
 
         test('theme(fontFamily.sans) (config)', async () => {
           expect(
-            await compileCss(
+            await run(
+              [],
               css`
                 @config "./my-config.js";
                 .fam {
                   font-family: theme(fontFamily.sans);
                 }
               `,
-              [],
               { loadModule: async () => ({ path: '', base: '/root', module: {} }) },
             ),
           ).toMatchInlineSnapshot(`
@@ -1095,7 +1095,8 @@ describe('theme(…)', () => {
   describe('in candidates', () => {
     test('sm:[--color:theme(colors.red[500])]', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['sm:[--color:theme(colors.red[500])]'],
           css`
             @tailwind utilities;
             @theme {
@@ -1103,7 +1104,6 @@ describe('theme(…)', () => {
               --color-red-500: #f00;
             }
           `,
-          ['sm:[--color:theme(colors.red[500])]'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -1119,18 +1119,18 @@ describe('theme(…)', () => {
     test("values that don't exist don't produce candidates", async () => {
       // This guarantees that valid candidates still make it through when some are invalid
       expect(
-        await compileCss(
+        await run(
+          [
+            'rounded-[theme(--radius-sm)]',
+            'rounded-[theme(i.do.not.exist)]',
+            'rounded-[theme(--i-do-not-exist)]',
+          ],
           css`
             @tailwind utilities;
             @theme reference {
               --radius-sm: 2rem;
             }
           `,
-          [
-            'rounded-[theme(--radius-sm)]',
-            'rounded-[theme(i.do.not.exist)]',
-            'rounded-[theme(--i-do-not-exist)]',
-          ],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -1142,14 +1142,14 @@ describe('theme(…)', () => {
 
       // This guarantees no output for the following candidates
       expect(
-        await compileCss(
+        await run(
+          ['rounded-[theme(i.do.not.exist)]', 'rounded-[theme(--i-do-not-exist)]'],
           css`
             @tailwind utilities;
             @theme reference {
               --radius-sm: 2rem;
             }
           `,
-          ['rounded-[theme(i.do.not.exist)]', 'rounded-[theme(--i-do-not-exist)]'],
         ),
       ).toEqual('')
     })
@@ -1280,7 +1280,8 @@ describe('theme(…)', () => {
 describe('in plugins', () => {
   test('CSS theme functions in plugins are properly evaluated', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['my-utility'],
         css`
           @layer base, utilities;
           @plugin "my-plugin";
@@ -1294,7 +1295,6 @@ describe('in plugins', () => {
             @tailwind utilities;
           }
         `,
-        ['my-utility'],
         {
           async loadModule() {
             return {
@@ -1344,7 +1344,8 @@ describe('in plugins', () => {
 describe('in JS config files', () => {
   test('CSS theme functions in config files are properly evaluated', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['my-utility'],
         css`
           @layer base, utilities;
           @config "./my-config.js";
@@ -1356,7 +1357,6 @@ describe('in JS config files', () => {
             @tailwind utilities;
           }
         `,
-        ['my-utility'],
         {
           loadModule: async () => ({
             path: '',
@@ -1411,14 +1411,14 @@ describe('in JS config files', () => {
 
 test('replaces CSS theme() function with values inside imported stylesheets', async () => {
   expect(
-    await compileCss(
+    await run(
+      [],
       css`
         @theme {
           --color-red-500: #f00;
         }
         @import './bar.css';
       `,
-      [],
       {
         async loadStylesheet() {
           return {
@@ -1444,7 +1444,8 @@ test('replaces CSS theme() function with values inside imported stylesheets', as
 
 test('resolves paths ending with a 1', async () => {
   expect(
-    await compileCss(
+    await run(
+      [],
       css`
         @theme {
           --spacing-1: 0.25rem;
@@ -1454,7 +1455,6 @@ test('resolves paths ending with a 1', async () => {
           margin: theme(spacing.1);
         }
       `,
-      [],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1467,13 +1467,13 @@ test('resolves paths ending with a 1', async () => {
 
 test('upgrades to a full JS compat theme lookup if a value cannot be mapped to a CSS variable', async () => {
   expect(
-    await compileCss(
+    await run(
+      [],
       css`
         .semi {
           font-weight: theme(fontWeight.semibold);
         }
       `,
-      [],
     ),
   ).toMatchInlineSnapshot(`
     "

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -1115,6 +1115,13 @@ describe('theme(…)', () => {
     })
 
     test("values that don't exist don't produce candidates", async () => {
+      let input = css`
+        @tailwind utilities;
+        @theme reference {
+          --radius-sm: 2rem;
+        }
+      `
+
       // This guarantees that valid candidates still make it through when some are invalid
       expect(
         await run(
@@ -1123,12 +1130,7 @@ describe('theme(…)', () => {
             'rounded-[theme(i.do.not.exist)]',
             'rounded-[theme(--i-do-not-exist)]',
           ],
-          css`
-            @tailwind utilities;
-            @theme reference {
-              --radius-sm: 2rem;
-            }
-          `,
+          input,
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -1140,15 +1142,7 @@ describe('theme(…)', () => {
 
       // This guarantees no output for the following candidates
       expect(
-        await run(
-          ['rounded-[theme(i.do.not.exist)]', 'rounded-[theme(--i-do-not-exist)]'],
-          css`
-            @tailwind utilities;
-            @theme reference {
-              --radius-sm: 2rem;
-            }
-          `,
-        ),
+        await run(['rounded-[theme(i.do.not.exist)]', 'rounded-[theme(--i-do-not-exist)]'], input),
       ).toEqual('')
     })
   })

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { compile } from '.'
 import plugin from './plugin'
-import { compileCss, optimizeCss } from './test-utils/run'
+import { compileCss } from './test-utils/run'
 
 const css = String.raw
 
@@ -829,23 +828,18 @@ describe('theme(…)', () => {
         })
 
         test('theme(fontFamily.sans) (config)', async () => {
-          let compiled = await compile(
-            css`
-              @config "./my-config.js";
-              .fam {
-                font-family: theme(fontFamily.sans);
-              }
-            `,
-            {
-              loadModule: async () => ({
-                path: '',
-                base: '/root',
-                module: {},
-              }),
-            },
-          )
-
-          expect(optimizeCss(compiled.build([]))).toMatchInlineSnapshot(`
+          expect(
+            await compileCss(
+              css`
+                @config "./my-config.js";
+                .fam {
+                  font-family: theme(fontFamily.sans);
+                }
+              `,
+              [],
+              { loadModule: async () => ({ path: '', base: '/root', module: {} }) },
+            ),
+          ).toMatchInlineSnapshot(`
             "
             .fam {
               font-family: ui-sans-serif, system-ui, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
@@ -1285,47 +1279,48 @@ describe('theme(…)', () => {
 
 describe('in plugins', () => {
   test('CSS theme functions in plugins are properly evaluated', async () => {
-    let compiled = await compile(
-      css`
-        @layer base, utilities;
-        @plugin "my-plugin";
-        @theme reference {
-          --color-red: oklch(62% 0.25 30);
-          --color-orange: oklch(79% 0.17 70);
-          --color-blue: oklch(45% 0.31 264);
-          --color-pink: oklch(87% 0.07 7);
-        }
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        async loadModule() {
-          return {
-            path: '',
-            base: '/root',
-            module: plugin(({ addBase, addUtilities }) => {
-              addBase({
-                '.my-base-rule': {
-                  color: 'theme(colors.red)',
-                  'outline-color': 'theme(colors.orange / 15%)',
-                  'background-color': 'theme(--color-blue)',
-                  'border-color': 'theme(--color-pink / 10%)',
-                },
-              })
-
-              addUtilities({
-                '.my-utility': {
-                  color: 'theme(colors.red)',
-                },
-              })
-            }),
+    expect(
+      await compileCss(
+        css`
+          @layer base, utilities;
+          @plugin "my-plugin";
+          @theme reference {
+            --color-red: oklch(62% 0.25 30);
+            --color-orange: oklch(79% 0.17 70);
+            --color-blue: oklch(45% 0.31 264);
+            --color-pink: oklch(87% 0.07 7);
           }
-        },
-      },
-    )
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['my-utility'],
+        {
+          async loadModule() {
+            return {
+              path: '',
+              base: '/root',
+              module: plugin(({ addBase, addUtilities }) => {
+                addBase({
+                  '.my-base-rule': {
+                    color: 'theme(colors.red)',
+                    'outline-color': 'theme(colors.orange / 15%)',
+                    'background-color': 'theme(--color-blue)',
+                    'border-color': 'theme(--color-pink / 10%)',
+                  },
+                })
 
-    expect(optimizeCss(compiled.build(['my-utility']))).toMatchInlineSnapshot(`
+                addUtilities({
+                  '.my-utility': {
+                    color: 'theme(colors.red)',
+                  },
+                })
+              }),
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer base {
         .my-base-rule {
@@ -1348,53 +1343,54 @@ describe('in plugins', () => {
 
 describe('in JS config files', () => {
   test('CSS theme functions in config files are properly evaluated', async () => {
-    let compiled = await compile(
-      css`
-        @layer base, utilities;
-        @config "./my-config.js";
-        @theme reference {
-          --color-red: red;
-          --color-orange: orange;
-        }
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: {
-            theme: {
-              extend: {
-                colors: {
-                  primary: 'theme(colors.red)',
-                  secondary: 'theme(--color-orange)',
+    expect(
+      await compileCss(
+        css`
+          @layer base, utilities;
+          @config "./my-config.js";
+          @theme reference {
+            --color-red: red;
+            --color-orange: orange;
+          }
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['my-utility'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: {
+              theme: {
+                extend: {
+                  colors: {
+                    primary: 'theme(colors.red)',
+                    secondary: 'theme(--color-orange)',
+                  },
                 },
               },
+              plugins: [
+                plugin(({ addBase, addUtilities }) => {
+                  addBase({
+                    '.my-base-rule': {
+                      background: 'theme(colors.primary)',
+                      color: 'theme(colors.secondary)',
+                    },
+                  })
+
+                  addUtilities({
+                    '.my-utility': {
+                      color: 'theme(colors.red)',
+                    },
+                  })
+                }),
+              ],
             },
-            plugins: [
-              plugin(({ addBase, addUtilities }) => {
-                addBase({
-                  '.my-base-rule': {
-                    background: 'theme(colors.primary)',
-                    color: 'theme(colors.secondary)',
-                  },
-                })
-
-                addUtilities({
-                  '.my-utility': {
-                    color: 'theme(colors.red)',
-                  },
-                })
-              }),
-            ],
-          },
-        }),
-      },
-    )
-
-    expect(optimizeCss(compiled.build(['my-utility']))).toMatchInlineSnapshot(`
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer base {
         .my-base-rule {

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -419,8 +419,7 @@ describe('--theme(…)', () => {
 
   test('--theme(…) function still works as expected, even when a plugin is imported', async () => {
     expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @layer base {
             html,
@@ -829,8 +828,7 @@ describe('theme(…)', () => {
 
         test('theme(fontFamily.sans) (config)', async () => {
           expect(
-            await run(
-              [],
+            await compileCss(
               css`
                 @config "./my-config.js";
                 .fam {
@@ -1411,8 +1409,7 @@ describe('in JS config files', () => {
 
 test('replaces CSS theme() function with values inside imported stylesheets', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @theme {
           --color-red-500: #f00;
@@ -1444,18 +1441,15 @@ test('replaces CSS theme() function with values inside imported stylesheets', as
 
 test('resolves paths ending with a 1', async () => {
   expect(
-    await run(
-      [],
-      css`
-        @theme {
-          --spacing-1: 0.25rem;
-        }
+    await compileCss(css`
+      @theme {
+        --spacing-1: 0.25rem;
+      }
 
-        .foo {
-          margin: theme(spacing.1);
-        }
-      `,
-    ),
+      .foo {
+        margin: theme(spacing.1);
+      }
+    `),
   ).toMatchInlineSnapshot(`
     "
     .foo {
@@ -1467,14 +1461,11 @@ test('resolves paths ending with a 1', async () => {
 
 test('upgrades to a full JS compat theme lookup if a value cannot be mapped to a CSS variable', async () => {
   expect(
-    await run(
-      [],
-      css`
-        .semi {
-          font-weight: theme(fontWeight.semibold);
-        }
-      `,
-    ),
+    await compileCss(css`
+      .semi {
+        font-weight: theme(fontWeight.semibold);
+      }
+    `),
   ).toMatchInlineSnapshot(`
     "
     .semi {

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1199,37 +1199,37 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 
     it('should error when an unterminated string is used', () => {
       let input = css`
-          .foo {
-            content: "Hello world!
-            /*                    ^ missing " */
-            font-weight: bold;
-          }
-        `
+        .foo {
+          content: "Hello world!
+          /*                    ^ missing " */
+          font-weight: bold;
+        }
+      `
 
       expect(() => parse(input)).toThrowErrorMatchingInlineSnapshot(
         `[CssSyntaxError: Unterminated string: "Hello world!"]`,
       )
 
       expect(() => parseWithLoc(input)).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css:3:22: Unterminated string: "Hello world!"]`,
+        `[CssSyntaxError: input.css:3:20: Unterminated string: "Hello world!"]`,
       )
     })
 
     it('should error when an unterminated string is used with a `;`', () => {
       let input = css`
-          .foo {
-            content: "Hello world!;
-            /*                    ^ missing " */
-            font-weight: bold;
-          }
-        `
+        .foo {
+          content: "Hello world!;
+          /*                    ^ missing " */
+          font-weight: bold;
+        }
+      `
 
       expect(() => parse(input)).toThrowErrorMatchingInlineSnapshot(
         `[CssSyntaxError: Unterminated string: "Hello world!;"]`,
       )
 
       expect(() => parseWithLoc(input)).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css:3:22: Unterminated string: "Hello world!;"]`,
+        `[CssSyntaxError: input.css:3:20: Unterminated string: "Hello world!;"]`,
       )
     })
 
@@ -1256,18 +1256,18 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     it('should error when an unterminated string is used in a custom property', () => {
       // prettier-ignore
       let input = css`
-          .foo {
-            --bar: 'Hello world!
-            /*                  ^ missing ' * /;
-          }
-        `
+        .foo {
+          --bar: 'Hello world!
+          /*                  ^ missing ' * /;
+        }
+      `
 
       expect(() => parse(input)).toThrowErrorMatchingInlineSnapshot(
         `[CssSyntaxError: Unterminated string: 'Hello world!']`,
       )
 
       expect(() => parseWithLoc(input)).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css:3:20: Unterminated string: 'Hello world!']`,
+        `[CssSyntaxError: input.css:3:18: Unterminated string: 'Hello world!']`,
       )
     })
 

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1198,49 +1198,37 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     })
 
     it('should error when an unterminated string is used', () => {
-      expect(() =>
-        parse(css`
+      let input = css`
           .foo {
             content: "Hello world!
             /*                    ^ missing " */
             font-weight: bold;
           }
-        `),
-      ).toThrowErrorMatchingInlineSnapshot(`[CssSyntaxError: Unterminated string: "Hello world!"]`)
+        `
 
-      expect(() =>
-        parseWithLoc(css`
-          .foo {
-            content: "Hello world!
-            /*                    ^ missing " */
-            font-weight: bold;
-          }
-        `),
-      ).toThrowErrorMatchingInlineSnapshot(
+      expect(() => parse(input)).toThrowErrorMatchingInlineSnapshot(
+        `[CssSyntaxError: Unterminated string: "Hello world!"]`,
+      )
+
+      expect(() => parseWithLoc(input)).toThrowErrorMatchingInlineSnapshot(
         `[CssSyntaxError: input.css:3:22: Unterminated string: "Hello world!"]`,
       )
     })
 
     it('should error when an unterminated string is used with a `;`', () => {
-      expect(() =>
-        parse(css`
+      let input = css`
           .foo {
             content: "Hello world!;
             /*                    ^ missing " */
             font-weight: bold;
           }
-        `),
-      ).toThrowErrorMatchingInlineSnapshot(`[CssSyntaxError: Unterminated string: "Hello world!;"]`)
+        `
 
-      expect(() =>
-        parseWithLoc(css`
-          .foo {
-            content: "Hello world!;
-            /*                    ^ missing " */
-            font-weight: bold;
-          }
-        `),
-      ).toThrowErrorMatchingInlineSnapshot(
+      expect(() => parse(input)).toThrowErrorMatchingInlineSnapshot(
+        `[CssSyntaxError: Unterminated string: "Hello world!;"]`,
+      )
+
+      expect(() => parseWithLoc(input)).toThrowErrorMatchingInlineSnapshot(
         `[CssSyntaxError: input.css:3:22: Unterminated string: "Hello world!;"]`,
       )
     })
@@ -1266,23 +1254,19 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     })
 
     it('should error when an unterminated string is used in a custom property', () => {
-      expect(() =>
-        parse(css`
+      // prettier-ignore
+      let input = css`
           .foo {
             --bar: 'Hello world!
             /*                  ^ missing ' * /;
           }
-        `),
-      ).toThrowErrorMatchingInlineSnapshot(`[CssSyntaxError: Unterminated string: 'Hello world!']`)
+        `
 
-      expect(() =>
-        parseWithLoc(css`
-          .foo {
-            --bar: 'Hello world!
-            /*                  ^ missing ' * /;
-          }
-        `),
-      ).toThrowErrorMatchingInlineSnapshot(
+      expect(() => parse(input)).toThrowErrorMatchingInlineSnapshot(
+        `[CssSyntaxError: Unterminated string: 'Hello world!']`,
+      )
+
+      expect(() => parseWithLoc(input)).toThrowErrorMatchingInlineSnapshot(
         `[CssSyntaxError: input.css:3:20: Unterminated string: 'Hello world!']`,
       )
     })

--- a/packages/tailwindcss/src/important.test.ts
+++ b/packages/tailwindcss/src/important.test.ts
@@ -1,18 +1,18 @@
 import { expect, test } from 'vitest'
-import { compileCss } from './test-utils/run'
+import { run } from './test-utils/run'
 
 const css = String.raw
 
 test('Utilities can be wrapped in a selector', async () => {
   // This is the v4 equivalent of `important: "#app"` from v3
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'hover:line-through'],
       css`
         #app {
           @tailwind utilities;
         }
       `,
-      ['underline', 'hover:line-through'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -32,13 +32,13 @@ test('Utilities can be wrapped in a selector', async () => {
 test('Utilities can be marked with important', async () => {
   // This is the v4 equivalent of `important: true` from v3
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'hover:line-through'],
       css`
         @import 'tailwindcss/utilities' important;
       `,
-      ['underline', 'hover:line-through'],
       {
-        loadStylesheet: async (id: string, base: string) => ({
+        loadStylesheet: async (_id: string, base: string) => ({
           base,
           content: '@tailwind utilities;',
           path: '',
@@ -64,7 +64,8 @@ test('Utilities can be wrapped with a selector and marked as important', async (
   // This does not have a direct equivalent in v3 but works as a consequence of
   // the new APIs
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'hover:line-through'],
       css`
         @media important {
           #app {
@@ -72,7 +73,6 @@ test('Utilities can be wrapped with a selector and marked as important', async (
           }
         }
       `,
-      ['underline', 'hover:line-through'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -91,14 +91,14 @@ test('Utilities can be wrapped with a selector and marked as important', async (
 
 test('variables in utilities should not be marked as important', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['ease-out!', 'z-10!'],
       css`
         @theme {
           --ease-out: cubic-bezier(0, 0, 0.2, 1);
         }
         @tailwind utilities;
       `,
-      ['ease-out!', 'z-10!'],
     ),
   ).toMatchInlineSnapshot(`
     "

--- a/packages/tailwindcss/src/important.test.ts
+++ b/packages/tailwindcss/src/important.test.ts
@@ -1,31 +1,28 @@
 import { expect, test } from 'vitest'
-import { compile } from '.'
-import { compileCss, pretty } from './test-utils/run'
+import { compileCss } from './test-utils/run'
 
 const css = String.raw
 
 test('Utilities can be wrapped in a selector', async () => {
   // This is the v4 equivalent of `important: "#app"` from v3
-  let input = css`
-    #app {
-      @tailwind utilities;
-    }
-  `
-
-  let compiler = await compile(input)
-
-  expect(pretty(compiler.build(['underline', 'hover:line-through']))).toMatchInlineSnapshot(`
-    "
-    #app {
-      .underline {
-        text-decoration-line: underline;
-      }
-      .hover\\:line-through {
-        &:hover {
-          @media (hover: hover) {
-            text-decoration-line: line-through;
-          }
+  expect(
+    await compileCss(
+      css`
+        #app {
+          @tailwind utilities;
         }
+      `,
+      ['underline', 'hover:line-through'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    #app .underline {
+      text-decoration-line: underline;
+    }
+
+    @media (hover: hover) {
+      #app .hover\\:line-through:hover {
+        text-decoration-line: line-through;
       }
     }
     "
@@ -34,28 +31,29 @@ test('Utilities can be wrapped in a selector', async () => {
 
 test('Utilities can be marked with important', async () => {
   // This is the v4 equivalent of `important: true` from v3
-  let input = css`
-    @import 'tailwindcss/utilities' important;
-  `
-
-  let compiler = await compile(input, {
-    loadStylesheet: async (id: string, base: string) => ({
-      base,
-      content: '@tailwind utilities;',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build(['underline', 'hover:line-through']))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @import 'tailwindcss/utilities' important;
+      `,
+      ['underline', 'hover:line-through'],
+      {
+        loadStylesheet: async (id: string, base: string) => ({
+          base,
+          content: '@tailwind utilities;',
+          path: '',
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .underline {
       text-decoration-line: underline !important;
     }
-    .hover\\:line-through {
-      &:hover {
-        @media (hover: hover) {
-          text-decoration-line: line-through !important;
-        }
+
+    @media (hover: hover) {
+      .hover\\:line-through:hover {
+        text-decoration-line: line-through !important;
       }
     }
     "
@@ -65,28 +63,26 @@ test('Utilities can be marked with important', async () => {
 test('Utilities can be wrapped with a selector and marked as important', async () => {
   // This does not have a direct equivalent in v3 but works as a consequence of
   // the new APIs
-  let input = css`
-    @media important {
-      #app {
-        @tailwind utilities;
-      }
-    }
-  `
-
-  let compiler = await compile(input)
-
-  expect(pretty(compiler.build(['underline', 'hover:line-through']))).toMatchInlineSnapshot(`
-    "
-    #app {
-      .underline {
-        text-decoration-line: underline !important;
-      }
-      .hover\\:line-through {
-        &:hover {
-          @media (hover: hover) {
-            text-decoration-line: line-through !important;
+  expect(
+    await compileCss(
+      css`
+        @media important {
+          #app {
+            @tailwind utilities;
           }
         }
+      `,
+      ['underline', 'hover:line-through'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    #app .underline {
+      text-decoration-line: underline !important;
+    }
+
+    @media (hover: hover) {
+      #app .hover\\:line-through:hover {
+        text-decoration-line: line-through !important;
       }
     }
     "

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -12,7 +12,8 @@ const css = String.raw
 describe('compiling CSS', () => {
   test('`@tailwind utilities` is replaced with the generated utility classes', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['flex', 'md:grid', 'hover:underline', 'dark:bg-black'],
         css`
           @theme {
             --color-black: #000;
@@ -23,7 +24,6 @@ describe('compiling CSS', () => {
             @tailwind utilities;
           }
         `,
-        ['flex', 'md:grid', 'hover:underline', 'dark:bg-black'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -60,7 +60,8 @@ describe('compiling CSS', () => {
 
   test('that only CSS variables are allowed', () => {
     return expect(
-      compileCss(
+      run(
+        ['bg-primary'],
         css`
           @theme {
             --color-primary: red;
@@ -70,7 +71,6 @@ describe('compiling CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['bg-primary'],
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [Error: \`@theme\` blocks must only contain custom properties or \`@keyframes\`.
@@ -86,12 +86,12 @@ describe('compiling CSS', () => {
 
   test('`@tailwind utilities` is only processed once', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['flex', 'grid'],
         css`
           @tailwind utilities;
           @tailwind utilities;
         `,
-        ['flex', 'grid'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -110,24 +110,24 @@ describe('compiling CSS', () => {
     let defaultTheme = fs.readFileSync(path.resolve(__dirname, '..', 'theme.css'), 'utf-8')
 
     expect(
-      await compileCss(
+      await run(
+        ['bg-red-500', 'w-4', 'sm:flex', 'shadow-sm'],
         css`
           ${defaultTheme}
           @tailwind utilities;
         `,
-        ['bg-red-500', 'w-4', 'sm:flex', 'shadow-sm'],
       ),
     ).toMatchSnapshot()
   })
 
   test('prefix all CSS variables inside preflight', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['font-mono'],
         css`
           @import 'tailwindcss' prefix(tw);
           @tailwind utilities;
         `,
-        ['font-mono'],
         {
           async loadStylesheet(id) {
             return {
@@ -146,7 +146,12 @@ describe('compiling CSS', () => {
 
   test('unescapes underscores to spaces inside arbitrary values except for `url()` and first argument of `var()` and `theme()`', async () => {
     expect(
-      await compileCss(
+      await run(
+        [
+          'bg-[no-repeat_url(./my_file.jpg)]',
+          'ml-[var(--spacing-1_5,_var(--spacing-2_5,_1rem))]',
+          'ml-[theme(--spacing-1_5,theme(--spacing-2_5,_1rem)))]',
+        ],
         css`
           @theme {
             --spacing-1_5: 1.5rem;
@@ -154,11 +159,6 @@ describe('compiling CSS', () => {
           }
           @tailwind utilities;
         `,
-        [
-          'bg-[no-repeat_url(./my_file.jpg)]',
-          'ml-[var(--spacing-1_5,_var(--spacing-2_5,_1rem))]',
-          'ml-[theme(--spacing-1_5,theme(--spacing-2_5,_1rem)))]',
-        ],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -184,7 +184,8 @@ describe('compiling CSS', () => {
 
   test('unescapes theme variables and handles dots as underscore', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['m-1.5', 'm-2.5', 'm-2_5', 'm-3.5', 'm-foo/bar'],
         css`
           @theme {
             --spacing-*: initial;
@@ -196,7 +197,6 @@ describe('compiling CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['m-1.5', 'm-2.5', 'm-2_5', 'm-3.5', 'm-foo/bar'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -228,11 +228,11 @@ describe('compiling CSS', () => {
 
   test('adds vendor prefixes', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['[text-size-adjust:none]'],
         css`
           @tailwind utilities;
         `,
-        ['[text-size-adjust:none]'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -317,7 +317,8 @@ describe('@apply', () => {
 
   it('@apply referencing theme values with `@tailwind utilities` should work', async () => {
     return expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @import 'tailwindcss';
 
@@ -325,7 +326,6 @@ describe('@apply', () => {
             @apply p-2;
           }
         `,
-        [],
         {
           async loadStylesheet() {
             return {
@@ -356,7 +356,8 @@ describe('@apply', () => {
 
   it('@apply referencing theme values with `@reference` should work', async () => {
     return expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @reference "style.css";
 
@@ -364,7 +365,6 @@ describe('@apply', () => {
             @apply p-2;
           }
         `,
-        [],
         {
           async loadStylesheet() {
             return {
@@ -498,12 +498,12 @@ describe('@apply', () => {
 
   it('should replace @apply with the correct result inside imported stylesheets', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @import './bar.css';
           @tailwind utilities;
         `,
-        [],
         {
           async loadStylesheet() {
             return {
@@ -696,7 +696,8 @@ describe('@apply', () => {
 
   it('should recursively apply with custom `@utility`, which is used before it is defined', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['a', 'b', 'c', 'flex', 'my-flex'],
         css`
           @tailwind utilities;
 
@@ -722,7 +723,6 @@ describe('@apply', () => {
             @apply flex;
           }
         `,
-        ['a', 'b', 'c', 'flex', 'my-flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -746,7 +746,8 @@ describe('@apply', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/16935
   it('should not swallow @utility declarations when @apply is used in nested rules', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['custom-utility'],
         css`
           @tailwind utilities;
 
@@ -761,7 +762,6 @@ describe('@apply', () => {
             @apply flex;
           }
         `,
-        ['custom-utility'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -783,7 +783,8 @@ describe('@apply', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/17924
   it('should correctly apply nested usages of @apply when one @utility applies another', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo', 'test', 'test2'],
         css`
           @theme {
             --color-green-500: green;
@@ -811,7 +812,6 @@ describe('@apply', () => {
             @apply test2;
           }
         `,
-        ['foo', 'test', 'test2'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -863,7 +863,8 @@ describe('@apply', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/18400
   it('should ignore the design systems `important` flag when using @apply', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['flex'],
         css`
           @import 'tailwindcss/utilities' important;
           .flex-explicitly-important {
@@ -873,7 +874,6 @@ describe('@apply', () => {
             @apply flex;
           }
         `,
-        ['flex'],
         {
           async loadStylesheet(_, base) {
             return {
@@ -1022,7 +1022,8 @@ describe('important', () => {
 
   it('should not mark declarations inside of @keyframes as important', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-spin!'],
         css`
           @theme {
             --animate-spin: spin 1s linear infinite;
@@ -1035,7 +1036,6 @@ describe('important', () => {
           }
           @tailwind utilities;
         `,
-        ['animate-spin!'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1070,14 +1070,14 @@ describe('important', () => {
 describe('sorting', () => {
   it('should sort utilities based on their property order', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['pointer-events-none', 'flex', 'p-1', 'px-1', 'pl-1'].sort(() => Math.random() - 0.5),
         css`
           @theme {
             --spacing-1: 0.25rem;
           }
           @tailwind utilities;
         `,
-        ['pointer-events-none', 'flex', 'p-1', 'px-1', 'pl-1'].sort(() => Math.random() - 0.5),
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1135,7 +1135,8 @@ describe('sorting', () => {
    */
   it('should sort utilities with a custom internal --tw-sort correctly', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['mx-0', 'gap-4', 'space-x-2'].sort(() => Math.random() - 0.5),
         css`
           @theme {
             --spacing-0: 0px;
@@ -1144,7 +1145,6 @@ describe('sorting', () => {
           }
           @tailwind utilities;
         `,
-        ['mx-0', 'gap-4', 'space-x-2'].sort(() => Math.random() - 0.5),
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1187,15 +1187,7 @@ describe('sorting', () => {
 
   it('should sort individual logical properties later than left/right pairs', async () => {
     expect(
-      await compileCss(
-        css`
-          @theme {
-            --spacing-1: 1px;
-            --spacing-2: 2px;
-            --spacing-3: 3px;
-          }
-          @tailwind utilities;
-        `,
+      await run(
         [
           // scroll-margin
           'scroll-ms-1',
@@ -1217,6 +1209,14 @@ describe('sorting', () => {
           'pe-2',
           'px-3',
         ].sort(() => Math.random() - 0.5),
+        css`
+          @theme {
+            --spacing-1: 1px;
+            --spacing-2: 2px;
+            --spacing-3: 3px;
+          }
+          @tailwind utilities;
+        `,
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1436,7 +1436,8 @@ describe('sorting', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/16973
   it('should not take undefined values into account when sorting', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['fancy-text', 'text-sm'],
         css`
           @theme {
             --text-sm: 0.875rem;
@@ -1449,7 +1450,6 @@ describe('sorting', () => {
             font-weight: var(--font-weight-bold);
           }
         `,
-        ['fancy-text', 'text-sm'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1476,14 +1476,14 @@ describe('sorting', () => {
 describe('Parsing theme values from CSS', () => {
   test('Can read values from `@theme`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['accent-red-500'],
         css`
           @theme {
             --color-red-500: #f00;
           }
           @tailwind utilities;
         `,
-        ['accent-red-500'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1500,7 +1500,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('Later values from `@theme` override earlier ones', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['accent-red-500'],
         css`
           @theme {
             --color-red-500: #f00;
@@ -1508,7 +1509,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['accent-red-500'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1525,7 +1525,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('Multiple `@theme` blocks are merged', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['accent-red-500', 'accent-blue-500'],
         css`
           @theme {
             --color-red-500: #f00;
@@ -1535,7 +1536,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['accent-red-500', 'accent-blue-500'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1557,7 +1557,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@theme` values with escaped forward slashes map to unescaped slashes in candidate values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['w-1/2', 'w-75%'],
         css`
           @theme {
             /* Cursed but we want this to work */
@@ -1566,7 +1567,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['w-1/2', 'w-75%'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1596,7 +1596,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@keyframes` in `@theme` are hoisted', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['accent-red', 'text-lg'],
         css`
           @theme {
             --color-red: red;
@@ -1612,7 +1613,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['accent-red', 'text-lg'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1634,7 +1634,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@keyframes` in `@theme` are generated when name contains a new line', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-very-long-animation-name'],
         css`
           @theme {
             --animate-very-long-animation-name: very-long-animation-name
@@ -1652,7 +1653,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['animate-very-long-animation-name'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1676,7 +1676,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@theme` values can be unset', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['accent-red', 'accent-blue', 'accent-green', 'text-sm', 'text-md'],
         css`
           @theme {
             --color-red: #f00;
@@ -1703,7 +1704,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['accent-red', 'accent-blue', 'accent-green', 'text-sm', 'text-md'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1725,7 +1725,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@theme` values can be unset (using the escaped syntax)', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['accent-red', 'accent-blue', 'accent-green', 'text-sm', 'text-md'],
         css`
           @theme {
             --color-red: #f00;
@@ -1752,7 +1753,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['accent-red', 'accent-blue', 'accent-green', 'text-sm', 'text-md'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1774,7 +1774,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('all `@theme` values can be unset at once', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['accent-red', 'accent-blue', 'accent-green', 'text-sm', 'text-md'],
         css`
           @theme {
             --color-red: #f00;
@@ -1790,7 +1791,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['accent-red', 'accent-blue', 'accent-green', 'text-sm', 'text-md'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1807,7 +1807,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('unsetting `--font-*` does not unset `--font-weight-*`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['font-bold', 'font-sans', 'font-serif', 'font-body'],
         css`
           @theme {
             --font-weight-bold: bold;
@@ -1820,7 +1821,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['font-bold', 'font-sans', 'font-serif', 'font-body'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1856,7 +1856,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('unsetting `--inset-*` does not unset `--inset-shadow-*`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['inset-shadow-sm', 'inset-ring-thick', 'inset-lg', 'inset-sm', 'inset-md'],
         css`
           @theme {
             --inset-shadow-sm: inset 0 2px 4px rgb(0 0 0 / 0.05);
@@ -1869,7 +1870,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['inset-shadow-sm', 'inset-ring-thick', 'inset-lg', 'inset-sm', 'inset-md'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -1991,7 +1991,15 @@ describe('Parsing theme values from CSS', () => {
 
   test('unsetting `--text-*` does not unset `--text-color-*`, `--text-underline-offset-*`, `--text-indent-*`, `--text-decoration-thickness-*` or `--text-decoration-color-*`', async () => {
     expect(
-      await compileCss(
+      await run(
+        [
+          'text-potato',
+          'underline-offset-potato',
+          'indent-potato',
+          'decoration-potato',
+          'decoration-salad',
+          'text-lg',
+        ],
         css`
           @theme {
             --text-color-potato: brown;
@@ -2007,14 +2015,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        [
-          'text-potato',
-          'underline-offset-potato',
-          'indent-potato',
-          'decoration-potato',
-          'decoration-salad',
-          'text-lg',
-        ],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2058,7 +2058,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('unused keyframes are removed when an animation is unset', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-foo', 'animate-foobar'],
         css`
           @theme {
             --animate-foo: foo 1s infinite;
@@ -2081,7 +2082,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['animate-foo', 'animate-foobar'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2104,7 +2104,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes are generated when used in an animation', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-foo'],
         css`
           @theme {
             --animate-foo: used 1s infinite;
@@ -2125,7 +2126,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['animate-foo'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2148,7 +2148,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes are generated when used in an animation within a prefixed setup', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['tw:animate-foo'],
         css`
           @theme prefix(tw) {
             --animate-foo: used 1s infinite;
@@ -2169,7 +2170,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['tw:animate-foo'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2192,7 +2192,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('custom properties are generated when used from a CSS var with a prefixed setup', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @theme prefix(tw) {
             --color-tomato: #e10c04;
@@ -2202,7 +2203,6 @@ describe('Parsing theme values from CSS', () => {
             color: var(--tw-color-tomato);
           }
         `,
-        [],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2220,7 +2220,8 @@ describe('Parsing theme values from CSS', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/16374
   test('custom properties in keyframes preserved', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-foo'],
         css`
           @theme {
             --animate-foo: used 1s infinite;
@@ -2235,7 +2236,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['animate-foo'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2259,7 +2259,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes are generated when used in an animation using `@theme inline`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-foo'],
         css`
           @theme inline {
             --animate-foo: used 1s infinite;
@@ -2280,7 +2281,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['animate-foo'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2299,7 +2299,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes are generated when used in an animation using `@theme static`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-foo'],
         css`
           @theme static {
             --animate-foo: used 1s infinite;
@@ -2320,7 +2321,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['animate-foo'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2350,7 +2350,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes are generated when used in user CSS', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @theme {
             @keyframes used {
@@ -2372,7 +2373,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        [],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2392,7 +2392,8 @@ describe('Parsing theme values from CSS', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/17332
   test('extracts keyframe names followed by comma', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['animate-test'],
         css`
           @theme {
             --animate-test: 500ms both fade-in, 1000ms linear 500ms spin infinite;
@@ -2409,7 +2410,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['animate-test'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2436,7 +2436,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes outside of `@theme are always preserved', async () => {
     expect(
-      await compileCss(
+      await run(
+        [],
         css`
           @theme {
             @keyframes used {
@@ -2458,7 +2459,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        [],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2483,7 +2483,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('theme values added as reference are not included in the output as variables but emit fallback values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato', 'bg-potato'],
         css`
           @theme {
             --color-tomato: #e10c04;
@@ -2493,7 +2494,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['bg-tomato', 'bg-potato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2514,7 +2514,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@keyframes` added in `@theme reference` should not be emitted', async () => {
     return expect(
-      await compileCss(
+      await run(
+        ['animate-foo'],
         css`
           @theme reference {
             --animate-foo: foo 1s infinite;
@@ -2531,7 +2532,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['animate-foo'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2554,7 +2554,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@keyframes` added in `@theme reference` should not be emitted, even if another `@theme` block exists', async () => {
     return expect(
-      await compileCss(
+      await run(
+        ['bg-pink', 'animate-foo'],
         css`
           @theme reference {
             --animate-foo: foo 1s infinite;
@@ -2576,7 +2577,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-pink', 'animate-foo'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2607,7 +2607,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('theme values added as reference that override existing theme value suppress the output of the original theme value as a variable', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-potato'],
         css`
           @theme {
             --color-potato: #ac855b;
@@ -2617,7 +2618,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['bg-potato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2630,7 +2630,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('overriding a reference theme value with a non-reference theme value includes it in the output as a variable', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-potato'],
         css`
           @theme reference {
             --color-potato: #ac855b;
@@ -2640,7 +2641,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['bg-potato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2657,7 +2657,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('wrapping `@theme` with `@media reference` behaves like `@theme reference` to support `@import` statements', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato', 'bg-potato', 'bg-avocado'],
         css`
           @theme {
             --color-tomato: #e10c04;
@@ -2672,7 +2673,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['bg-tomato', 'bg-potato', 'bg-avocado'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2697,11 +2697,11 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@import "tailwindcss" theme(static)` will always generate theme values, regardless of whether they were used or not', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato'],
         css`
           @import 'tailwindcss' theme(static);
         `,
-        ['bg-tomato'],
         {
           async loadStylesheet() {
             return {
@@ -2737,7 +2737,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@media theme(reference)` can only contain `@theme` rules', () => {
     return expect(
-      compileCss(
+      run(
+        ['bg-tomato', 'bg-potato', 'bg-avocado'],
         css`
           @media theme(reference) {
             .not-a-theme-rule {
@@ -2746,7 +2747,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['bg-tomato', 'bg-potato', 'bg-avocado'],
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `
@@ -2758,7 +2758,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('theme values added as `inline` are not wrapped in `var(…)` when used as utility values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato', 'bg-potato', 'bg-primary'],
         css`
           @theme inline {
             --color-tomato: #e10c04;
@@ -2768,7 +2769,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2789,11 +2789,11 @@ describe('Parsing theme values from CSS', () => {
 
   test('`@import "tailwindcss" theme(inline)` theme values added as `inline` are not wrapped in `var(…)` when used as utility values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato'],
         css`
           @import 'tailwindcss' theme(inline);
         `,
-        ['bg-tomato'],
         {
           async loadStylesheet() {
             return {
@@ -2823,7 +2823,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('theme values added as `static` will always be generated, regardless of whether they were used or not', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato'],
         css`
           @theme static {
             --color-tomato: #e10c04;
@@ -2833,7 +2834,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-tomato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2852,7 +2852,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('when no theme values are emitted, empty layers can be removed', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['underline'],
         css`
           @layer theme1 {
             @layer theme2 {
@@ -2865,7 +2866,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['underline'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2878,7 +2878,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('wrapping `@theme` with `@media theme(inline)` behaves like `@theme inline` to support `@import` statements', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato', 'bg-potato', 'bg-primary'],
         css`
           @media theme(inline) {
             @theme {
@@ -2890,7 +2891,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2911,7 +2911,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`inline` and `reference` can be used together', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato', 'bg-potato', 'bg-primary'],
         css`
           @theme reference inline {
             --color-tomato: #e10c04;
@@ -2921,7 +2922,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2942,7 +2942,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`inline` and `reference` can be used together in `media(…)`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-tomato', 'bg-potato', 'bg-primary'],
         css`
           @media theme(reference inline) {
             @theme {
@@ -2954,7 +2955,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -2975,7 +2975,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`default` theme values can be overridden by regular theme values`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-potato'],
         css`
           @theme {
             --color-potato: #ac855b;
@@ -2986,7 +2987,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-potato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3003,7 +3003,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`default` and `inline` can be used together', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-potato'],
         css`
           @theme default inline {
             --color-potato: #efb46b;
@@ -3011,7 +3012,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-potato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3024,7 +3024,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`default` and `reference` can be used together', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-potato'],
         css`
           @theme default reference {
             --color-potato: #efb46b;
@@ -3032,7 +3033,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-potato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3045,7 +3045,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`default`, `inline`, and `reference` can be used together', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-potato'],
         css`
           @theme default reference inline {
             --color-potato: #efb46b;
@@ -3053,7 +3054,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-potato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3066,7 +3066,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`default` can be used in `media(…)`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bg-potato', 'bg-tomato'],
         css`
           @media theme() {
             @theme {
@@ -3082,7 +3083,6 @@ describe('Parsing theme values from CSS', () => {
 
           @tailwind utilities;
         `,
-        ['bg-potato', 'bg-tomato'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3104,7 +3104,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`default` theme values can be overridden by plugin theme values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-red', 'text-orange'],
         css`
           @theme default {
             --color-red: red;
@@ -3115,7 +3116,6 @@ describe('Parsing theme values from CSS', () => {
           @plugin "my-plugin";
           @tailwind utilities;
         `,
-        ['text-red', 'text-orange'],
         {
           loadModule: async () => {
             return {
@@ -3154,7 +3154,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('`default` theme values can be overridden by config theme values', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-red', 'text-orange'],
         css`
           @theme default {
             --color-red: red;
@@ -3165,7 +3166,6 @@ describe('Parsing theme values from CSS', () => {
           @config "./my-config.js";
           @tailwind utilities;
         `,
-        ['text-red', 'text-orange'],
         {
           loadModule: async () => {
             return {
@@ -3204,7 +3204,8 @@ describe('Parsing theme values from CSS', () => {
 
   test('only emits theme variables that are used outside of being defined by another variable', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['get-var-b', 'get-var-two'],
         css`
           @theme {
             --var-a: var(--var-b);
@@ -3228,7 +3229,6 @@ describe('Parsing theme values from CSS', () => {
           }
           @tailwind utilities;
         `,
-        ['get-var-b', 'get-var-two'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -3317,14 +3317,14 @@ describe('plugins', () => {
     expect.hasAssertions()
 
     expect(
-      await compileCss(
+      await run(
+        ['text-primary'],
         css`
           @tailwind utilities;
           @plugin "my-plugin" {
             color: red;
           }
         `,
-        ['text-primary'],
         {
           loadModule: async () => ({
             path: '',
@@ -3530,14 +3530,14 @@ describe('plugins', () => {
 
   test('addVariant with string selector', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async () => ({
             path: '',
@@ -3565,14 +3565,14 @@ describe('plugins', () => {
 
   test('addVariant with array of selectors', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async () => ({
             path: '',
@@ -3600,14 +3600,14 @@ describe('plugins', () => {
 
   test('addVariant with object syntax and @slot', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async () => ({
             path: '',
@@ -3638,14 +3638,14 @@ describe('plugins', () => {
 
   test('addVariant with object syntax, media, nesting and multiple @slot', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline', 'group-hocus:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline', 'group-hocus:flex'],
         {
           loadModule: async () => ({
             path: '',
@@ -3690,14 +3690,14 @@ describe('plugins', () => {
 
   test('@slot is preserved when used as a custom property value', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:underline'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        ['hocus:underline'],
         {
           loadModule: async () => ({
             path: '',
@@ -3952,7 +3952,8 @@ describe('@source', () => {
 
     test('can be negated', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['container'],
           css`
             @theme {
               --breakpoint-sm: 40rem;
@@ -3964,14 +3965,14 @@ describe('@source', () => {
             @source not inline("container");
             @tailwind utilities;
           `,
-          ['container'],
         ),
       ).toEqual('')
     })
 
     test('applies brace expansion to negated sources', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['bg-red-500', 'bg-red-700'],
           css`
             @theme {
               --color-red-50: oklch(0.971 0.013 17.38);
@@ -3989,7 +3990,6 @@ describe('@source', () => {
             @source not inline("bg-red-{50,{100..900..100},950}");
             @tailwind utilities;
           `,
-          ['bg-red-500', 'bg-red-700'],
         ),
       ).toEqual('')
     })
@@ -4136,7 +4136,8 @@ describe('@custom-variant', () => {
   describe('body-less syntax', () => {
     test('selector variant', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['hocus:underline', 'group-hocus:flex'],
           css`
             @custom-variant hocus (&:hover, &:focus);
 
@@ -4144,7 +4145,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['hocus:underline', 'group-hocus:flex'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4163,7 +4163,8 @@ describe('@custom-variant', () => {
 
     test('at-rule variant', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['any-hover:hover:underline'],
           css`
             @custom-variant any-hover (@media (any-hover: hover));
 
@@ -4171,7 +4172,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['any-hover:hover:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4190,7 +4190,8 @@ describe('@custom-variant', () => {
 
     test('style-rules and at-rules', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['cant-hover:focus:underline'],
           css`
             @custom-variant cant-hover (&:not(:hover), &:not(:active), @media not (any-hover: hover), @media not (pointer: fine));
 
@@ -4198,7 +4199,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['cant-hover:focus:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4227,7 +4227,8 @@ describe('@custom-variant', () => {
   describe('body with @slot syntax', () => {
     test('selector with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['selected:underline', 'group-selected:underline'],
           css`
             @custom-variant selected {
               &[data-selected] {
@@ -4239,7 +4240,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['selected:underline', 'group-selected:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4254,7 +4254,8 @@ describe('@custom-variant', () => {
 
     test('grouped selectors with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['hocus:underline', 'group-hocus:underline'],
           css`
             @custom-variant hocus {
               &:hover,
@@ -4267,7 +4268,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['hocus:underline', 'group-hocus:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4282,7 +4282,8 @@ describe('@custom-variant', () => {
 
     test('multiple selectors with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['hocus:underline', 'group-hocus:underline'],
           css`
             @custom-variant hocus {
               &:hover {
@@ -4298,7 +4299,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['hocus:underline', 'group-hocus:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4313,7 +4313,8 @@ describe('@custom-variant', () => {
 
     test('nested selector with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['custom-before:underline'],
           css`
             @custom-variant custom-before {
               & {
@@ -4328,7 +4329,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['custom-before:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4347,7 +4347,8 @@ describe('@custom-variant', () => {
 
     test('grouped nested selectors with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['custom-before:underline'],
           css`
             @custom-variant custom-before {
               & {
@@ -4365,7 +4366,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['custom-before:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4384,7 +4384,8 @@ describe('@custom-variant', () => {
 
     test('nested multiple selectors with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['hocus:underline', 'group-hocus:underline'],
           css`
             @custom-variant hocus {
               &:hover {
@@ -4402,7 +4403,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['hocus:underline', 'group-hocus:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4433,7 +4433,8 @@ describe('@custom-variant', () => {
 
     test('selector nested under at-rule with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['hocus:underline', 'group-hocus:underline'],
           css`
             @custom-variant hocus {
               @media (hover: hover) {
@@ -4447,7 +4448,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['hocus:underline', 'group-hocus:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4464,7 +4464,8 @@ describe('@custom-variant', () => {
 
     test('at-rule with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['any-hover:underline'],
           css`
             @custom-variant any-hover {
               @media (any-hover: hover) {
@@ -4476,7 +4477,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['any-hover:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4493,7 +4493,8 @@ describe('@custom-variant', () => {
 
     test('multiple at-rules with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['desktop:underline'],
           css`
             @custom-variant desktop {
               @media (any-hover: hover) {
@@ -4509,7 +4510,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['desktop:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4532,7 +4532,8 @@ describe('@custom-variant', () => {
 
     test('nested at-rules with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['custom-variant:underline'],
           css`
             @custom-variant custom-variant {
               @media (orientation: landscape) {
@@ -4550,7 +4551,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['custom-variant:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4575,7 +4575,8 @@ describe('@custom-variant', () => {
 
     test('at-rule and selector with @slot', async () => {
       expect(
-        await compileCss(
+        await run(
+          ['custom-dark:underline'],
           css`
             @custom-variant custom-dark {
               @media (prefers-color-scheme: dark) {
@@ -4590,7 +4591,6 @@ describe('@custom-variant', () => {
               @tailwind utilities;
             }
           `,
-          ['custom-dark:underline'],
         ),
       ).toMatchInlineSnapshot(`
         "
@@ -4643,7 +4643,8 @@ describe('@custom-variant', () => {
 
   test('at-rule-only variants cannot be used with compound variants', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo:flex', 'group-foo:flex', 'peer-foo:flex', 'has-foo:flex', 'not-foo:flex'],
         css`
           @custom-variant foo (@media foo);
 
@@ -4651,8 +4652,6 @@ describe('@custom-variant', () => {
             @tailwind utilities;
           }
         `,
-
-        ['foo:flex', 'group-foo:flex', 'peer-foo:flex', 'has-foo:flex', 'not-foo:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4675,7 +4674,8 @@ describe('@custom-variant', () => {
 
   test('@custom-variant can reuse existing @variant in the definition', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:flex'],
         css`
           @custom-variant hocus {
             @variant hover {
@@ -4687,7 +4687,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['hocus:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4702,7 +4701,8 @@ describe('@custom-variant', () => {
 
   test('@custom-variant can reuse @custom-variant that is defined later', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:flex'],
         css`
           @custom-variant hocus {
             @variant custom-hover {
@@ -4716,7 +4716,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['hocus:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4729,7 +4728,8 @@ describe('@custom-variant', () => {
 
   test('@custom-variant can reuse existing @variant that is overwritten later', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:flex'],
         css`
           @custom-variant hocus {
             @variant hover {
@@ -4743,7 +4743,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['hocus:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4756,7 +4755,8 @@ describe('@custom-variant', () => {
 
   test('@custom-variant cannot use @variant that eventually results in a circular dependency', async () => {
     return expect(() =>
-      compileCss(
+      run(
+        ['foo:flex'],
         css`
           @custom-variant custom-variant {
             @variant foo {
@@ -4790,7 +4790,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['foo:flex'],
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       [Error: Circular dependency detected in custom variants:
@@ -4814,7 +4813,8 @@ describe('@custom-variant', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/19618
   test('@custom-variant can use a @variant that eventually uses another @custom-variant', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['a:flex', 'b:flex', 'a:b:flex', 'b:a:flex'],
         css`
           @custom-variant a {
             @slot;
@@ -4828,7 +4828,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['a:flex', 'b:flex', 'a:b:flex', 'b:a:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4841,7 +4840,8 @@ describe('@custom-variant', () => {
 
   test('@custom-variant can use a @variant that eventually uses another @custom-variant (2)', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['a:flex', 'b:flex', 'a:b:flex', 'b:a:flex'],
         css`
           @custom-variant a {
             .a {
@@ -4861,7 +4861,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['a:flex', 'b:flex', 'a:b:flex', 'b:a:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4875,7 +4874,8 @@ describe('@custom-variant', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/19618#issuecomment-3830775912
   test('@custom-variant can use existing @slot @variants', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['hocus:flex'],
         css`
           @custom-variant hocus {
             @variant hover {
@@ -4897,7 +4897,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['hocus:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4910,7 +4909,8 @@ describe('@custom-variant', () => {
 
   test('@custom-variant setup that results in a circular dependency error can be solved', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['baz:flex'],
         css`
           @custom-variant foo {
             @variant hover {
@@ -4941,7 +4941,6 @@ describe('@custom-variant', () => {
 
           @tailwind utilities;
         `,
-        ['baz:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4991,7 +4990,8 @@ describe('@utility', () => {
 
   test('@utility can handle escape sequences correctly', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['push-1/2', 'push-50%'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -5005,7 +5005,6 @@ describe('@utility', () => {
             right: 50%;
           }
         `,
-        ['push-1/2', 'push-50%'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -5045,7 +5044,8 @@ describe('@utility', () => {
   // https://github.com/tailwindlabs/tailwindcss/issues/19505
   test('@utility name cannot contain multiple `/` characters', async () => {
     await expect(
-      compileCss(
+      run(
+        ['ui/button'],
         css`
           @utility ui/button {
             display: inline-flex;
@@ -5053,7 +5053,6 @@ describe('@utility', () => {
           }
           @tailwind utilities;
         `,
-        ['ui/button'],
       ),
     ).resolves.toMatchInlineSnapshot(
       `
@@ -5082,7 +5081,8 @@ describe('@utility', () => {
 
 test('addBase', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['underline'],
       css`
         @plugin "my-plugin";
         @layer base, utilities;
@@ -5090,7 +5090,6 @@ test('addBase', async () => {
           @tailwind utilities;
         }
       `,
-      ['underline'],
       {
         loadModule: async () => ({
           path: '',
@@ -5124,7 +5123,8 @@ test('addBase', async () => {
 
 test('JS APIs support @variant', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'foo', 'bar-one'],
       css`
         @plugin "my-plugin";
         @layer base, utilities;
@@ -5132,7 +5132,6 @@ test('JS APIs support @variant', async () => {
           @tailwind utilities;
         }
       `,
-      ['underline', 'foo', 'bar-one'],
       {
         loadModule: async () => ({
           path: '',
@@ -5179,11 +5178,11 @@ test('JS APIs support @variant', async () => {
 
 it("should error when `layer(…)` is used, but it's not the first param", async () => {
   await expect(async () => {
-    return await compileCss(
+    return await run(
+      [],
       css`
         @import './bar.css' supports(display: grid) layer(utilities);
       `,
-      [],
       {
         async loadStylesheet() {
           return {
@@ -5234,15 +5233,15 @@ describe('`@reference "…" imports`', () => {
     }
 
     await expect(
-      compileCss(
-        `
+      run(
+        [],
+        css`
           @reference './foo/bar.css';
 
           .bar {
             @apply md:hocus:foo;
           }
         `,
-        [],
         { loadStylesheet },
       ),
     ).resolves.toMatchInlineSnapshot(`
@@ -5258,11 +5257,11 @@ describe('`@reference "…" imports`', () => {
 
   test('does not generate utilities', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-underline', 'border'],
         css`
           @reference './foo/bar.css';
         `,
-        ['text-underline', 'border'],
         {
           loadStylesheet: async (id: string, base = '/root/foo') => {
             if (id === './foo/baz.css') {
@@ -5291,7 +5290,8 @@ describe('`@reference "…" imports`', () => {
 
   test('removes all @keyframes, even those contributed by JavasScript plugins', async () => {
     await expect(
-      compileCss(
+      run(
+        ['animate-spin', 'match-utility-initial', 'match-components-initial'],
         css`
           @media reference {
             @layer theme, base, components, utilities;
@@ -5322,7 +5322,6 @@ describe('`@reference "…" imports`', () => {
             @apply animate-spin;
           }
         `,
-        ['animate-spin', 'match-utility-initial', 'match-components-initial'],
         {
           loadModule: async () => ({
             path: '',
@@ -5429,14 +5428,14 @@ describe('`@reference "…" imports`', () => {
     }
 
     await expect(
-      compileCss(
-        `
+      run(
+        [],
+        css`
           @reference './one.css';
           .bar {
             @apply text-red animate-wiggle;
           }
         `,
-        [],
         { loadStylesheet },
       ),
     ).resolves.toMatchInlineSnapshot(`
@@ -5480,15 +5479,15 @@ describe('`@reference "…" imports`', () => {
     }
 
     await expect(
-      compileCss(
-        `
-            @import './foo/bar.css' reference;
-
-            .bar {
-              @apply md:hocus:foo;
-            }
-          `,
+      run(
         [],
+        css`
+          @import './foo/bar.css' reference;
+
+          .bar {
+            @apply md:hocus:foo;
+          }
+        `,
         { loadStylesheet },
       ),
     ).resolves.toMatchInlineSnapshot(`
@@ -5504,8 +5503,9 @@ describe('`@reference "…" imports`', () => {
 
   test('removes styles when the import resolver was handled outside of Tailwind CSS', async () => {
     await expect(
-      compileCss(
-        `
+      run(
+        [],
+        css`
           @media reference {
             @layer theme {
               @theme {
@@ -5525,7 +5525,6 @@ describe('`@reference "…" imports`', () => {
             @apply md:hocus:foo;
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -5542,12 +5541,12 @@ describe('`@reference "…" imports`', () => {
 describe('@variant', () => {
   it('should convert legacy body-less `@variant` as a `@custom-variant`', async () => {
     await expect(
-      compileCss(
+      run(
+        ['hocus:underline'],
         css`
           @variant hocus (&:hover, &:focus);
           @tailwind utilities;
         `,
-        ['hocus:underline'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -5560,7 +5559,8 @@ describe('@variant', () => {
 
   it('should convert legacy `@variant` with `@slot` as a `@custom-variant`', async () => {
     await expect(
-      compileCss(
+      run(
+        ['hocus:underline'],
         css`
           @variant hocus {
             &:hover {
@@ -5573,7 +5573,6 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `,
-        ['hocus:underline'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -5586,7 +5585,8 @@ describe('@variant', () => {
 
   it('should be possible to use `@variant` in your CSS', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           .btn {
             background: black;
@@ -5628,7 +5628,6 @@ describe('@variant', () => {
             }
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -5679,7 +5678,8 @@ describe('@variant', () => {
 
   it('should be possible to use `@variant` in your CSS with a `@custom-variant` that is defined later', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           .btn {
             background: black;
@@ -5691,7 +5691,6 @@ describe('@variant', () => {
 
           @custom-variant hocus (&:hover, &:focus);
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -5708,7 +5707,8 @@ describe('@variant', () => {
 
   it('should be possible to use nested `@variant` rules', async () => {
     await expect(
-      compileCss(
+      run(
+        ['disabled:focus:underline'],
         css`
           .btn {
             background: black;
@@ -5721,7 +5721,6 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `,
-        ['disabled:focus:underline'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6179,7 +6178,8 @@ describe('@variant', () => {
 
   it('should be possible to use `@variant` with a funky looking variants', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           @theme inline reference {
             --container-md: 768px;
@@ -6195,7 +6195,6 @@ describe('@variant', () => {
             }
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6216,14 +6215,14 @@ describe('@variant', () => {
 describe('`color-mix(…)` polyfill', () => {
   it('creates an inlined variable version of the color-mix(…) usages', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-red-500/50'],
         css`
           @theme {
             --color-red-500: oklch(63.7% 0.237 25.331);
           }
           @tailwind utilities;
         `,
-        ['text-red-500/50'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6246,7 +6245,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('creates an inlined variable version of the color-mix(…) usages when it resolves to a var(…) containing another theme variable', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-red/50'],
         css`
           @theme {
             --color-red: var(--color-red-500);
@@ -6254,7 +6254,6 @@ describe('`color-mix(…)` polyfill', () => {
           }
           @tailwind utilities;
         `,
-        ['text-red/50'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6278,7 +6277,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('works for color values in the first and second position', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           @theme {
             --color-red-500: oklch(63.7% 0.237 25.331);
@@ -6289,7 +6289,6 @@ describe('`color-mix(…)` polyfill', () => {
             color: color-mix(in lch, var(--color-red-500) 50%, var(--color-orange-500));
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6313,7 +6312,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('works for nested `color-mix(…)` calls', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           @theme {
             --color-red-500: oklch(63.7% 0.237 25.331);
@@ -6327,7 +6327,6 @@ describe('`color-mix(…)` polyfill', () => {
             );
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6350,7 +6349,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('works with multiple `color-mix(…)` functions in one declaration', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           @theme {
             --color-red-500: oklch(63.7% 0.237 25.331);
@@ -6366,7 +6366,6 @@ describe('`color-mix(…)` polyfill', () => {
             );
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6424,14 +6423,14 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('uses the first color value as the fallback when the `color-mix(…)` function contains non-theme variables', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-(--my-color)/50', 'text-red-500/(--my-opacity)', 'text-(--my-color)/(--my-opacity)'],
         css`
           @theme {
             --color-red-500: oklch(63.7% 0.237 25.331);
           }
           @tailwind utilities;
         `,
-        ['text-(--my-color)/50', 'text-red-500/(--my-opacity)', 'text-(--my-color)/(--my-opacity)'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6474,11 +6473,11 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('uses the first color value as the fallback when the `color-mix(…)` function contains currentcolor', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-current/50'],
         css`
           @tailwind utilities;
         `,
-        ['text-current/50'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6497,14 +6496,14 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('uses the first color value as the fallback when the `color-mix(…)` function contains theme variables that resolves to other variables', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-red/50'],
         css`
           @tailwind utilities;
           @theme {
             --color-red: var(--my-red);
           }
         `,
-        ['text-red/50'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6527,7 +6526,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('uses the first color value of the inner most `color-mix(…)` function as the fallback when nested `color-mix(…)` function all contain non-theme variables', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           @tailwind utilities;
           .stacked {
@@ -6539,7 +6539,6 @@ describe('`color-mix(…)` polyfill', () => {
             );
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6558,14 +6557,14 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('does not create a fallback when all color values are statically analyzable (lightningcss will flatten this)', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-red-500/50'],
         css`
           @theme inline {
             --color-red-500: oklch(63.7% 0.237 25.331);
           }
           @tailwind utilities;
         `,
-        ['text-red-500/50'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6578,7 +6577,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('also replaces eventual variables in opacity values', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-red-500/(--my-half)'],
         css`
           @theme {
             --my-half: 50%;
@@ -6586,7 +6586,6 @@ describe('`color-mix(…)` polyfill', () => {
           }
           @tailwind utilities;
         `,
-        ['text-red-500/(--my-half)'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6610,7 +6609,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('does not delete theme variables from the output', async () => {
     await expect(
-      compileCss(
+      run(
+        ['text-red-500', 'shadow-xl', 'opacity-disabled'],
         css`
           @layer theme {
             @theme {
@@ -6621,7 +6621,6 @@ describe('`color-mix(…)` polyfill', () => {
           }
           @tailwind utilities;
         `,
-        ['text-red-500', 'shadow-xl', 'opacity-disabled'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6759,7 +6758,8 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('does not apply optimizations when already inside a @supports (color: color-mix... block', async () => {
     await expect(
-      compileCss(
+      run(
+        ['mixed'],
         css`
           @tailwind utilities;
           @utility mixed {
@@ -6768,7 +6768,6 @@ describe('`color-mix(…)` polyfill', () => {
             }
           }
         `,
-        ['mixed'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6785,7 +6784,8 @@ describe('`color-mix(…)` polyfill', () => {
 describe('`@property` polyfill', async () => {
   it('emits fallbacks', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           @tailwind utilities;
 
@@ -6808,7 +6808,6 @@ describe('`@property` polyfill', async () => {
             initial-value: red;
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "
@@ -6853,7 +6852,8 @@ describe('`@property` polyfill', async () => {
 
   it('emitting fallbacks can be disabled (necessary for CSS modules)', async () => {
     await expect(
-      compileCss(
+      run(
+        [],
         css`
           @tailwind utilities;
 
@@ -6876,7 +6876,6 @@ describe('`@property` polyfill', async () => {
             initial-value: red;
           }
         `,
-        [],
         {
           polyfills: Polyfills.None,
         },

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -310,8 +310,7 @@ describe('@apply', () => {
 
   it('@apply referencing theme values with `@tailwind utilities` should work', async () => {
     return expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @import 'tailwindcss';
 
@@ -349,8 +348,7 @@ describe('@apply', () => {
 
   it('@apply referencing theme values with `@reference` should work', async () => {
     return expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @reference "style.css";
 
@@ -491,8 +489,7 @@ describe('@apply', () => {
 
   it('should replace @apply with the correct result inside imported stylesheets', async () => {
     expect(
-      await run(
-        [],
+      await compileCss(
         css`
           @import './bar.css';
           @tailwind utilities;
@@ -2185,18 +2182,15 @@ describe('Parsing theme values from CSS', () => {
 
   test('custom properties are generated when used from a CSS var with a prefixed setup', async () => {
     expect(
-      await run(
-        [],
-        css`
-          @theme prefix(tw) {
-            --color-tomato: #e10c04;
-          }
-          @tailwind utilities;
-          .red {
-            color: var(--tw-color-tomato);
-          }
-        `,
-      ),
+      await compileCss(css`
+        @theme prefix(tw) {
+          --color-tomato: #e10c04;
+        }
+        @tailwind utilities;
+        .red {
+          color: var(--tw-color-tomato);
+        }
+      `),
     ).toMatchInlineSnapshot(`
       "
       :root, :host {
@@ -2343,30 +2337,27 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes are generated when used in user CSS', async () => {
     expect(
-      await run(
-        [],
-        css`
-          @theme {
-            @keyframes used {
-              to {
-                opacity: 1;
-              }
-            }
-
-            @keyframes unused {
-              to {
-                opacity: 0;
-              }
+      await compileCss(css`
+        @theme {
+          @keyframes used {
+            to {
+              opacity: 1;
             }
           }
 
-          .foo {
-            animation: used 1s infinite;
+          @keyframes unused {
+            to {
+              opacity: 0;
+            }
           }
+        }
 
-          @tailwind utilities;
-        `,
-      ),
+        .foo {
+          animation: used 1s infinite;
+        }
+
+        @tailwind utilities;
+      `),
     ).toMatchInlineSnapshot(`
       "
       .foo {
@@ -2429,30 +2420,27 @@ describe('Parsing theme values from CSS', () => {
 
   test('keyframes outside of `@theme are always preserved', async () => {
     expect(
-      await run(
-        [],
-        css`
-          @theme {
-            @keyframes used {
-              to {
-                opacity: 1;
-              }
-            }
-          }
-
-          @keyframes unused {
+      await compileCss(css`
+        @theme {
+          @keyframes used {
             to {
-              opacity: 0;
+              opacity: 1;
             }
           }
+        }
 
-          .foo {
-            animation: used 1s infinite;
+        @keyframes unused {
+          to {
+            opacity: 0;
           }
+        }
 
-          @tailwind utilities;
-        `,
-      ),
+        .foo {
+          animation: used 1s infinite;
+        }
+
+        @tailwind utilities;
+      `),
     ).toMatchInlineSnapshot(`
       "
       @keyframes unused {
@@ -5170,8 +5158,7 @@ test('JS APIs support @variant', async () => {
 
 it("should error when `layer(…)` is used, but it's not the first param", async () => {
   await expect(async () => {
-    return await run(
-      [],
+    return await compileCss(
       css`
         @import './bar.css' supports(display: grid) layer(utilities);
       `,
@@ -5225,8 +5212,7 @@ describe('`@reference "…" imports`', () => {
     }
 
     await expect(
-      run(
-        [],
+      compileCss(
         css`
           @reference './foo/bar.css';
 
@@ -5420,8 +5406,7 @@ describe('`@reference "…" imports`', () => {
     }
 
     await expect(
-      run(
-        [],
+      compileCss(
         css`
           @reference './one.css';
           .bar {
@@ -5471,8 +5456,7 @@ describe('`@reference "…" imports`', () => {
     }
 
     await expect(
-      run(
-        [],
+      compileCss(
         css`
           @import './foo/bar.css' reference;
 
@@ -5495,29 +5479,26 @@ describe('`@reference "…" imports`', () => {
 
   test('removes styles when the import resolver was handled outside of Tailwind CSS', async () => {
     await expect(
-      run(
-        [],
-        css`
-          @media reference {
-            @layer theme {
-              @theme {
-                --breakpoint-md: 48rem;
-              }
-              .foo {
-                color: red;
-              }
+      compileCss(css`
+        @media reference {
+          @layer theme {
+            @theme {
+              --breakpoint-md: 48rem;
             }
-            @utility foo {
+            .foo {
               color: red;
             }
-            @custom-variant hocus (&:hover, &:focus);
           }
+          @utility foo {
+            color: red;
+          }
+          @custom-variant hocus (&:hover, &:focus);
+        }
 
-          .bar {
-            @apply md:hocus:foo;
-          }
-        `,
-      ),
+        .bar {
+          @apply md:hocus:foo;
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       @media (min-width: 48rem) {
@@ -5577,50 +5558,47 @@ describe('@variant', () => {
 
   it('should be possible to use `@variant` in your CSS', async () => {
     await expect(
-      run(
-        [],
-        css`
-          .btn {
-            background: black;
+      compileCss(css`
+        .btn {
+          background: black;
 
-            @variant dark {
-              background: white;
-            }
+          @variant dark {
+            background: white;
           }
+        }
 
-          @variant hover {
-            @variant landscape {
-              .btn2 {
-                color: red;
-              }
-            }
-          }
-
-          @variant hover {
-            .foo {
+        @variant hover {
+          @variant landscape {
+            .btn2 {
               color: red;
             }
-            @variant landscape {
-              .bar {
-                color: blue;
-              }
-            }
-            .baz {
-              @variant portrait {
-                color: green;
-              }
-            }
           }
+        }
 
-          @media something {
-            @variant landscape {
-              @page {
-                color: red;
-              }
+        @variant hover {
+          .foo {
+            color: red;
+          }
+          @variant landscape {
+            .bar {
+              color: blue;
             }
           }
-        `,
-      ),
+          .baz {
+            @variant portrait {
+              color: green;
+            }
+          }
+        }
+
+        @media something {
+          @variant landscape {
+            @page {
+              color: red;
+            }
+          }
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       .btn {
@@ -5670,20 +5648,17 @@ describe('@variant', () => {
 
   it('should be possible to use `@variant` in your CSS with a `@custom-variant` that is defined later', async () => {
     await expect(
-      run(
-        [],
-        css`
-          .btn {
-            background: black;
+      compileCss(css`
+        .btn {
+          background: black;
 
-            @variant hocus {
-              background: white;
-            }
+          @variant hocus {
+            background: white;
           }
+        }
 
-          @custom-variant hocus (&:hover, &:focus);
-        `,
-      ),
+        @custom-variant hocus (&:hover, &:focus);
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       .btn {
@@ -6170,24 +6145,21 @@ describe('@variant', () => {
 
   it('should be possible to use `@variant` with a funky looking variants', async () => {
     await expect(
-      run(
-        [],
-        css`
-          @theme inline reference {
-            --container-md: 768px;
-          }
+      compileCss(css`
+        @theme inline reference {
+          --container-md: 768px;
+        }
 
-          .btn {
-            background: black;
+        .btn {
+          background: black;
 
-            @variant @md {
-              @variant [&.foo] {
-                background: white;
-              }
+          @variant @md {
+            @variant [&.foo] {
+              background: white;
             }
           }
-        `,
-      ),
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       .btn {
@@ -6269,19 +6241,16 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('works for color values in the first and second position', async () => {
     await expect(
-      run(
-        [],
-        css`
-          @theme {
-            --color-red-500: oklch(63.7% 0.237 25.331);
-            --color-orange-500: oklch(70.5% 0.213 47.604);
-          }
-          @tailwind utilities;
-          .mixed {
-            color: color-mix(in lch, var(--color-red-500) 50%, var(--color-orange-500));
-          }
-        `,
-      ),
+      compileCss(css`
+        @theme {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+          --color-orange-500: oklch(70.5% 0.213 47.604);
+        }
+        @tailwind utilities;
+        .mixed {
+          color: color-mix(in lch, var(--color-red-500) 50%, var(--color-orange-500));
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       :root, :host {
@@ -6304,22 +6273,19 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('works for nested `color-mix(…)` calls', async () => {
     await expect(
-      run(
-        [],
-        css`
-          @theme {
-            --color-red-500: oklch(63.7% 0.237 25.331);
-          }
-          @tailwind utilities;
-          .stacked {
-            color: color-mix(
-              in lch,
-              color-mix(in lch, var(--color-red-500) 50%, transparent) 50%,
-              transparent
-            );
-          }
-        `,
-      ),
+      compileCss(css`
+        @theme {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+        }
+        @tailwind utilities;
+        .stacked {
+          color: color-mix(
+            in lch,
+            color-mix(in lch, var(--color-red-500) 50%, transparent) 50%,
+            transparent
+          );
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       :root, :host {
@@ -6341,24 +6307,21 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('works with multiple `color-mix(…)` functions in one declaration', async () => {
     await expect(
-      run(
-        [],
-        css`
-          @theme {
-            --color-red-500: oklch(63.7% 0.237 25.331);
-            --color-orange-500: oklch(70.5% 0.213 47.604);
-          }
-          @tailwind utilities;
-          .gradient {
-            background: linear-gradient(
-              90deg,
-              color-mix(in oklab, var(--color-red-500) 50%, transparent) 0%,
-              color-mix(in oklab, var(--color-orange-500) 50%, transparent) 0%,
-              100%
-            );
-          }
-        `,
-      ),
+      compileCss(css`
+        @theme {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+          --color-orange-500: oklch(70.5% 0.213 47.604);
+        }
+        @tailwind utilities;
+        .gradient {
+          background: linear-gradient(
+            90deg,
+            color-mix(in oklab, var(--color-red-500) 50%, transparent) 0%,
+            color-mix(in oklab, var(--color-orange-500) 50%, transparent) 0%,
+            100%
+          );
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       :root, :host {
@@ -6517,20 +6480,17 @@ describe('`color-mix(…)` polyfill', () => {
 
   it('uses the first color value of the inner most `color-mix(…)` function as the fallback when nested `color-mix(…)` function all contain non-theme variables', async () => {
     await expect(
-      run(
-        [],
-        css`
-          @tailwind utilities;
-          .stacked {
-            color: color-mix(
-              in oklab,
-              color-mix(in oklab, var(--my-color) var(--my-inner-opacity), transparent)
-                var(--my-outer-opacity),
-              transparent
-            );
-          }
-        `,
-      ),
+      compileCss(css`
+        @tailwind utilities;
+        .stacked {
+          color: color-mix(
+            in oklab,
+            color-mix(in oklab, var(--my-color) var(--my-inner-opacity), transparent)
+              var(--my-outer-opacity),
+            transparent
+          );
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       .stacked {
@@ -6775,31 +6735,28 @@ describe('`color-mix(…)` polyfill', () => {
 describe('`@property` polyfill', async () => {
   it('emits fallbacks', async () => {
     await expect(
-      run(
-        [],
-        css`
-          @tailwind utilities;
+      compileCss(css`
+        @tailwind utilities;
 
-          @property --no-inherit-no-value {
-            syntax: '*';
-            inherits: false;
-          }
-          @property --no-inherit-value {
-            syntax: '*';
-            inherits: false;
-            initial-value: red;
-          }
-          @property --inherit-no-value {
-            syntax: '*';
-            inherits: true;
-          }
-          @property --inherit-value {
-            syntax: '*';
-            inherits: true;
-            initial-value: red;
-          }
-        `,
-      ),
+        @property --no-inherit-no-value {
+          syntax: '*';
+          inherits: false;
+        }
+        @property --no-inherit-value {
+          syntax: '*';
+          inherits: false;
+          initial-value: red;
+        }
+        @property --inherit-no-value {
+          syntax: '*';
+          inherits: true;
+        }
+        @property --inherit-value {
+          syntax: '*';
+          inherits: true;
+          initial-value: red;
+        }
+      `),
     ).resolves.toMatchInlineSnapshot(`
       "
       @layer properties {
@@ -6843,8 +6800,7 @@ describe('`@property` polyfill', async () => {
 
   it('emitting fallbacks can be disabled (necessary for CSS modules)', async () => {
     await expect(
-      run(
-        [],
+      compileCss(
         css`
           @tailwind utilities;
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5708,18 +5708,18 @@ describe('@variant', () => {
 
   describe('comma-separated `@variant` rules', () => {
     it('should be possible to use comma-separated `@variant` rules', async () => {
-      expect(
-        await compileCss(css`
-          .btn {
-            background: black;
+      let input = css`
+        .btn {
+          background: black;
 
-            @variant hover, focus {
-              background: red;
-            }
+          @variant hover, focus {
+            background: red;
           }
-          @tailwind utilities;
-        `),
-      ).toMatchInlineSnapshot(`
+        }
+        @tailwind utilities;
+      `
+
+      expect(await compileCss(input)).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -5737,18 +5737,7 @@ describe('@variant', () => {
         "
       `)
 
-      expect(
-        await compileCss(css`
-          .btn {
-            background: black;
-
-            @variant hover, focus {
-              background: red;
-            }
-          }
-          @tailwind utilities;
-        `),
-      ).toEqual(
+      expect(await compileCss(input)).toEqual(
         await compileCss(css`
           .btn {
             background: black;
@@ -5832,22 +5821,22 @@ describe('@variant', () => {
     })
 
     it('should handle nested comma-separated variants', async () => {
-      expect(
-        await compileCss(css`
-          .btn {
-            background: black;
+      let input = css`
+        .btn {
+          background: black;
 
-            @variant hover, focus {
-              background: red;
+          @variant hover, focus {
+            background: red;
 
-              @variant active, disabled {
-                background: blue;
-              }
+            @variant active, disabled {
+              background: blue;
             }
           }
-          @tailwind utilities;
-        `),
-      ).toMatchInlineSnapshot(`
+        }
+        @tailwind utilities;
+      `
+
+      expect(await compileCss(input)).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -5873,22 +5862,7 @@ describe('@variant', () => {
         "
       `)
 
-      expect(
-        await compileCss(css`
-          .btn {
-            background: black;
-
-            @variant hover, focus {
-              background: red;
-
-              @variant active, disabled {
-                background: blue;
-              }
-            }
-          }
-          @tailwind utilities;
-        `),
-      ).toEqual(
+      expect(await compileCss(input)).toEqual(
         await compileCss(css`
           .btn {
             background: black;
@@ -6049,22 +6023,22 @@ describe('@variant', () => {
   })
 
   it('should be possible to use compound and stacked variants in `@variant`', async () => {
-    expect(
-      await compileCss(css`
-        .btn {
-          background: black;
+    let input = css`
+      .btn {
+        background: black;
 
-          @variant data-a, data-b:data-c {
-            background: red;
+        @variant data-a, data-b:data-c {
+          background: red;
 
-            @variant data-d, data-e:data-f {
-              background: blue;
-            }
+          @variant data-d, data-e:data-f {
+            background: blue;
           }
         }
-        @tailwind utilities;
-      `),
-    ).toMatchInlineSnapshot(`
+      }
+      @tailwind utilities;
+    `
+
+    expect(await compileCss(input)).toMatchInlineSnapshot(`
       "
       .btn {
         background: #000;
@@ -6088,22 +6062,7 @@ describe('@variant', () => {
       "
     `)
 
-    expect(
-      await compileCss(css`
-        .btn {
-          background: black;
-
-          @variant data-a, data-b:data-c {
-            background: red;
-
-            @variant data-d, data-e:data-f {
-              background: blue;
-            }
-          }
-        }
-        @tailwind utilities;
-      `),
-    ).toEqual(
+    expect(await compileCss(input)).toEqual(
       await compileCss(css`
         .btn {
           background: black;

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -3724,16 +3724,16 @@ describe('plugins', () => {
 
   test('built-in variants can be overridden while keeping their order', async () => {
     expect(
-      await compileCss(
+      await run(
+        // Make sure the order does not change by including the variants
+        // immediately before and after `dark`
+        ['rtl:flex', 'dark:flex', 'starting:flex'],
         css`
           @plugin "my-plugin";
           @layer utilities {
             @tailwind utilities;
           }
         `,
-        // Make sure the order does not change by including the variants
-        // immediately before and after `dark`
-        ['rtl:flex', 'dark:flex', 'starting:flex'],
         {
           loadModule: async () => ({
             path: '',
@@ -4605,17 +4605,16 @@ describe('@custom-variant', () => {
 
   test('built-in variants can be overridden while keeping their order', async () => {
     expect(
-      await compileCss(
+      await run(
+        // Make sure the order does not change by including the variants
+        // immediately before and after `dark`
+        ['rtl:flex', 'dark:flex', 'starting:flex'],
         css`
           @custom-variant dark (&:is([data-theme='dark'] *));
           @layer utilities {
             @tailwind utilities;
           }
         `,
-
-        // Make sure the order does not change by including the variants
-        // immediately before and after `dark`
-        ['rtl:flex', 'dark:flex', 'starting:flex'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -6393,7 +6392,6 @@ describe('`color-mix(…)` polyfill', () => {
             color: color-mix(in oklab,var(--color-red-500)50%,transparent);
           }
         `,
-        [],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -6426,14 +6426,7 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('uses the first color value as the fallback when the `color-mix(…)` function contains currentcolor', async () => {
-    expect(
-      await run(
-        ['text-current/50'],
-        css`
-          @tailwind utilities;
-        `,
-      ),
-    ).toMatchInlineSnapshot(`
+    expect(await run(['text-current/50'])).toMatchInlineSnapshot(`
       "
       .text-current\\/50 {
         color: currentColor;

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -227,14 +227,7 @@ describe('compiling CSS', () => {
   })
 
   test('adds vendor prefixes', async () => {
-    expect(
-      await run(
-        ['[text-size-adjust:none]'],
-        css`
-          @tailwind utilities;
-        `,
-      ),
-    ).toMatchInlineSnapshot(`
+    expect(await run(['[text-size-adjust:none]'])).toMatchInlineSnapshot(`
       "
       .\\[text-size-adjust\\:none\\] {
         -webkit-text-size-adjust: none;

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5023,8 +5023,8 @@ describe('@utility', () => {
 
   // https://github.com/tailwindlabs/tailwindcss/issues/19505
   test('@utility name cannot contain multiple `/` characters', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['ui/button'],
         css`
           @utility ui/button {
@@ -5034,7 +5034,7 @@ describe('@utility', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(
+    ).toMatchInlineSnapshot(
       `
       "
       .ui\\/button {
@@ -5211,8 +5211,8 @@ describe('`@reference "…" imports`', () => {
       }
     }
 
-    await expect(
-      compileCss(
+    expect(
+      await compileCss(
         css`
           @reference './foo/bar.css';
 
@@ -5222,7 +5222,7 @@ describe('`@reference "…" imports`', () => {
         `,
         { loadStylesheet },
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       @media (min-width: 768px) {
         .bar:hover, .bar:focus {
@@ -5267,8 +5267,8 @@ describe('`@reference "…" imports`', () => {
   })
 
   test('removes all @keyframes, even those contributed by JavasScript plugins', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['animate-spin', 'match-utility-initial', 'match-components-initial'],
         css`
           @media reference {
@@ -5340,7 +5340,7 @@ describe('`@reference "…" imports`', () => {
           }),
         },
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .bar {
         animation: var(--animate-spin, spin 1s linear infinite);
@@ -5405,8 +5405,8 @@ describe('`@reference "…" imports`', () => {
       throw new Error('unreachable')
     }
 
-    await expect(
-      compileCss(
+    expect(
+      await compileCss(
         css`
           @reference './one.css';
           .bar {
@@ -5415,7 +5415,7 @@ describe('`@reference "…" imports`', () => {
         `,
         { loadStylesheet },
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .bar {
         animation: var(--animate-wiggle, wiggle 1s ease-in-out infinite);
@@ -5455,8 +5455,8 @@ describe('`@reference "…" imports`', () => {
       }
     }
 
-    await expect(
-      compileCss(
+    expect(
+      await compileCss(
         css`
           @import './foo/bar.css' reference;
 
@@ -5466,7 +5466,7 @@ describe('`@reference "…" imports`', () => {
         `,
         { loadStylesheet },
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       @media (min-width: 768px) {
         .bar:hover, .bar:focus {
@@ -5478,8 +5478,8 @@ describe('`@reference "…" imports`', () => {
   })
 
   test('removes styles when the import resolver was handled outside of Tailwind CSS', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         @media reference {
           @layer theme {
             @theme {
@@ -5499,7 +5499,7 @@ describe('`@reference "…" imports`', () => {
           @apply md:hocus:foo;
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       @media (min-width: 48rem) {
         .bar:hover, .bar:focus {
@@ -5513,15 +5513,15 @@ describe('`@reference "…" imports`', () => {
 
 describe('@variant', () => {
   it('should convert legacy body-less `@variant` as a `@custom-variant`', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['hocus:underline'],
         css`
           @variant hocus (&:hover, &:focus);
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .hocus\\:underline:hover, .hocus\\:underline:focus {
         text-decoration-line: underline;
@@ -5531,8 +5531,8 @@ describe('@variant', () => {
   })
 
   it('should convert legacy `@variant` with `@slot` as a `@custom-variant`', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['hocus:underline'],
         css`
           @variant hocus {
@@ -5547,7 +5547,7 @@ describe('@variant', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .hocus\\:underline:hover, .hocus\\:underline:focus {
         text-decoration-line: underline;
@@ -5557,8 +5557,8 @@ describe('@variant', () => {
   })
 
   it('should be possible to use `@variant` in your CSS', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         .btn {
           background: black;
 
@@ -5599,7 +5599,7 @@ describe('@variant', () => {
           }
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .btn {
         background: #000;
@@ -5647,8 +5647,8 @@ describe('@variant', () => {
   })
 
   it('should be possible to use `@variant` in your CSS with a `@custom-variant` that is defined later', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         .btn {
           background: black;
 
@@ -5659,7 +5659,7 @@ describe('@variant', () => {
 
         @custom-variant hocus (&:hover, &:focus);
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .btn {
         background: #000;
@@ -5673,8 +5673,8 @@ describe('@variant', () => {
   })
 
   it('should be possible to use nested `@variant` rules', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['disabled:focus:underline'],
         css`
           .btn {
@@ -5689,7 +5689,7 @@ describe('@variant', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .btn {
         background: #000;
@@ -5708,8 +5708,8 @@ describe('@variant', () => {
 
   describe('comma-separated `@variant` rules', () => {
     it('should be possible to use comma-separated `@variant` rules', async () => {
-      await expect(
-        compileCss(css`
+      expect(
+        await compileCss(css`
           .btn {
             background: black;
 
@@ -5719,7 +5719,7 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `),
-      ).resolves.toMatchInlineSnapshot(`
+      ).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -5775,8 +5775,8 @@ describe('@variant', () => {
     )(
       "should handle optional whitespace ('%s', '%s') between `@variant` variants",
       async (before, after) => {
-        await expect(
-          compileCss(css`
+        expect(
+          await compileCss(css`
             .btn {
               background: black;
 
@@ -5786,7 +5786,7 @@ describe('@variant', () => {
             }
             @tailwind utilities;
           `),
-        ).resolves.toMatchInlineSnapshot(`
+        ).toMatchInlineSnapshot(`
           "
           .btn {
             background: #000;
@@ -5807,8 +5807,8 @@ describe('@variant', () => {
     )
 
     it('should handle variants containing a `,` inside', async () => {
-      await expect(
-        compileCss(css`
+      expect(
+        await compileCss(css`
           .btn {
             background: black;
 
@@ -5818,7 +5818,7 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `),
-      ).resolves.toMatchInlineSnapshot(`
+      ).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -5832,8 +5832,8 @@ describe('@variant', () => {
     })
 
     it('should handle nested comma-separated variants', async () => {
-      await expect(
-        compileCss(css`
+      expect(
+        await compileCss(css`
           .btn {
             background: black;
 
@@ -5847,7 +5847,7 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `),
-      ).resolves.toMatchInlineSnapshot(`
+      ).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -5959,8 +5959,8 @@ describe('@variant', () => {
 
   describe('stacked `@variant` rules', () => {
     it('should handle stacked variants', async () => {
-      await expect(
-        compileCss(css`
+      expect(
+        await compileCss(css`
           .btn {
             background: black;
 
@@ -5970,7 +5970,7 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `),
-      ).resolves.toMatchInlineSnapshot(`
+      ).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -5986,8 +5986,8 @@ describe('@variant', () => {
     })
 
     it('should handle stacked variants & comma-separated variants', async () => {
-      await expect(
-        compileCss(css`
+      expect(
+        await compileCss(css`
           .btn {
             background: black;
 
@@ -5997,7 +5997,7 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `),
-      ).resolves.toMatchInlineSnapshot(`
+      ).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -6017,8 +6017,8 @@ describe('@variant', () => {
     })
 
     it('should handle variants containing a `:` inside', async () => {
-      await expect(
-        compileCss(css`
+      expect(
+        await compileCss(css`
           .btn {
             background: black;
 
@@ -6028,7 +6028,7 @@ describe('@variant', () => {
           }
           @tailwind utilities;
         `),
-      ).resolves.toMatchInlineSnapshot(`
+      ).toMatchInlineSnapshot(`
         "
         .btn {
           background: #000;
@@ -6049,8 +6049,8 @@ describe('@variant', () => {
   })
 
   it('should be possible to use compound and stacked variants in `@variant`', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         .btn {
           background: black;
 
@@ -6064,7 +6064,7 @@ describe('@variant', () => {
         }
         @tailwind utilities;
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .btn {
         background: #000;
@@ -6144,8 +6144,8 @@ describe('@variant', () => {
   })
 
   it('should be possible to use `@variant` with a funky looking variants', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         @theme inline reference {
           --container-md: 768px;
         }
@@ -6160,7 +6160,7 @@ describe('@variant', () => {
           }
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .btn {
         background: #000;
@@ -6178,8 +6178,8 @@ describe('@variant', () => {
 
 describe('`color-mix(…)` polyfill', () => {
   it('creates an inlined variable version of the color-mix(…) usages', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-red-500/50'],
         css`
           @theme {
@@ -6188,7 +6188,7 @@ describe('`color-mix(…)` polyfill', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red-500: oklch(63.7% .237 25.331);
@@ -6208,8 +6208,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('creates an inlined variable version of the color-mix(…) usages when it resolves to a var(…) containing another theme variable', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-red/50'],
         css`
           @theme {
@@ -6219,7 +6219,7 @@ describe('`color-mix(…)` polyfill', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red: var(--color-red-500);
@@ -6240,8 +6240,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('works for color values in the first and second position', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         @theme {
           --color-red-500: oklch(63.7% 0.237 25.331);
           --color-orange-500: oklch(70.5% 0.213 47.604);
@@ -6251,7 +6251,7 @@ describe('`color-mix(…)` polyfill', () => {
           color: color-mix(in lch, var(--color-red-500) 50%, var(--color-orange-500));
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red-500: oklch(63.7% .237 25.331);
@@ -6272,8 +6272,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('works for nested `color-mix(…)` calls', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         @theme {
           --color-red-500: oklch(63.7% 0.237 25.331);
         }
@@ -6286,7 +6286,7 @@ describe('`color-mix(…)` polyfill', () => {
           );
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red-500: oklch(63.7% .237 25.331);
@@ -6306,8 +6306,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('works with multiple `color-mix(…)` functions in one declaration', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         @theme {
           --color-red-500: oklch(63.7% 0.237 25.331);
           --color-orange-500: oklch(70.5% 0.213 47.604);
@@ -6322,7 +6322,7 @@ describe('`color-mix(…)` polyfill', () => {
           );
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red-500: oklch(63.7% .237 25.331);
@@ -6343,8 +6343,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('works with no spaces after the `var(…)`', async () => {
-    await expect(
-      compileCss(
+    expect(
+      await compileCss(
         // prettier-ignore
         css`
           @theme {
@@ -6356,7 +6356,7 @@ describe('`color-mix(…)` polyfill', () => {
           }
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red-500: oklch(63.7% .237 25.331);
@@ -6376,8 +6376,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('uses the first color value as the fallback when the `color-mix(…)` function contains non-theme variables', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-(--my-color)/50', 'text-red-500/(--my-opacity)', 'text-(--my-color)/(--my-opacity)'],
         css`
           @theme {
@@ -6386,7 +6386,7 @@ describe('`color-mix(…)` polyfill', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red-500: oklch(63.7% .237 25.331);
@@ -6426,14 +6426,14 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('uses the first color value as the fallback when the `color-mix(…)` function contains currentcolor', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-current/50'],
         css`
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .text-current\\/50 {
         color: currentColor;
@@ -6449,8 +6449,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('uses the first color value as the fallback when the `color-mix(…)` function contains theme variables that resolves to other variables', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-red/50'],
         css`
           @tailwind utilities;
@@ -6459,7 +6459,7 @@ describe('`color-mix(…)` polyfill', () => {
           }
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .text-red\\/50 {
         color: var(--color-red);
@@ -6479,8 +6479,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('uses the first color value of the inner most `color-mix(…)` function as the fallback when nested `color-mix(…)` function all contain non-theme variables', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         @tailwind utilities;
         .stacked {
           color: color-mix(
@@ -6491,7 +6491,7 @@ describe('`color-mix(…)` polyfill', () => {
           );
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .stacked {
         color: var(--my-color);
@@ -6507,8 +6507,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('does not create a fallback when all color values are statically analyzable (lightningcss will flatten this)', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-red-500/50'],
         css`
           @theme inline {
@@ -6517,7 +6517,7 @@ describe('`color-mix(…)` polyfill', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       .text-red-500\\/50 {
         color: oklab(63.7% .214 .101 / .5);
@@ -6527,8 +6527,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('also replaces eventual variables in opacity values', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-red-500/(--my-half)'],
         css`
           @theme {
@@ -6538,7 +6538,7 @@ describe('`color-mix(…)` polyfill', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --my-half: 50%;
@@ -6559,8 +6559,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('does not delete theme variables from the output', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['text-red-500', 'shadow-xl', 'opacity-disabled'],
         css`
           @layer theme {
@@ -6573,7 +6573,7 @@ describe('`color-mix(…)` polyfill', () => {
           @tailwind utilities;
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       @layer properties {
         @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
@@ -6708,8 +6708,8 @@ describe('`color-mix(…)` polyfill', () => {
   })
 
   it('does not apply optimizations when already inside a @supports (color: color-mix... block', async () => {
-    await expect(
-      run(
+    expect(
+      await run(
         ['mixed'],
         css`
           @tailwind utilities;
@@ -6720,7 +6720,7 @@ describe('`color-mix(…)` polyfill', () => {
           }
         `,
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       @supports (color: color-mix(in lab, red, red)) {
         .mixed {
@@ -6734,8 +6734,8 @@ describe('`color-mix(…)` polyfill', () => {
 
 describe('`@property` polyfill', async () => {
   it('emits fallbacks', async () => {
-    await expect(
-      compileCss(css`
+    expect(
+      await compileCss(css`
         @tailwind utilities;
 
         @property --no-inherit-no-value {
@@ -6757,7 +6757,7 @@ describe('`@property` polyfill', async () => {
           initial-value: red;
         }
       `),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       @layer properties {
         @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
@@ -6799,8 +6799,8 @@ describe('`@property` polyfill', async () => {
   })
 
   it('emitting fallbacks can be disabled (necessary for CSS modules)', async () => {
-    await expect(
-      compileCss(
+    expect(
+      await compileCss(
         css`
           @tailwind utilities;
 
@@ -6827,7 +6827,7 @@ describe('`@property` polyfill', async () => {
           polyfills: Polyfills.None,
         },
       ),
-    ).resolves.toMatchInlineSnapshot(`
+    ).toMatchInlineSnapshot(`
       "
       @property --no-inherit-no-value {
         syntax: "*";

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -3814,14 +3814,10 @@ describe('@source', () => {
   describe('@source inline(…)', () => {
     test('always includes the candidate', async () => {
       expect(
-        await compileCss(
-          css`
-            @source inline("underline");
-            @tailwind utilities;
-          `,
-          [],
-          { base: '/root' },
-        ),
+        await compileCss(css`
+          @source inline("underline");
+          @tailwind utilities;
+        `),
       ).toMatchInlineSnapshot(`
         "
         .underline {
@@ -3833,27 +3829,23 @@ describe('@source', () => {
 
     test('applies brace expansion', async () => {
       expect(
-        await compileCss(
-          css`
-            @theme {
-              --color-red-50: oklch(0.971 0.013 17.38);
-              --color-red-100: oklch(0.936 0.032 17.717);
-              --color-red-200: oklch(0.885 0.062 18.334);
-              --color-red-300: oklch(0.808 0.114 19.571);
-              --color-red-400: oklch(0.704 0.191 22.216);
-              --color-red-500: oklch(0.637 0.237 25.331);
-              --color-red-600: oklch(0.577 0.245 27.325);
-              --color-red-700: oklch(0.505 0.213 27.518);
-              --color-red-800: oklch(0.444 0.177 26.899);
-              --color-red-900: oklch(0.396 0.141 25.723);
-              --color-red-950: oklch(0.258 0.092 26.042);
-            }
-            @source inline("bg-red-{50,{100..900..100},950}");
-            @tailwind utilities;
-          `,
-          [],
-          { base: '/root' },
-        ),
+        await compileCss(css`
+          @theme {
+            --color-red-50: oklch(0.971 0.013 17.38);
+            --color-red-100: oklch(0.936 0.032 17.717);
+            --color-red-200: oklch(0.885 0.062 18.334);
+            --color-red-300: oklch(0.808 0.114 19.571);
+            --color-red-400: oklch(0.704 0.191 22.216);
+            --color-red-500: oklch(0.637 0.237 25.331);
+            --color-red-600: oklch(0.577 0.245 27.325);
+            --color-red-700: oklch(0.505 0.213 27.518);
+            --color-red-800: oklch(0.444 0.177 26.899);
+            --color-red-900: oklch(0.396 0.141 25.723);
+            --color-red-950: oklch(0.258 0.092 26.042);
+          }
+          @source inline("bg-red-{50,{100..900..100},950}");
+          @tailwind utilities;
+        `),
       ).toMatchInlineSnapshot(`
         "
         :root, :host {
@@ -3919,18 +3911,14 @@ describe('@source', () => {
 
     test('adds multiple inline sources separated by spaces', async () => {
       expect(
-        await compileCss(
-          css`
-            @theme {
-              --color-red-100: oklch(0.936 0.032 17.717);
-              --color-red-200: oklch(0.885 0.062 18.334);
-            }
-            @source inline("block bg-red-{100..200..100}");
-            @tailwind utilities;
-          `,
-          [],
-          { base: '/root' },
-        ),
+        await compileCss(css`
+          @theme {
+            --color-red-100: oklch(0.936 0.032 17.717);
+            --color-red-200: oklch(0.885 0.062 18.334);
+          }
+          @source inline("block bg-red-{100..200..100}");
+          @tailwind utilities;
+        `),
       ).toMatchInlineSnapshot(`
         "
         :root, :host {
@@ -3955,14 +3943,10 @@ describe('@source', () => {
 
     test('ignores invalid inline candidates', async () => {
       expect(
-        await compileCss(
-          css`
-            @source inline("my-cucumber");
-            @tailwind utilities;
-          `,
-          [],
-          { base: '/root' },
-        ),
+        await compileCss(css`
+          @source inline("my-cucumber");
+          @tailwind utilities;
+        `),
       ).toEqual('')
     })
 
@@ -3981,7 +3965,6 @@ describe('@source', () => {
             @tailwind utilities;
           `,
           ['container'],
-          { base: '/root' },
         ),
       ).toEqual('')
     })
@@ -4007,22 +3990,17 @@ describe('@source', () => {
             @tailwind utilities;
           `,
           ['bg-red-500', 'bg-red-700'],
-          { base: '/root' },
         ),
       ).toEqual('')
     })
 
     test('works with whitespace around the argument', async () => {
       expect(
-        await compileCss(
-          css`
-            /* prettier-ignore */
-            @source inline( "underline" );
-            @tailwind utilities;
-          `,
-          [],
-          { base: '/root' },
-        ),
+        await compileCss(css`
+          /* prettier-ignore */
+          @source inline( "underline" );
+          @tailwind utilities;
+        `),
       ).toMatchInlineSnapshot(`
         "
         .underline {
@@ -4034,17 +4012,13 @@ describe('@source', () => {
 
     test('works with newlines around the argument', async () => {
       expect(
-        await compileCss(
-          css`
-            /* prettier-ignore */
-            @source inline(
+        await compileCss(css`
+          /* prettier-ignore */
+          @source inline(
             "underline"
           );
-            @tailwind utilities;
-          `,
-          [],
-          { base: '/root' },
-        ),
+          @tailwind utilities;
+        `),
       ).toMatchInlineSnapshot(`
         "
         .underline {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5,7 +5,7 @@ import { compile, Features, Polyfills } from '.'
 import { cartesian } from './cartesian'
 import type { PluginAPI } from './compat/plugin-api'
 import plugin from './plugin'
-import { compileCss, optimizeCss, pretty, run } from './test-utils/run'
+import { compileCss, run } from './test-utils/run'
 
 const css = String.raw
 
@@ -3103,38 +3103,39 @@ describe('Parsing theme values from CSS', () => {
   })
 
   test('`default` theme values can be overridden by plugin theme values', async () => {
-    let { build } = await compile(
-      css`
-        @theme default {
-          --color-red: red;
-        }
-        @theme {
-          --color-orange: orange;
-        }
-        @plugin "my-plugin";
-        @tailwind utilities;
-      `,
-      {
-        loadModule: async () => {
-          return {
-            path: '',
-            base: '/root',
-            module: plugin(({}) => {}, {
-              theme: {
-                extend: {
-                  colors: {
-                    red: 'tomato',
-                    orange: '#f28500',
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --color-red: red;
+          }
+          @theme {
+            --color-orange: orange;
+          }
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        ['text-red', 'text-orange'],
+        {
+          loadModule: async () => {
+            return {
+              path: '',
+              base: '/root',
+              module: plugin(({}) => {}, {
+                theme: {
+                  extend: {
+                    colors: {
+                      red: 'tomato',
+                      orange: '#f28500',
+                    },
                   },
                 },
-              },
-            }),
-          }
+              }),
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(build(['text-red', 'text-orange']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-orange: orange;
@@ -3152,38 +3153,39 @@ describe('Parsing theme values from CSS', () => {
   })
 
   test('`default` theme values can be overridden by config theme values', async () => {
-    let { build } = await compile(
-      css`
-        @theme default {
-          --color-red: red;
-        }
-        @theme {
-          --color-orange: orange;
-        }
-        @config "./my-config.js";
-        @tailwind utilities;
-      `,
-      {
-        loadModule: async () => {
-          return {
-            path: '',
-            base: '/root',
-            module: {
-              theme: {
-                extend: {
-                  colors: {
-                    red: 'tomato',
-                    orange: '#f28500',
+    expect(
+      await compileCss(
+        css`
+          @theme default {
+            --color-red: red;
+          }
+          @theme {
+            --color-orange: orange;
+          }
+          @config "./my-config.js";
+          @tailwind utilities;
+        `,
+        ['text-red', 'text-orange'],
+        {
+          loadModule: async () => {
+            return {
+              path: '',
+              base: '/root',
+              module: {
+                theme: {
+                  extend: {
+                    colors: {
+                      red: 'tomato',
+                      orange: '#f28500',
+                    },
                   },
                 },
               },
-            },
-          }
+            }
+          },
         },
-      },
-    )
-
-    expect(optimizeCss(build(['text-red', 'text-orange']))).toMatchInlineSnapshot(`
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-orange: orange;
@@ -3201,34 +3203,34 @@ describe('Parsing theme values from CSS', () => {
   })
 
   test('only emits theme variables that are used outside of being defined by another variable', async () => {
-    let { build } = await compile(
-      css`
-        @theme {
-          --var-a: var(--var-b);
-          --var-b: var(--var-c);
-          --var-c: var(--var-d);
-          --var-d: red;
+    expect(
+      await compileCss(
+        css`
+          @theme {
+            --var-a: var(--var-b);
+            --var-b: var(--var-c);
+            --var-c: var(--var-d);
+            --var-d: red;
 
-          --var-four: green;
-          --var-three: var(--var-four);
-          --var-two: var(--var-three);
-          --var-one: var(--var-two);
+            --var-four: green;
+            --var-three: var(--var-four);
+            --var-two: var(--var-three);
+            --var-one: var(--var-two);
 
-          --var-eins: var(--var-zwei);
-          --var-zwei: var(--var-drei);
-          --var-drei: var(--var-vier);
-          --var-vier: blue;
-        }
+            --var-eins: var(--var-zwei);
+            --var-zwei: var(--var-drei);
+            --var-drei: var(--var-vier);
+            --var-vier: blue;
+          }
 
-        @utility get-var-* {
-          color: --value(--var-\*);
-        }
-        @tailwind utilities;
-      `,
-      {},
-    )
-
-    expect(optimizeCss(build(['get-var-b', 'get-var-two']))).toMatchInlineSnapshot(`
+          @utility get-var-* {
+            color: --value(--var-\*);
+          }
+          @tailwind utilities;
+        `,
+        ['get-var-b', 'get-var-two'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --var-b: var(--var-c);
@@ -3314,37 +3316,36 @@ describe('plugins', () => {
   test('@plugin can accept options', async () => {
     expect.hasAssertions()
 
-    let { build } = await compile(
-      css`
-        @tailwind utilities;
-        @plugin "my-plugin" {
-          color: red;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: plugin.withOptions((options) => {
-            expect(options).toEqual({
-              color: 'red',
-            })
-
-            return ({ addUtilities }) => {
-              addUtilities({
-                '.text-primary': {
-                  color: options.color,
-                },
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+          @plugin "my-plugin" {
+            color: red;
+          }
+        `,
+        ['text-primary'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: plugin.withOptions((options) => {
+              expect(options).toEqual({
+                color: 'red',
               })
-            }
+
+              return ({ addUtilities }) => {
+                addUtilities({
+                  '.text-primary': {
+                    color: options.color,
+                  },
+                })
+              }
+            }),
           }),
-        }),
-      },
-    )
-
-    let compiled = build(['text-primary'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       .text-primary {
         color: red;
@@ -3528,26 +3529,26 @@ describe('plugins', () => {
   })
 
   test('addVariant with string selector', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: ({ addVariant }: PluginAPI) => {
-            addVariant('hocus', '&:hover, &:focus')
-          },
-        }),
-      },
-    )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: ({ addVariant }: PluginAPI) => {
+              addVariant('hocus', '&:hover, &:focus')
+            },
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
@@ -3563,27 +3564,26 @@ describe('plugins', () => {
   })
 
   test('addVariant with array of selectors', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: ({ addVariant }: PluginAPI) => {
-            addVariant('hocus', ['&:hover', '&:focus'])
-          },
-        }),
-      },
-    )
-
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: ({ addVariant }: PluginAPI) => {
+              addVariant('hocus', ['&:hover', '&:focus'])
+            },
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
@@ -3599,29 +3599,29 @@ describe('plugins', () => {
   })
 
   test('addVariant with object syntax and @slot', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: ({ addVariant }: PluginAPI) => {
-            addVariant('hocus', {
-              '&:hover': '@slot',
-              '&:focus': '@slot',
-            })
-          },
-        }),
-      },
-    )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: ({ addVariant }: PluginAPI) => {
+              addVariant('hocus', {
+                '&:hover': '@slot',
+                '&:focus': '@slot',
+              })
+            },
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
@@ -3637,31 +3637,31 @@ describe('plugins', () => {
   })
 
   test('addVariant with object syntax, media, nesting and multiple @slot', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: ({ addVariant }: PluginAPI) => {
-            addVariant('hocus', {
-              '@media (hover: hover)': {
-                '&:hover': '@slot',
-              },
-              '&:focus': '@slot',
-            })
-          },
-        }),
-      },
-    )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['hocus:underline', 'group-hocus:flex'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: ({ addVariant }: PluginAPI) => {
+              addVariant('hocus', {
+                '@media (hover: hover)': {
+                  '&:hover': '@slot',
+                },
+                '&:focus': '@slot',
+              })
+            },
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         @media (hover: hover) {
@@ -3689,32 +3689,32 @@ describe('plugins', () => {
   })
 
   test('@slot is preserved when used as a custom property value', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: ({ addVariant }: PluginAPI) => {
-            addVariant('hocus', {
-              '&': {
-                '--custom-property': '@slot',
-                '&:hover': '@slot',
-                '&:focus': '@slot',
-              },
-            })
-          },
-        }),
-      },
-    )
-    let compiled = build(['hocus:underline'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        ['hocus:underline'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: ({ addVariant }: PluginAPI) => {
+              addVariant('hocus', {
+                '&': {
+                  '--custom-property': '@slot',
+                  '&:hover': '@slot',
+                  '&:focus': '@slot',
+                },
+              })
+            },
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .hocus\\:underline {
@@ -3730,30 +3730,28 @@ describe('plugins', () => {
   })
 
   test('built-in variants can be overridden while keeping their order', async () => {
-    let { build } = await compile(
-      css`
-        @plugin "my-plugin";
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `,
-      {
-        loadModule: async () => ({
-          path: '',
-          base: '/root',
-          module: ({ addVariant }: PluginAPI) => {
-            addVariant('dark', '&:is([data-theme=dark] *)')
-          },
-        }),
-      },
-    )
-    let compiled = build(
-      // Make sure the order does not change by including the variants
-      // immediately before and after `dark`
-      ['rtl:flex', 'dark:flex', 'starting:flex'],
-    )
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+        `,
+        // Make sure the order does not change by including the variants
+        // immediately before and after `dark`
+        ['rtl:flex', 'dark:flex', 'starting:flex'],
+        {
+          loadModule: async () => ({
+            path: '',
+            base: '/root',
+            module: ({ addVariant }: PluginAPI) => {
+              addVariant('dark', '&:is([data-theme=dark] *)')
+            },
+          }),
+        },
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .rtl\\:flex:where(:dir(rtl), [dir="rtl"], [dir="rtl"] *), .dark\\:flex:is([data-theme="dark"] *) {
@@ -3815,15 +3813,16 @@ describe('@source', () => {
 
   describe('@source inline(…)', () => {
     test('always includes the candidate', async () => {
-      let { build } = await compile(
-        css`
-          @source inline("underline");
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(pretty(build([]))).toMatchInlineSnapshot(`
+      expect(
+        await compileCss(
+          css`
+            @source inline("underline");
+            @tailwind utilities;
+          `,
+          [],
+          { base: '/root' },
+        ),
+      ).toMatchInlineSnapshot(`
         "
         .underline {
           text-decoration-line: underline;
@@ -3833,72 +3832,84 @@ describe('@source', () => {
     })
 
     test('applies brace expansion', async () => {
-      let { build } = await compile(
-        css`
-          @theme {
-            --color-red-50: oklch(0.971 0.013 17.38);
-            --color-red-100: oklch(0.936 0.032 17.717);
-            --color-red-200: oklch(0.885 0.062 18.334);
-            --color-red-300: oklch(0.808 0.114 19.571);
-            --color-red-400: oklch(0.704 0.191 22.216);
-            --color-red-500: oklch(0.637 0.237 25.331);
-            --color-red-600: oklch(0.577 0.245 27.325);
-            --color-red-700: oklch(0.505 0.213 27.518);
-            --color-red-800: oklch(0.444 0.177 26.899);
-            --color-red-900: oklch(0.396 0.141 25.723);
-            --color-red-950: oklch(0.258 0.092 26.042);
-          }
-          @source inline("bg-red-{50,{100..900..100},950}");
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(pretty(build([]))).toMatchInlineSnapshot(`
+      expect(
+        await compileCss(
+          css`
+            @theme {
+              --color-red-50: oklch(0.971 0.013 17.38);
+              --color-red-100: oklch(0.936 0.032 17.717);
+              --color-red-200: oklch(0.885 0.062 18.334);
+              --color-red-300: oklch(0.808 0.114 19.571);
+              --color-red-400: oklch(0.704 0.191 22.216);
+              --color-red-500: oklch(0.637 0.237 25.331);
+              --color-red-600: oklch(0.577 0.245 27.325);
+              --color-red-700: oklch(0.505 0.213 27.518);
+              --color-red-800: oklch(0.444 0.177 26.899);
+              --color-red-900: oklch(0.396 0.141 25.723);
+              --color-red-950: oklch(0.258 0.092 26.042);
+            }
+            @source inline("bg-red-{50,{100..900..100},950}");
+            @tailwind utilities;
+          `,
+          [],
+          { base: '/root' },
+        ),
+      ).toMatchInlineSnapshot(`
         "
         :root, :host {
-          --color-red-50: oklch(0.971 0.013 17.38);
-          --color-red-100: oklch(0.936 0.032 17.717);
-          --color-red-200: oklch(0.885 0.062 18.334);
-          --color-red-300: oklch(0.808 0.114 19.571);
-          --color-red-400: oklch(0.704 0.191 22.216);
-          --color-red-500: oklch(0.637 0.237 25.331);
-          --color-red-600: oklch(0.577 0.245 27.325);
-          --color-red-700: oklch(0.505 0.213 27.518);
-          --color-red-800: oklch(0.444 0.177 26.899);
-          --color-red-900: oklch(0.396 0.141 25.723);
-          --color-red-950: oklch(0.258 0.092 26.042);
+          --color-red-50: oklch(97.1% .013 17.38);
+          --color-red-100: oklch(93.6% .032 17.717);
+          --color-red-200: oklch(88.5% .062 18.334);
+          --color-red-300: oklch(80.8% .114 19.571);
+          --color-red-400: oklch(70.4% .191 22.216);
+          --color-red-500: oklch(63.7% .237 25.331);
+          --color-red-600: oklch(57.7% .245 27.325);
+          --color-red-700: oklch(50.5% .213 27.518);
+          --color-red-800: oklch(44.4% .177 26.899);
+          --color-red-900: oklch(39.6% .141 25.723);
+          --color-red-950: oklch(25.8% .092 26.042);
         }
+
         .bg-red-50 {
           background-color: var(--color-red-50);
         }
+
         .bg-red-100 {
           background-color: var(--color-red-100);
         }
+
         .bg-red-200 {
           background-color: var(--color-red-200);
         }
+
         .bg-red-300 {
           background-color: var(--color-red-300);
         }
+
         .bg-red-400 {
           background-color: var(--color-red-400);
         }
+
         .bg-red-500 {
           background-color: var(--color-red-500);
         }
+
         .bg-red-600 {
           background-color: var(--color-red-600);
         }
+
         .bg-red-700 {
           background-color: var(--color-red-700);
         }
+
         .bg-red-800 {
           background-color: var(--color-red-800);
         }
+
         .bg-red-900 {
           background-color: var(--color-red-900);
         }
+
         .bg-red-950 {
           background-color: var(--color-red-950);
         }
@@ -3907,30 +3918,34 @@ describe('@source', () => {
     })
 
     test('adds multiple inline sources separated by spaces', async () => {
-      let { build } = await compile(
-        css`
-          @theme {
-            --color-red-100: oklch(0.936 0.032 17.717);
-            --color-red-200: oklch(0.885 0.062 18.334);
-          }
-          @source inline("block bg-red-{100..200..100}");
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(pretty(build([]))).toMatchInlineSnapshot(`
+      expect(
+        await compileCss(
+          css`
+            @theme {
+              --color-red-100: oklch(0.936 0.032 17.717);
+              --color-red-200: oklch(0.885 0.062 18.334);
+            }
+            @source inline("block bg-red-{100..200..100}");
+            @tailwind utilities;
+          `,
+          [],
+          { base: '/root' },
+        ),
+      ).toMatchInlineSnapshot(`
         "
         :root, :host {
-          --color-red-100: oklch(0.936 0.032 17.717);
-          --color-red-200: oklch(0.885 0.062 18.334);
+          --color-red-100: oklch(93.6% .032 17.717);
+          --color-red-200: oklch(88.5% .062 18.334);
         }
+
         .block {
           display: block;
         }
+
         .bg-red-100 {
           background-color: var(--color-red-100);
         }
+
         .bg-red-200 {
           background-color: var(--color-red-200);
         }
@@ -3939,72 +3954,76 @@ describe('@source', () => {
     })
 
     test('ignores invalid inline candidates', async () => {
-      let { build } = await compile(
-        css`
-          @source inline("my-cucumber");
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(build([])).toEqual('')
+      expect(
+        await compileCss(
+          css`
+            @source inline("my-cucumber");
+            @tailwind utilities;
+          `,
+          [],
+          { base: '/root' },
+        ),
+      ).toEqual('')
     })
 
     test('can be negated', async () => {
-      let { build } = await compile(
-        css`
-          @theme {
-            --breakpoint-sm: 40rem;
-            --breakpoint-md: 48rem;
-            --breakpoint-lg: 64rem;
-            --breakpoint-xl: 80rem;
-            --breakpoint-2xl: 96rem;
-          }
-          @source not inline("container");
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(build(['container'])).toEqual('')
+      expect(
+        await compileCss(
+          css`
+            @theme {
+              --breakpoint-sm: 40rem;
+              --breakpoint-md: 48rem;
+              --breakpoint-lg: 64rem;
+              --breakpoint-xl: 80rem;
+              --breakpoint-2xl: 96rem;
+            }
+            @source not inline("container");
+            @tailwind utilities;
+          `,
+          ['container'],
+          { base: '/root' },
+        ),
+      ).toEqual('')
     })
 
     test('applies brace expansion to negated sources', async () => {
-      let { build } = await compile(
-        css`
-          @theme {
-            --color-red-50: oklch(0.971 0.013 17.38);
-            --color-red-100: oklch(0.936 0.032 17.717);
-            --color-red-200: oklch(0.885 0.062 18.334);
-            --color-red-300: oklch(0.808 0.114 19.571);
-            --color-red-400: oklch(0.704 0.191 22.216);
-            --color-red-500: oklch(0.637 0.237 25.331);
-            --color-red-600: oklch(0.577 0.245 27.325);
-            --color-red-700: oklch(0.505 0.213 27.518);
-            --color-red-800: oklch(0.444 0.177 26.899);
-            --color-red-900: oklch(0.396 0.141 25.723);
-            --color-red-950: oklch(0.258 0.092 26.042);
-          }
-          @source not inline("bg-red-{50,{100..900..100},950}");
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(build(['bg-red-500', 'bg-red-700'])).toEqual('')
+      expect(
+        await compileCss(
+          css`
+            @theme {
+              --color-red-50: oklch(0.971 0.013 17.38);
+              --color-red-100: oklch(0.936 0.032 17.717);
+              --color-red-200: oklch(0.885 0.062 18.334);
+              --color-red-300: oklch(0.808 0.114 19.571);
+              --color-red-400: oklch(0.704 0.191 22.216);
+              --color-red-500: oklch(0.637 0.237 25.331);
+              --color-red-600: oklch(0.577 0.245 27.325);
+              --color-red-700: oklch(0.505 0.213 27.518);
+              --color-red-800: oklch(0.444 0.177 26.899);
+              --color-red-900: oklch(0.396 0.141 25.723);
+              --color-red-950: oklch(0.258 0.092 26.042);
+            }
+            @source not inline("bg-red-{50,{100..900..100},950}");
+            @tailwind utilities;
+          `,
+          ['bg-red-500', 'bg-red-700'],
+          { base: '/root' },
+        ),
+      ).toEqual('')
     })
 
     test('works with whitespace around the argument', async () => {
-      let { build } = await compile(
-        css`
-          /* prettier-ignore */
-          @source inline( "underline" );
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(pretty(build([]))).toMatchInlineSnapshot(`
+      expect(
+        await compileCss(
+          css`
+            /* prettier-ignore */
+            @source inline( "underline" );
+            @tailwind utilities;
+          `,
+          [],
+          { base: '/root' },
+        ),
+      ).toMatchInlineSnapshot(`
         "
         .underline {
           text-decoration-line: underline;
@@ -4014,18 +4033,19 @@ describe('@source', () => {
     })
 
     test('works with newlines around the argument', async () => {
-      let { build } = await compile(
-        css`
-          /* prettier-ignore */
-          @source inline(
+      expect(
+        await compileCss(
+          css`
+            /* prettier-ignore */
+            @source inline(
             "underline"
           );
-          @tailwind utilities;
-        `,
-        { base: '/root' },
-      )
-
-      expect(pretty(build([]))).toMatchInlineSnapshot(`
+            @tailwind utilities;
+          `,
+          [],
+          { base: '/root' },
+        ),
+      ).toMatchInlineSnapshot(`
         "
         .underline {
           text-decoration-line: underline;
@@ -4141,16 +4161,18 @@ describe('@custom-variant', () => {
 
   describe('body-less syntax', () => {
     test('selector variant', async () => {
-      let { build } = await compile(css`
-        @custom-variant hocus (&:hover, &:focus);
+      expect(
+        await compileCss(
+          css`
+            @custom-variant hocus (&:hover, &:focus);
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['hocus:underline', 'group-hocus:flex'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['hocus:underline', 'group-hocus:flex'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
@@ -4166,16 +4188,18 @@ describe('@custom-variant', () => {
     })
 
     test('at-rule variant', async () => {
-      let { build } = await compile(css`
-        @custom-variant any-hover (@media (any-hover: hover));
+      expect(
+        await compileCss(
+          css`
+            @custom-variant any-hover (@media (any-hover: hover));
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['any-hover:hover:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['any-hover:hover:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           @media (any-hover: hover) {
@@ -4191,16 +4215,18 @@ describe('@custom-variant', () => {
     })
 
     test('style-rules and at-rules', async () => {
-      let { build } = await compile(css`
-        @custom-variant cant-hover (&:not(:hover), &:not(:active), @media not (any-hover: hover), @media not (pointer: fine));
+      expect(
+        await compileCss(
+          css`
+            @custom-variant cant-hover (&:not(:hover), &:not(:active), @media not (any-hover: hover), @media not (pointer: fine));
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['cant-hover:focus:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['cant-hover:focus:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           :is(.cant-hover\\:focus\\:underline:not(:hover), .cant-hover\\:focus\\:underline:not(:active)):focus {
@@ -4226,20 +4252,22 @@ describe('@custom-variant', () => {
 
   describe('body with @slot syntax', () => {
     test('selector with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant selected {
-          &[data-selected] {
-            @slot;
-          }
-        }
+      expect(
+        await compileCss(
+          css`
+            @custom-variant selected {
+              &[data-selected] {
+                @slot;
+              }
+            }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['selected:underline', 'group-selected:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['selected:underline', 'group-selected:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           .group-selected\\:underline:is(:where(.group)[data-selected] *), .selected\\:underline[data-selected] {
@@ -4251,21 +4279,23 @@ describe('@custom-variant', () => {
     })
 
     test('grouped selectors with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant hocus {
-          &:hover,
-          &:focus {
-            @slot;
-          }
-        }
+      expect(
+        await compileCss(
+          css`
+            @custom-variant hocus {
+              &:hover,
+              &:focus {
+                @slot;
+              }
+            }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['hocus:underline', 'group-hocus:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['hocus:underline', 'group-hocus:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           .group-hocus\\:underline:is(:is(:where(.group):hover, :where(.group):focus) *), .hocus\\:underline:hover, .hocus\\:underline:focus {
@@ -4277,24 +4307,26 @@ describe('@custom-variant', () => {
     })
 
     test('multiple selectors with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant hocus {
-          &:hover {
-            @slot;
-          }
+      expect(
+        await compileCss(
+          css`
+            @custom-variant hocus {
+              &:hover {
+                @slot;
+              }
 
-          &:focus {
-            @slot;
-          }
-        }
+              &:focus {
+                @slot;
+              }
+            }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['hocus:underline', 'group-hocus:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['hocus:underline', 'group-hocus:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           .group-hocus\\:underline:is(:where(.group):hover *), .group-hocus\\:underline:is(:where(.group):focus *), .hocus\\:underline:hover, .hocus\\:underline:focus {
@@ -4306,23 +4338,25 @@ describe('@custom-variant', () => {
     })
 
     test('nested selector with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant custom-before {
-          & {
-            --has-before: 1;
-            &::before {
-              @slot;
+      expect(
+        await compileCss(
+          css`
+            @custom-variant custom-before {
+              & {
+                --has-before: 1;
+                &::before {
+                  @slot;
+                }
+              }
             }
-          }
-        }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['custom-before:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['custom-before:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           .custom-before\\:underline {
@@ -4338,26 +4372,28 @@ describe('@custom-variant', () => {
     })
 
     test('grouped nested selectors with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant custom-before {
-          & {
-            --has-before: 1;
-            &::before {
-              &:hover,
-              &:focus {
-                @slot;
+      expect(
+        await compileCss(
+          css`
+            @custom-variant custom-before {
+              & {
+                --has-before: 1;
+                &::before {
+                  &:hover,
+                  &:focus {
+                    @slot;
+                  }
+                }
               }
             }
-          }
-        }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['custom-before:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['custom-before:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           .custom-before\\:underline {
@@ -4373,26 +4409,28 @@ describe('@custom-variant', () => {
     })
 
     test('nested multiple selectors with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant hocus {
-          &:hover {
-            @media (hover: hover) {
-              @slot;
+      expect(
+        await compileCss(
+          css`
+            @custom-variant hocus {
+              &:hover {
+                @media (hover: hover) {
+                  @slot;
+                }
+              }
+
+              &:focus {
+                @slot;
+              }
             }
-          }
 
-          &:focus {
-            @slot;
-          }
-        }
-
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['hocus:underline', 'group-hocus:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['hocus:underline', 'group-hocus:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           @media (hover: hover) {
@@ -4420,22 +4458,24 @@ describe('@custom-variant', () => {
     })
 
     test('selector nested under at-rule with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant hocus {
-          @media (hover: hover) {
-            &:hover {
-              @slot;
+      expect(
+        await compileCss(
+          css`
+            @custom-variant hocus {
+              @media (hover: hover) {
+                &:hover {
+                  @slot;
+                }
+              }
             }
-          }
-        }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['hocus:underline', 'group-hocus:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['hocus:underline', 'group-hocus:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           @media (hover: hover) {
@@ -4449,20 +4489,22 @@ describe('@custom-variant', () => {
     })
 
     test('at-rule with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant any-hover {
-          @media (any-hover: hover) {
-            @slot;
-          }
-        }
+      expect(
+        await compileCss(
+          css`
+            @custom-variant any-hover {
+              @media (any-hover: hover) {
+                @slot;
+              }
+            }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['any-hover:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['any-hover:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           @media (any-hover: hover) {
@@ -4476,24 +4518,26 @@ describe('@custom-variant', () => {
     })
 
     test('multiple at-rules with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant desktop {
-          @media (any-hover: hover) {
-            @slot;
-          }
+      expect(
+        await compileCss(
+          css`
+            @custom-variant desktop {
+              @media (any-hover: hover) {
+                @slot;
+              }
 
-          @media (pointer: fine) {
-            @slot;
-          }
-        }
+              @media (pointer: fine) {
+                @slot;
+              }
+            }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['desktop:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['desktop:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           @media (any-hover: hover) {
@@ -4513,26 +4557,28 @@ describe('@custom-variant', () => {
     })
 
     test('nested at-rules with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant custom-variant {
-          @media (orientation: landscape) {
-            @media screen {
-              @slot;
+      expect(
+        await compileCss(
+          css`
+            @custom-variant custom-variant {
+              @media (orientation: landscape) {
+                @media screen {
+                  @slot;
+                }
+
+                @media print {
+                  display: none;
+                }
+              }
             }
 
-            @media print {
-              display: none;
+            @layer utilities {
+              @tailwind utilities;
             }
-          }
-        }
-
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['custom-variant:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          `,
+          ['custom-variant:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           @media (orientation: landscape) {
@@ -4554,23 +4600,25 @@ describe('@custom-variant', () => {
     })
 
     test('at-rule and selector with @slot', async () => {
-      let { build } = await compile(css`
-        @custom-variant custom-dark {
-          @media (prefers-color-scheme: dark) {
-            @slot;
-          }
-          &:is(.dark *) {
-            @slot;
-          }
-        }
+      expect(
+        await compileCss(
+          css`
+            @custom-variant custom-dark {
+              @media (prefers-color-scheme: dark) {
+                @slot;
+              }
+              &:is(.dark *) {
+                @slot;
+              }
+            }
 
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `)
-      let compiled = build(['custom-dark:underline'])
-
-      expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+            @layer utilities {
+              @tailwind utilities;
+            }
+          `,
+          ['custom-dark:underline'],
+        ),
+      ).toMatchInlineSnapshot(`
         "
         @layer utilities {
           @media (prefers-color-scheme: dark) {
@@ -4968,22 +5016,24 @@ describe('@utility', () => {
   })
 
   test('@utility can handle escape sequences correctly', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @utility push-1\/2 {
-        right: 50%;
-      }
+          @utility push-1\/2 {
+            right: 50%;
+          }
 
-      @utility push-50\% {
-        right: 50%;
-      }
-    `)
-    let compiled = build(['push-1/2', 'push-50%'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility push-50\% {
+            right: 50%;
+          }
+        `,
+        ['push-1/2', 'push-50%'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .push-1\\/2, .push-50\\% {
@@ -5057,32 +5107,31 @@ describe('@utility', () => {
 })
 
 test('addBase', async () => {
-  let { build } = await compile(
-    css`
-      @plugin "my-plugin";
-      @layer base, utilities;
-      @layer utilities {
-        @tailwind utilities;
-      }
-    `,
-    {
-      loadModule: async () => ({
-        path: '',
-        base: '/root',
-        module: ({ addBase }: PluginAPI) => {
-          addBase({
-            body: {
-              'font-feature-settings': '"tnum"',
-            },
-          })
-        },
-      }),
-    },
-  )
-
-  let compiled = build(['underline'])
-
-  expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @plugin "my-plugin";
+        @layer base, utilities;
+        @layer utilities {
+          @tailwind utilities;
+        }
+      `,
+      ['underline'],
+      {
+        loadModule: async () => ({
+          path: '',
+          base: '/root',
+          module: ({ addBase }: PluginAPI) => {
+            addBase({
+              body: {
+                'font-feature-settings': '"tnum"',
+              },
+            })
+          },
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     @layer base {
       body {
@@ -5100,33 +5149,32 @@ test('addBase', async () => {
 })
 
 test('JS APIs support @variant', async () => {
-  let { build } = await compile(
-    css`
-      @plugin "my-plugin";
-      @layer base, utilities;
-      @layer utilities {
-        @tailwind utilities;
-      }
-    `,
-    {
-      loadModule: async () => ({
-        path: '',
-        base: '/root',
-        module: ({ addBase, addUtilities, matchUtilities }: PluginAPI) => {
-          addBase({ body: { '@variant dark': { color: 'red' } } })
-          addUtilities({ '.foo': { '@variant dark': { '--foo': 'foo' } } })
-          matchUtilities(
-            { bar: (value) => ({ '@variant dark': { '--bar': value } }) },
-            { values: { one: '1' } },
-          )
-        },
-      }),
-    },
-  )
-
-  let compiled = build(['underline', 'foo', 'bar-one'])
-
-  expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @plugin "my-plugin";
+        @layer base, utilities;
+        @layer utilities {
+          @tailwind utilities;
+        }
+      `,
+      ['underline', 'foo', 'bar-one'],
+      {
+        loadModule: async () => ({
+          path: '',
+          base: '/root',
+          module: ({ addBase, addUtilities, matchUtilities }: PluginAPI) => {
+            addBase({ body: { '@variant dark': { color: 'red' } } })
+            addUtilities({ '.foo': { '@variant dark': { '--foo': 'foo' } } })
+            matchUtilities(
+              { bar: (value) => ({ '@variant dark': { '--bar': value } }) },
+              { values: { one: '1' } },
+            )
+          },
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     @layer base {
       @media (prefers-color-scheme: dark) {
@@ -5235,35 +5283,36 @@ describe('`@reference "…" imports`', () => {
   })
 
   test('does not generate utilities', async () => {
-    let loadStylesheet = async (id: string, base = '/root/foo') => {
-      if (id === './foo/baz.css') {
-        return {
-          base,
-          path: '',
-          content: css`
-            @layer utilities {
-              @tailwind utilities;
-            }
-          `,
-        }
-      }
-      return {
-        path: '',
-        base: '/root/foo',
-        content: css`
-          @import './foo/baz.css';
+    expect(
+      await compileCss(
+        css`
+          @reference './foo/bar.css';
         `,
-      }
-    }
-
-    let { build } = await compile(
-      css`
-        @reference './foo/bar.css';
-      `,
-      { loadStylesheet },
-    )
-
-    expect(build(['text-underline', 'border'])).toEqual('')
+        ['text-underline', 'border'],
+        {
+          loadStylesheet: async (id: string, base = '/root/foo') => {
+            if (id === './foo/baz.css') {
+              return {
+                base,
+                path: '',
+                content: css`
+                  @layer utilities {
+                    @tailwind utilities;
+                  }
+                `,
+              }
+            }
+            return {
+              path: '',
+              base: '/root/foo',
+              content: css`
+                @import './foo/baz.css';
+              `,
+            }
+          },
+        },
+      ),
+    ).toEqual('')
   })
 
   test('removes all @keyframes, even those contributed by JavasScript plugins', async () => {

--- a/packages/tailwindcss/src/plugin.test.ts
+++ b/packages/tailwindcss/src/plugin.test.ts
@@ -1,30 +1,31 @@
 import { expect, test } from 'vitest'
-import { compile } from '.'
 import plugin from './plugin'
-import { pretty } from './test-utils/run'
+import { compileCss } from './test-utils/run'
 
 const css = String.raw
 
 test('plugin', async () => {
-  let input = css`
-    @plugin "my-plugin";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: plugin(function ({ addBase }) {
-        addBase({
-          body: {
-            margin: '0',
-          },
-        })
-      }),
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @plugin "my-plugin";
+      `,
+      [],
+      {
+        loadModule: async () => ({
+          module: plugin(function ({ addBase }) {
+            addBase({
+              body: {
+                margin: '0',
+              },
+            })
+          }),
+          base: '/root',
+          path: '',
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     @layer base {
       body {
@@ -36,27 +37,29 @@ test('plugin', async () => {
 })
 
 test('plugin.withOptions', async () => {
-  let input = css`
-    @plugin "my-plugin";
-  `
-
-  let compiler = await compile(input, {
-    loadModule: async () => ({
-      module: plugin.withOptions(function (opts = { foo: '1px' }) {
-        return function ({ addBase }) {
-          addBase({
-            body: {
-              margin: opts.foo,
-            },
-          })
-        }
-      }),
-      base: '/root',
-      path: '',
-    }),
-  })
-
-  expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @plugin "my-plugin";
+      `,
+      [],
+      {
+        loadModule: async () => ({
+          module: plugin.withOptions(function (opts = { foo: '1px' }) {
+            return function ({ addBase }) {
+              addBase({
+                body: {
+                  margin: opts.foo,
+                },
+              })
+            }
+          }),
+          base: '/root',
+          path: '',
+        }),
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     @layer base {
       body {

--- a/packages/tailwindcss/src/plugin.test.ts
+++ b/packages/tailwindcss/src/plugin.test.ts
@@ -1,13 +1,12 @@
 import { expect, test } from 'vitest'
 import plugin from './plugin'
-import { run } from './test-utils/run'
+import { compileCss } from './test-utils/run'
 
 const css = String.raw
 
 test('plugin', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @plugin "my-plugin";
       `,
@@ -38,8 +37,7 @@ test('plugin', async () => {
 
 test('plugin.withOptions', async () => {
   expect(
-    await run(
-      [],
+    await compileCss(
       css`
         @plugin "my-plugin";
       `,

--- a/packages/tailwindcss/src/plugin.test.ts
+++ b/packages/tailwindcss/src/plugin.test.ts
@@ -1,16 +1,16 @@
 import { expect, test } from 'vitest'
 import plugin from './plugin'
-import { compileCss } from './test-utils/run'
+import { run } from './test-utils/run'
 
 const css = String.raw
 
 test('plugin', async () => {
   expect(
-    await compileCss(
+    await run(
+      [],
       css`
         @plugin "my-plugin";
       `,
-      [],
       {
         loadModule: async () => ({
           module: plugin(function ({ addBase }) {
@@ -38,11 +38,11 @@ test('plugin', async () => {
 
 test('plugin.withOptions', async () => {
   expect(
-    await compileCss(
+    await run(
+      [],
       css`
         @plugin "my-plugin";
       `,
-      [],
       {
         loadModule: async () => ({
           module: plugin.withOptions(function (opts = { foo: '1px' }) {

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -1,82 +1,79 @@
 import { expect, test } from 'vitest'
 import { compile } from '.'
 import plugin from './plugin'
-import { pretty } from './test-utils/run'
+import { compileCss } from './test-utils/run'
 
 const css = String.raw
 
 test('utilities must be prefixed', async () => {
-  let input = css`
-    @theme reference prefix(tw);
-    @tailwind utilities;
-
-    @utility custom {
-      color: red;
-    }
-  `
-
-  let compiler = await compile(input)
-
   // Prefixed utilities are generated
   expect(
-    pretty(
-      compiler.build([
+    await compileCss(
+      css`
+        @theme reference prefix(tw);
+        @tailwind utilities;
+
+        @utility custom {
+          color: red;
+        }
+      `,
+      [
         'tw:underline',
         'tw:hover:line-through',
         'tw:custom',
         'tw:group-hover:flex',
         'tw:peer-hover:flex',
-      ]),
+      ],
     ),
   ).toMatchInlineSnapshot(`
     "
     .tw\\:custom {
       color: red;
     }
+
     .tw\\:underline {
       text-decoration-line: underline;
     }
-    .tw\\:group-hover\\:flex {
-      &:is(:where(.tw\\:group):hover *) {
-        @media (hover: hover) {
-          display: flex;
-        }
+
+    @media (hover: hover) {
+      .tw\\:group-hover\\:flex:is(:where(.tw\\:group):hover *), .tw\\:peer-hover\\:flex:is(:where(.tw\\:peer):hover ~ *) {
+        display: flex;
       }
-    }
-    .tw\\:peer-hover\\:flex {
-      &:is(:where(.tw\\:peer):hover ~ *) {
-        @media (hover: hover) {
-          display: flex;
-        }
-      }
-    }
-    .tw\\:hover\\:line-through {
-      &:hover {
-        @media (hover: hover) {
-          text-decoration-line: line-through;
-        }
+
+      .tw\\:hover\\:line-through:hover {
+        text-decoration-line: line-through;
       }
     }
     "
   `)
 
   // Non-prefixed utilities are ignored
-  compiler = await compile(input)
+  expect(
+    await compileCss(
+      css`
+        @theme reference prefix(tw);
+        @tailwind utilities;
 
-  expect(compiler.build(['underline', 'hover:line-through', 'custom'])).toEqual('')
+        @utility custom {
+          color: red;
+        }
+      `,
+      ['underline', 'hover:line-through', 'custom'],
+    ),
+  ).toEqual('')
 })
 
 test('utilities used in @apply must be prefixed', async () => {
-  let compiler = await compile(css`
-    @theme reference prefix(tw);
-
-    .my-underline {
-      @apply tw:underline;
-    }
-  `)
-
   // Prefixed utilities are generated
-  expect(pretty(compiler.build([]))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(css`
+      @theme reference prefix(tw);
+
+      .my-underline {
+        @apply tw:underline;
+      }
+    `),
+  ).toMatchInlineSnapshot(`
     "
     .my-underline {
       text-decoration-line: underline;
@@ -99,22 +96,26 @@ test('utilities used in @apply must be prefixed', async () => {
 })
 
 test('CSS variables output by the theme are prefixed', async () => {
-  let compiler = await compile(css`
-    @theme prefix(tw) {
-      --color-red: #f00;
-      --color-green: #0f0;
-      --breakpoint-sm: 640px;
-    }
-
-    @tailwind utilities;
-  `)
-
   // Prefixed utilities are generated
-  expect(pretty(compiler.build(['tw:text-red']))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @theme prefix(tw) {
+          --color-red: #f00;
+          --color-green: #0f0;
+          --breakpoint-sm: 640px;
+        }
+
+        @tailwind utilities;
+      `,
+      ['tw:text-red'],
+    ),
+  ).toMatchInlineSnapshot(`
     "
     :root, :host {
-      --tw-color-red: #f00;
+      --tw-color-red: red;
     }
+
     .tw\\:text-red {
       color: var(--tw-color-red);
     }
@@ -123,80 +124,81 @@ test('CSS variables output by the theme are prefixed', async () => {
 })
 
 test('CSS theme functions do not use the prefix', async () => {
-  let compiler = await compile(css`
-    @theme prefix(tw) {
-      --color-red: #f00;
-      --color-green: #0f0;
-      --breakpoint-sm: 640px;
+  expect(
+    await compileCss(
+      css`
+        @theme prefix(tw) {
+          --color-red: #f00;
+          --color-green: #0f0;
+          --breakpoint-sm: 640px;
+        }
+
+        @tailwind utilities;
+      `,
+      ['tw:[color:theme(--color-red)]', 'tw:text-[theme(--color-red)]'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    .tw\\:\\[color\\:theme\\(--color-red\\)\\], .tw\\:text-\\[theme\\(--color-red\\)\\] {
+      color: red;
     }
-
-    @tailwind utilities;
-  `)
-
-  expect(pretty(compiler.build(['tw:[color:theme(--color-red)]', 'tw:text-[theme(--color-red)]'])))
-    .toMatchInlineSnapshot(`
-      "
-      .tw\\:\\[color\\:theme\\(--color-red\\)\\] {
-        color: #f00;
-      }
-      .tw\\:text-\\[theme\\(--color-red\\)\\] {
-        color: #f00;
-      }
-      "
-    `)
-
-  compiler = await compile(css`
-    @theme reference prefix(tw) {
-      --color-red: #f00;
-      --color-green: #0f0;
-      --breakpoint-sm: 640px;
-    }
-
-    @tailwind utilities;
+    "
   `)
 
   expect(
-    compiler.build(['tw:[color:theme(--tw-color-red)]', 'tw:text-[theme(--tw-color-red)]']),
+    await compileCss(
+      css`
+        @theme reference prefix(tw) {
+          --color-red: #f00;
+          --color-green: #0f0;
+          --breakpoint-sm: 640px;
+        }
+
+        @tailwind utilities;
+      `,
+      ['tw:[color:theme(--tw-color-red)]', 'tw:text-[theme(--tw-color-red)]'],
+    ),
   ).toEqual('')
 })
 
 test('JS theme functions do not use the prefix', async () => {
-  let compiler = await compile(
-    css`
-      @theme prefix(tw) {
-        --color-red: #f00;
-        --color-green: #0f0;
-        --breakpoint-sm: 640px;
-      }
-
-      @plugin "./plugin.js";
-
-      @tailwind utilities;
-    `,
-    {
-      async loadModule(id, base) {
-        return {
-          path: '',
-          base,
-          module: plugin(({ addUtilities, theme }) => {
-            addUtilities({
-              '.my-custom': {
-                color: theme('--color-red'),
-              },
-            })
-
-            // The theme function does not use the prefix
-            expect(theme('--tw-color-red')).toEqual(undefined)
-          }),
+  expect(
+    await compileCss(
+      css`
+        @theme prefix(tw) {
+          --color-red: #f00;
+          --color-green: #0f0;
+          --breakpoint-sm: 640px;
         }
-      },
-    },
-  )
 
-  expect(pretty(compiler.build(['tw:my-custom']))).toMatchInlineSnapshot(`
+        @plugin "./plugin.js";
+
+        @tailwind utilities;
+      `,
+      ['tw:my-custom'],
+      {
+        async loadModule(_id, base) {
+          return {
+            path: '',
+            base,
+            module: plugin(({ addUtilities, theme }) => {
+              addUtilities({
+                '.my-custom': {
+                  color: theme('--color-red'),
+                },
+              })
+
+              // The theme function does not use the prefix
+              expect(theme('--tw-color-red')).toEqual(undefined)
+            }),
+          }
+        },
+      },
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .tw\\:my-custom {
-      color: #f00;
+      color: red;
     }
     "
   `)
@@ -212,69 +214,63 @@ test('a prefix can be configured via @import theme(…)', async () => {
     }
   `
 
-  let compiler = await compile(input, {
-    async loadStylesheet(id, base) {
-      return {
-        path: '',
-        base,
-        content: css`
-          @theme {
-            --color-potato: #7a4724;
-          }
-        `,
-      }
-    },
-  })
-
   // Prefixed utilities are generated
   expect(
-    pretty(
-      compiler.build([
-        'tw:underline',
-        'tw:bg-potato',
-        'tw:hover:line-through',
-        'tw:custom',
-        'flex',
-        'text-potato',
-      ]),
+    await compileCss(
+      input,
+      ['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom', 'flex', 'text-potato'],
+      {
+        async loadStylesheet(_id, base) {
+          return {
+            path: '',
+            base,
+            content: css`
+              @theme {
+                --color-potato: #7a4724;
+              }
+            `,
+          }
+        },
+      },
     ),
   ).toMatchInlineSnapshot(`
     "
     .tw\\:bg-potato {
       background-color: var(--tw-color-potato, #7a4724);
     }
+
     .tw\\:custom {
       color: red;
     }
+
     .tw\\:underline {
       text-decoration-line: underline;
     }
-    .tw\\:hover\\:line-through {
-      &:hover {
-        @media (hover: hover) {
-          text-decoration-line: line-through;
-        }
+
+    @media (hover: hover) {
+      .tw\\:hover\\:line-through:hover {
+        text-decoration-line: line-through;
       }
     }
     "
   `)
 
   // Non-prefixed utilities are ignored
-  compiler = await compile(input, {
-    async loadStylesheet(id, base) {
-      return {
-        path: '',
-        base,
-        content: css`
-          @theme {
-            --color-potato: #7a4724;
-          }
-        `,
-      }
-    },
-  })
-
-  expect(compiler.build(['underline', 'hover:line-through', 'custom'])).toEqual('')
+  expect(
+    await compileCss(input, ['underline', 'hover:line-through', 'custom'], {
+      async loadStylesheet(_id, base) {
+        return {
+          path: '',
+          base,
+          content: css`
+            @theme {
+              --color-potato: #7a4724;
+            }
+          `,
+        }
+      },
+    }),
+  ).toEqual('')
 })
 
 test('a prefix can be configured via @import prefix(…)', async () => {
@@ -286,64 +282,68 @@ test('a prefix can be configured via @import prefix(…)', async () => {
     }
   `
 
-  let compiler = await compile(input, {
-    async loadStylesheet(id, base) {
-      return {
-        path: '',
-        base,
-        content: css`
-          @theme {
-            --color-potato: #7a4724;
-          }
-          @tailwind utilities;
-        `,
-      }
-    },
-  })
-
   expect(
-    pretty(compiler.build(['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom'])),
-  ).toMatchInlineSnapshot(`
-      "
-      :root, :host {
-        --tw-color-potato: #7a4724;
-      }
-      .tw\\:bg-potato {
-        background-color: var(--tw-color-potato);
-      }
-      .tw\\:custom {
-        color: red;
-      }
-      .tw\\:underline {
-        text-decoration-line: underline;
-      }
-      .tw\\:hover\\:line-through {
-        &:hover {
-          @media (hover: hover) {
-            text-decoration-line: line-through;
+    await compileCss(
+      input,
+      ['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom'],
+      {
+        async loadStylesheet(_id, base) {
+          return {
+            path: '',
+            base,
+            content: css`
+              @theme {
+                --color-potato: #7a4724;
+              }
+              @tailwind utilities;
+            `,
           }
-        }
+        },
+      },
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    :root, :host {
+      --tw-color-potato: #7a4724;
+    }
+
+    .tw\\:bg-potato {
+      background-color: var(--tw-color-potato);
+    }
+
+    .tw\\:custom {
+      color: red;
+    }
+
+    .tw\\:underline {
+      text-decoration-line: underline;
+    }
+
+    @media (hover: hover) {
+      .tw\\:hover\\:line-through:hover {
+        text-decoration-line: line-through;
       }
-      "
-    `)
+    }
+    "
+  `)
 
   // Non-prefixed utilities are ignored
-  compiler = await compile(input, {
-    async loadStylesheet(id, base) {
-      return {
-        path: '',
-        base,
-        content: css`
-          @theme {
-            --color-potato: #7a4724;
-          }
-          @tailwind utilities;
-        `,
-      }
-    },
-  })
-
-  expect(compiler.build(['underline', 'hover:line-through', 'custom'])).toEqual('')
+  expect(
+    await compileCss(input, ['underline', 'hover:line-through', 'custom'], {
+      async loadStylesheet(_id, base) {
+        return {
+          path: '',
+          base,
+          content: css`
+            @theme {
+              --color-potato: #7a4724;
+            }
+            @tailwind utilities;
+          `,
+        }
+      },
+    }),
+  ).toEqual('')
 })
 
 test('a prefix must be letters only', async () => {
@@ -357,14 +357,15 @@ test('a prefix must be letters only', async () => {
 })
 
 test('a candidate matching the prefix does not crash', async () => {
-  let input = css`
-    @theme reference prefix(tomato);
-    @tailwind utilities;
-  `
-
-  let compiler = await compile(input)
-
-  expect(pretty(compiler.build(['tomato', 'tomato:flex']))).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @theme reference prefix(tomato);
+        @tailwind utilities;
+      `,
+      ['tomato', 'tomato:flex'],
+    ),
+  ).toMatchInlineSnapshot(`
     "
     .tomato\\:flex {
       display: flex;

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -1,14 +1,21 @@
 import { expect, test } from 'vitest'
 import { compile } from '.'
 import plugin from './plugin'
-import { compileCss } from './test-utils/run'
+import { compileCss, run } from './test-utils/run'
 
 const css = String.raw
 
 test('utilities must be prefixed', async () => {
   // Prefixed utilities are generated
   expect(
-    await compileCss(
+    await run(
+      [
+        'tw:underline',
+        'tw:hover:line-through',
+        'tw:custom',
+        'tw:group-hover:flex',
+        'tw:peer-hover:flex',
+      ],
       css`
         @theme reference prefix(tw);
         @tailwind utilities;
@@ -17,13 +24,6 @@ test('utilities must be prefixed', async () => {
           color: red;
         }
       `,
-      [
-        'tw:underline',
-        'tw:hover:line-through',
-        'tw:custom',
-        'tw:group-hover:flex',
-        'tw:peer-hover:flex',
-      ],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -49,7 +49,8 @@ test('utilities must be prefixed', async () => {
 
   // Non-prefixed utilities are ignored
   expect(
-    await compileCss(
+    await run(
+      ['underline', 'hover:line-through', 'custom'],
       css`
         @theme reference prefix(tw);
         @tailwind utilities;
@@ -58,7 +59,6 @@ test('utilities must be prefixed', async () => {
           color: red;
         }
       `,
-      ['underline', 'hover:line-through', 'custom'],
     ),
   ).toEqual('')
 })
@@ -98,7 +98,8 @@ test('utilities used in @apply must be prefixed', async () => {
 test('CSS variables output by the theme are prefixed', async () => {
   // Prefixed utilities are generated
   expect(
-    await compileCss(
+    await run(
+      ['tw:text-red'],
       css`
         @theme prefix(tw) {
           --color-red: #f00;
@@ -108,7 +109,6 @@ test('CSS variables output by the theme are prefixed', async () => {
 
         @tailwind utilities;
       `,
-      ['tw:text-red'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -125,7 +125,8 @@ test('CSS variables output by the theme are prefixed', async () => {
 
 test('CSS theme functions do not use the prefix', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['tw:[color:theme(--color-red)]', 'tw:text-[theme(--color-red)]'],
       css`
         @theme prefix(tw) {
           --color-red: #f00;
@@ -135,7 +136,6 @@ test('CSS theme functions do not use the prefix', async () => {
 
         @tailwind utilities;
       `,
-      ['tw:[color:theme(--color-red)]', 'tw:text-[theme(--color-red)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -146,7 +146,8 @@ test('CSS theme functions do not use the prefix', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['tw:[color:theme(--tw-color-red)]', 'tw:text-[theme(--tw-color-red)]'],
       css`
         @theme reference prefix(tw) {
           --color-red: #f00;
@@ -156,14 +157,14 @@ test('CSS theme functions do not use the prefix', async () => {
 
         @tailwind utilities;
       `,
-      ['tw:[color:theme(--tw-color-red)]', 'tw:text-[theme(--tw-color-red)]'],
     ),
   ).toEqual('')
 })
 
 test('JS theme functions do not use the prefix', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['tw:my-custom'],
       css`
         @theme prefix(tw) {
           --color-red: #f00;
@@ -175,7 +176,6 @@ test('JS theme functions do not use the prefix', async () => {
 
         @tailwind utilities;
       `,
-      ['tw:my-custom'],
       {
         async loadModule(_id, base) {
           return {
@@ -216,9 +216,9 @@ test('a prefix can be configured via @import theme(…)', async () => {
 
   // Prefixed utilities are generated
   expect(
-    await compileCss(
-      input,
+    await run(
       ['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom', 'flex', 'text-potato'],
+      input,
       {
         async loadStylesheet(_id, base) {
           return {
@@ -257,7 +257,7 @@ test('a prefix can be configured via @import theme(…)', async () => {
 
   // Non-prefixed utilities are ignored
   expect(
-    await compileCss(input, ['underline', 'hover:line-through', 'custom'], {
+    await run(['underline', 'hover:line-through', 'custom'], input, {
       async loadStylesheet(_id, base) {
         return {
           path: '',
@@ -283,24 +283,20 @@ test('a prefix can be configured via @import prefix(…)', async () => {
   `
 
   expect(
-    await compileCss(
-      input,
-      ['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom'],
-      {
-        async loadStylesheet(_id, base) {
-          return {
-            path: '',
-            base,
-            content: css`
-              @theme {
-                --color-potato: #7a4724;
-              }
-              @tailwind utilities;
-            `,
-          }
-        },
+    await run(['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom'], input, {
+      async loadStylesheet(_id, base) {
+        return {
+          path: '',
+          base,
+          content: css`
+            @theme {
+              --color-potato: #7a4724;
+            }
+            @tailwind utilities;
+          `,
+        }
       },
-    ),
+    }),
   ).toMatchInlineSnapshot(`
     "
     :root, :host {
@@ -329,7 +325,7 @@ test('a prefix can be configured via @import prefix(…)', async () => {
 
   // Non-prefixed utilities are ignored
   expect(
-    await compileCss(input, ['underline', 'hover:line-through', 'custom'], {
+    await run(['underline', 'hover:line-through', 'custom'], input, {
       async loadStylesheet(_id, base) {
         return {
           path: '',
@@ -358,12 +354,12 @@ test('a prefix must be letters only', async () => {
 
 test('a candidate matching the prefix does not crash', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['tomato', 'tomato:flex'],
       css`
         @theme reference prefix(tomato);
         @tailwind utilities;
       `,
-      ['tomato', 'tomato:flex'],
     ),
   ).toMatchInlineSnapshot(`
     "

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -6,6 +6,15 @@ import { compileCss, run } from './test-utils/run'
 const css = String.raw
 
 test('utilities must be prefixed', async () => {
+  let input = css`
+    @theme reference prefix(tw);
+    @tailwind utilities;
+
+    @utility custom {
+      color: red;
+    }
+  `
+
   // Prefixed utilities are generated
   expect(
     await run(
@@ -16,14 +25,7 @@ test('utilities must be prefixed', async () => {
         'tw:group-hover:flex',
         'tw:peer-hover:flex',
       ],
-      css`
-        @theme reference prefix(tw);
-        @tailwind utilities;
-
-        @utility custom {
-          color: red;
-        }
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -48,19 +50,7 @@ test('utilities must be prefixed', async () => {
   `)
 
   // Non-prefixed utilities are ignored
-  expect(
-    await run(
-      ['underline', 'hover:line-through', 'custom'],
-      css`
-        @theme reference prefix(tw);
-        @tailwind utilities;
-
-        @utility custom {
-          color: red;
-        }
-      `,
-    ),
-  ).toEqual('')
+  expect(await run(['underline', 'hover:line-through', 'custom'], input)).toEqual('')
 })
 
 test('utilities used in @apply must be prefixed', async () => {
@@ -214,24 +204,26 @@ test('a prefix can be configured via @import theme(…)', async () => {
     }
   `
 
+  let options = {
+    async loadStylesheet(_id, base) {
+      return {
+        path: '',
+        base,
+        content: css`
+          @theme {
+            --color-potato: #7a4724;
+          }
+        `,
+      }
+    },
+  }
+
   // Prefixed utilities are generated
   expect(
     await run(
       ['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom', 'flex', 'text-potato'],
       input,
-      {
-        async loadStylesheet(_id, base) {
-          return {
-            path: '',
-            base,
-            content: css`
-              @theme {
-                --color-potato: #7a4724;
-              }
-            `,
-          }
-        },
-      },
+      options,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -256,21 +248,7 @@ test('a prefix can be configured via @import theme(…)', async () => {
   `)
 
   // Non-prefixed utilities are ignored
-  expect(
-    await run(['underline', 'hover:line-through', 'custom'], input, {
-      async loadStylesheet(_id, base) {
-        return {
-          path: '',
-          base,
-          content: css`
-            @theme {
-              --color-potato: #7a4724;
-            }
-          `,
-        }
-      },
-    }),
-  ).toEqual('')
+  expect(await run(['underline', 'hover:line-through', 'custom'], input, options)).toEqual('')
 })
 
 test('a prefix can be configured via @import prefix(…)', async () => {
@@ -282,21 +260,27 @@ test('a prefix can be configured via @import prefix(…)', async () => {
     }
   `
 
+  let options = {
+    async loadStylesheet(_id, base) {
+      return {
+        path: '',
+        base,
+        content: css`
+          @theme {
+            --color-potato: #7a4724;
+          }
+          @tailwind utilities;
+        `,
+      }
+    },
+  }
+
   expect(
-    await run(['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom'], input, {
-      async loadStylesheet(_id, base) {
-        return {
-          path: '',
-          base,
-          content: css`
-            @theme {
-              --color-potato: #7a4724;
-            }
-            @tailwind utilities;
-          `,
-        }
-      },
-    }),
+    await run(
+      ['tw:underline', 'tw:bg-potato', 'tw:hover:line-through', 'tw:custom'],
+      input,
+      options,
+    ),
   ).toMatchInlineSnapshot(`
     "
     :root, :host {
@@ -324,22 +308,7 @@ test('a prefix can be configured via @import prefix(…)', async () => {
   `)
 
   // Non-prefixed utilities are ignored
-  expect(
-    await run(['underline', 'hover:line-through', 'custom'], input, {
-      async loadStylesheet(_id, base) {
-        return {
-          path: '',
-          base,
-          content: css`
-            @theme {
-              --color-potato: #7a4724;
-            }
-            @tailwind utilities;
-          `,
-        }
-      },
-    }),
-  ).toEqual('')
+  expect(await run(['underline', 'hover:line-through', 'custom'], input, options)).toEqual('')
 })
 
 test('a prefix must be letters only', async () => {

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -204,7 +204,7 @@ test('a prefix can be configured via @import theme(…)', async () => {
     }
   `
 
-  let options = {
+  let options: Partial<Parameters<typeof compile>[1]> = {
     async loadStylesheet(_id, base) {
       return {
         path: '',
@@ -260,7 +260,7 @@ test('a prefix can be configured via @import prefix(…)', async () => {
     }
   `
 
-  let options = {
+  let options: Partial<Parameters<typeof compile>[1]> = {
     async loadStylesheet(_id, base) {
       return {
         path: '',

--- a/packages/tailwindcss/src/test-utils/run.ts
+++ b/packages/tailwindcss/src/test-utils/run.ts
@@ -3,11 +3,6 @@ import { optimize } from '../../../@tailwindcss-node/src/optimize'
 
 const css = String.raw
 
-export async function compileCss(css: string, options: Parameters<typeof compile>[1] = {}) {
-  let { build } = await compile(css, options)
-  return pretty(optimize(build([])).code)
-}
-
 export async function run(
   candidates: string[],
   input = css`
@@ -17,6 +12,10 @@ export async function run(
 ) {
   let { build } = await compile(input, options)
   return pretty(optimize(build(candidates)).code)
+}
+
+export async function compileCss(css: string, options: Parameters<typeof compile>[1] = {}) {
+  return run([], css, options)
 }
 
 export function pretty(input: string) {

--- a/packages/tailwindcss/src/test-utils/run.ts
+++ b/packages/tailwindcss/src/test-utils/run.ts
@@ -3,13 +3,9 @@ import { optimize } from '../../../@tailwindcss-node/src/optimize'
 
 const css = String.raw
 
-export async function compileCss(
-  css: string,
-  candidates: string[] = [],
-  options: Parameters<typeof compile>[1] = {},
-) {
+export async function compileCss(css: string, options: Parameters<typeof compile>[1] = {}) {
   let { build } = await compile(css, options)
-  return pretty(optimize(build(candidates)).code)
+  return pretty(optimize(build([])).code)
 }
 
 export async function run(

--- a/packages/tailwindcss/src/test-utils/run.ts
+++ b/packages/tailwindcss/src/test-utils/run.ts
@@ -1,6 +1,8 @@
 import { compile } from '..'
 import { optimize } from '../../../@tailwindcss-node/src/optimize'
 
+const css = String.raw
+
 export async function compileCss(
   css: string,
   candidates: string[] = [],
@@ -10,8 +12,14 @@ export async function compileCss(
   return pretty(optimize(build(candidates)).code)
 }
 
-export async function run(candidates: string[]) {
-  let { build } = await compile('@tailwind utilities;')
+export async function run(
+  candidates: string[],
+  input = css`
+    @tailwind utilities;
+  `,
+  options: Parameters<typeof compile>[1] = {},
+) {
+  let { build } = await compile(input, options)
   return pretty(optimize(build(candidates)).code)
 }
 

--- a/packages/tailwindcss/src/test-utils/run.ts
+++ b/packages/tailwindcss/src/test-utils/run.ts
@@ -23,10 +23,6 @@ export async function run(
   return pretty(optimize(build(candidates)).code)
 }
 
-export function optimizeCss(input: string) {
-  return pretty(optimize(input).code)
-}
-
 export function pretty(input: string) {
   input = input.trim()
   if (input === '') return ''

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile } from '.'
-import { run } from './test-utils/run'
+import { compileCss, run } from './test-utils/run'
 import { isValidFunctionalUtilityName, isValidStaticUtilityName } from './utilities'
 
 const css = String.raw
@@ -29531,7 +29531,7 @@ describe('custom utilities', () => {
     `
 
     // `foo` is not used yet:
-    expect(await run([], input)).toMatchInlineSnapshot(`
+    expect(await compileCss(input)).toMatchInlineSnapshot(`
       "
       @layer utilities;
       "

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile } from '.'
-import { compileCss, optimizeCss, run } from './test-utils/run'
+import { compileCss, run } from './test-utils/run'
 import { isValidFunctionalUtilityName, isValidStaticUtilityName } from './utilities'
 
 const css = String.raw
@@ -29302,16 +29302,18 @@ test('@container', async () => {
 
 describe('spacing utilities', () => {
   test('`--spacing: initial` disables the spacing multiplier', async () => {
-    let { build } = await compile(css`
-      @theme {
-        --spacing: initial;
-        --spacing-4: 1rem;
-      }
-      @tailwind utilities;
-    `)
-    let compiled = build(['px-1', 'px-4'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @theme {
+            --spacing: initial;
+            --spacing-4: 1rem;
+          }
+          @tailwind utilities;
+        `,
+        ['px-1', 'px-4'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --spacing-4: 1rem;
@@ -29325,16 +29327,18 @@ describe('spacing utilities', () => {
   })
 
   test('`--spacing-*: initial` disables the spacing multiplier', async () => {
-    let { build } = await compile(css`
-      @theme {
-        --spacing-*: initial;
-        --spacing-4: 1rem;
-      }
-      @tailwind utilities;
-    `)
-    let compiled = build(['px-1', 'px-4'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @theme {
+            --spacing-*: initial;
+            --spacing-4: 1rem;
+          }
+          @tailwind utilities;
+        `,
+        ['px-1', 'px-4'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --spacing-4: 1rem;
@@ -29348,15 +29352,17 @@ describe('spacing utilities', () => {
   })
 
   test('only multiples of 0.25 with no trailing zeroes are supported with the spacing multiplier', async () => {
-    let { build } = await compile(css`
-      @theme {
-        --spacing: 4px;
-      }
-      @tailwind utilities;
-    `)
-    let compiled = build(['px-0.25', 'px-1.5', 'px-2.75', 'px-0.375', 'px-2.50', 'px-.75'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @theme {
+            --spacing: 4px;
+          }
+          @tailwind utilities;
+        `,
+        ['px-0.25', 'px-1.5', 'px-2.75', 'px-0.375', 'px-2.50', 'px-.75'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --spacing: 4px;
@@ -29378,28 +29384,32 @@ describe('spacing utilities', () => {
   })
 
   test('spacing utilities must have a value', async () => {
-    let { build } = await compile(css`
-      @theme reference {
-        --spacing: 4px;
-      }
-      @tailwind utilities;
-    `)
-    let compiled = build(['px'])
-
-    expect(optimizeCss(compiled)).toEqual('')
+    expect(
+      await compileCss(
+        css`
+          @theme reference {
+            --spacing: 4px;
+          }
+          @tailwind utilities;
+        `,
+        ['px'],
+      ),
+    ).toEqual('')
   })
 
   test('--spacing-* variables take precedence over --container-* variables', async () => {
-    let { build } = await compile(css`
-      @theme {
-        --spacing-sm: 8px;
-        --container-sm: 256px;
-      }
-      @tailwind utilities;
-    `)
-    let compiled = build(['w-sm', 'max-w-sm', 'min-w-sm', 'basis-sm'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss(
+        css`
+          @theme {
+            --spacing-sm: 8px;
+            --container-sm: 256px;
+          }
+          @tailwind utilities;
+        `,
+        ['w-sm', 'max-w-sm', 'min-w-sm', 'basis-sm'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       :root, :host {
         --spacing-sm: 8px;
@@ -29469,23 +29479,25 @@ describe('custom utilities', () => {
   })
 
   test('custom static utility', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @theme reference {
-        --breakpoint-lg: 1024px;
-      }
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
 
-      @utility text-trim {
-        text-box-trim: both;
-        text-box-edge: cap alphabetic;
-      }
-    `)
-    let compiled = build(['text-trim', 'lg:text-trim'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility text-trim {
+            text-box-trim: both;
+            text-box-edge: cap alphabetic;
+          }
+        `,
+        ['text-trim', 'lg:text-trim'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .text-trim {
@@ -29505,7 +29517,7 @@ describe('custom utilities', () => {
   })
 
   test('custom static utility emit CSS variables if the utility is used', async () => {
-    let { build } = await compile(css`
+    let input = css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -29517,19 +29529,17 @@ describe('custom utilities', () => {
       @utility foo {
         value: var(--example-foo);
       }
-    `)
-    let compiled = build([])
+    `
 
     // `foo` is not used yet:
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(await compileCss(input, [])).toMatchInlineSnapshot(`
       "
       @layer utilities;
       "
     `)
 
     // `foo` is used, and the CSS variable is emitted:
-    compiled = build(['foo'])
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+    expect(await compileCss(input, ['foo'])).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo {
@@ -29545,18 +29555,20 @@ describe('custom utilities', () => {
   })
 
   test('custom static utility (negative)', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @utility -example {
-        value: -1;
-      }
-    `)
-    let compiled = build(['-example', 'lg:-example'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility -example {
+            value: -1;
+          }
+        `,
+        ['-example', 'lg:-example'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .-example {
@@ -29568,23 +29580,25 @@ describe('custom utilities', () => {
   })
 
   test('Multiple static utilities are merged', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @utility really-round {
-        --custom-prop: hi;
-        border-radius: 50rem;
-      }
+          @utility really-round {
+            --custom-prop: hi;
+            border-radius: 50rem;
+          }
 
-      @utility really-round {
-        border-radius: 30rem;
-      }
-    `)
-    let compiled = build(['really-round'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility really-round {
+            border-radius: 30rem;
+          }
+        `,
+        ['really-round'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .really-round {
@@ -29597,22 +29611,24 @@ describe('custom utilities', () => {
   })
 
   test('custom utilities support some special characters', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @utility push-1/2 {
-        right: 50%;
-      }
+          @utility push-1/2 {
+            right: 50%;
+          }
 
-      @utility push-50% {
-        right: 50%;
-      }
-    `)
-    let compiled = build(['push-1/2', 'push-50%'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility push-50% {
+            right: 50%;
+          }
+        `,
+        ['push-1/2', 'push-50%'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .push-1\\/2, .push-50\\% {
@@ -29624,25 +29640,27 @@ describe('custom utilities', () => {
   })
 
   test('can override specific versions of a functional utility with a static utility', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @theme reference {
-        --text-sm: 0.875rem;
-        --text-sm--line-height: 1.25rem;
-      }
+          @theme reference {
+            --text-sm: 0.875rem;
+            --text-sm--line-height: 1.25rem;
+          }
 
-      @utility text-sm {
-        font-size: var(--text-sm, 0.8755rem);
-        line-height: var(--text-sm--line-height, 1.255rem);
-        text-rendering: optimizeLegibility;
-      }
-    `)
-    let compiled = build(['text-sm'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility text-sm {
+            font-size: var(--text-sm, 0.8755rem);
+            line-height: var(--text-sm--line-height, 1.255rem);
+            text-rendering: optimizeLegibility;
+          }
+        `,
+        ['text-sm'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .text-sm {
@@ -29658,22 +29676,24 @@ describe('custom utilities', () => {
   })
 
   test('can override the default value of a functional utility', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @theme reference {
-        --radius-xl: 16px;
-      }
+          @theme reference {
+            --radius-xl: 16px;
+          }
 
-      @utility rounded {
-        border-radius: 50rem;
-      }
-    `)
-    let compiled = build(['rounded', 'rounded-xl', 'rounded-[33px]'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility rounded {
+            border-radius: 50rem;
+          }
+        `,
+        ['rounded', 'rounded-xl', 'rounded-[33px]'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .rounded {
@@ -29693,18 +29713,20 @@ describe('custom utilities', () => {
   })
 
   test('custom utilities are sorted by used properties', async () => {
-    let { build } = await compile(css`
-      @layer utilities {
-        @tailwind utilities;
-      }
+    expect(
+      await compileCss(
+        css`
+          @layer utilities {
+            @tailwind utilities;
+          }
 
-      @utility push-left {
-        right: 100%;
-      }
-    `)
-    let compiled = build(['top-[100px]', 'push-left', 'right-[100px]', 'bottom-[100px]'])
-
-    expect(optimizeCss(compiled)).toMatchInlineSnapshot(`
+          @utility push-left {
+            right: 100%;
+          }
+        `,
+        ['top-[100px]', 'push-left', 'right-[100px]', 'bottom-[100px]'],
+      ),
+    ).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .top-\\[100px\\] {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile } from '.'
-import { compileCss, run } from './test-utils/run'
+import { run } from './test-utils/run'
 import { isValidFunctionalUtilityName, isValidStaticUtilityName } from './utilities'
 
 const css = String.raw
@@ -134,15 +134,7 @@ test('position', async () => {
 
 test('inset', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-auto',
         'inset-shadow-sm',
@@ -154,6 +146,14 @@ test('inset', async () => {
         '-inset-4',
         'inset-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -320,14 +320,7 @@ test('inset', async () => {
 
 test('inset-x', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-x-shadowned',
         'inset-x-auto',
@@ -338,6 +331,13 @@ test('inset-x', async () => {
         '-inset-x-4',
         'inset-x-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -380,14 +380,7 @@ test('inset-x', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px #0000000d;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-x-shadow-sm',
         'inset-x',
@@ -403,20 +396,20 @@ test('inset-x', async () => {
         '-inset-x-4/foo',
         'inset-x-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px #0000000d;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('inset-y', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-y-shadowned',
         'inset-y-auto',
@@ -427,6 +420,13 @@ test('inset-y', async () => {
         '-inset-y-4',
         'inset-y-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -469,14 +469,7 @@ test('inset-y', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-y-shadow-sm',
         'inset-y',
@@ -492,20 +485,20 @@ test('inset-y', async () => {
         '-inset-y-4/foo',
         'inset-y-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('inset-s', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-s-shadowned',
         'inset-s-auto',
@@ -516,6 +509,13 @@ test('inset-s', async () => {
         '-inset-s-4',
         'inset-s-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -558,14 +558,7 @@ test('inset-s', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-s-shadow-sm',
         'inset-s',
@@ -581,20 +574,20 @@ test('inset-s', async () => {
         '-inset-s-4/foo',
         'inset-s-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('inset-e', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-e-shadowned',
         'inset-e-auto',
@@ -605,6 +598,13 @@ test('inset-e', async () => {
         '-inset-e-4',
         'inset-e-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -647,14 +647,7 @@ test('inset-e', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-e-shadow-sm',
         'inset-e',
@@ -670,20 +663,20 @@ test('inset-e', async () => {
         '-inset-e-4/foo',
         'inset-e-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('inset-bs', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-bs-shadowned',
         'inset-bs-auto',
@@ -694,6 +687,13 @@ test('inset-bs', async () => {
         '-inset-bs-4',
         'inset-bs-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -736,14 +736,7 @@ test('inset-bs', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-bs-shadow-sm',
         'inset-bs',
@@ -759,20 +752,20 @@ test('inset-bs', async () => {
         '-inset-bs-4/foo',
         'inset-bs-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('inset-be', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-be-shadowned',
         'inset-be-auto',
@@ -783,6 +776,13 @@ test('inset-be', async () => {
         '-inset-be-4',
         'inset-be-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -825,14 +825,7 @@ test('inset-be', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inset-be-shadow-sm',
         'inset-be',
@@ -848,21 +841,20 @@ test('inset-be', async () => {
         '-inset-be-4/foo',
         'inset-be-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('top', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
-
+    await run(
       [
         'top-shadowned',
         'top-auto',
@@ -873,6 +865,13 @@ test('top', async () => {
         '-top-4',
         'top-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -915,14 +914,7 @@ test('top', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'top-shadow-sm',
         'top',
@@ -938,20 +930,20 @@ test('top', async () => {
         '-top-4/foo',
         'top-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('right', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'right-shadowned',
         'right-auto',
@@ -962,6 +954,13 @@ test('right', async () => {
         '-right-4',
         'right-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1004,14 +1003,7 @@ test('right', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'right-shadow-sm',
         'right',
@@ -1027,20 +1019,20 @@ test('right', async () => {
         '-right-4/foo',
         'right-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('bottom', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'bottom-shadowned',
         'bottom-auto',
@@ -1051,6 +1043,13 @@ test('bottom', async () => {
         '-bottom-4',
         'bottom-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1093,14 +1092,7 @@ test('bottom', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'bottom-shadow-sm',
         'bottom',
@@ -1116,20 +1108,20 @@ test('bottom', async () => {
         '-bottom-4/foo',
         'bottom-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('left', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --inset-shadowned: 1940px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'left-shadowned',
         'left-auto',
@@ -1143,6 +1135,13 @@ test('left', async () => {
         // https://github.com/tailwindlabs/tailwindcss/issues/20010
         '-left-[(var(--my-var1)+var(--my-var2))]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --inset-shadowned: 1940px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1189,14 +1188,7 @@ test('left', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'left-shadow-sm',
         'left',
@@ -1212,6 +1204,13 @@ test('left', async () => {
         '-left-4/foo',
         'left-[4px]/foo',
       ],
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
@@ -1274,14 +1273,14 @@ test('z-index', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['z-auto'],
       css`
         @theme {
           --z-index-auto: 42;
         }
         @tailwind utilities;
       `,
-      ['z-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1358,14 +1357,14 @@ test('order', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['order-first'],
       css`
         @theme {
           --order-first: 1;
         }
         @tailwind utilities;
       `,
-      ['order-first'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1380,14 +1379,14 @@ test('order', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['order-last'],
       css`
         @theme {
           --order-last: -1;
         }
         @tailwind utilities;
       `,
-      ['order-last'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1466,14 +1465,14 @@ test('col', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['col-auto'],
       css`
         @theme {
           --grid-column-auto: 5;
         }
         @tailwind utilities;
       `,
-      ['col-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1490,13 +1489,7 @@ test('col', async () => {
 
 test('col-start', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --grid-column-start-custom: 1 column-start;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'col-start-auto',
         'col-start-4',
@@ -1505,6 +1498,12 @@ test('col-start', async () => {
         '-col-start-4',
         'col-start-custom',
       ],
+      css`
+        @theme {
+          --grid-column-start-custom: 1 column-start;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1551,14 +1550,14 @@ test('col-start', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['col-start-auto'],
       css`
         @theme {
           --grid-column-start-auto: 7;
         }
         @tailwind utilities;
       `,
-      ['col-start-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1575,14 +1574,14 @@ test('col-start', async () => {
 
 test('col-end', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['col-end-auto', 'col-end-4', 'col-end-99', 'col-end-[123]', '-col-end-4', 'col-end-custom'],
       css`
         @theme {
           --grid-column-end-custom: 1 column-end;
         }
         @tailwind utilities;
       `,
-      ['col-end-auto', 'col-end-4', 'col-end-99', 'col-end-[123]', '-col-end-4', 'col-end-custom'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1629,14 +1628,14 @@ test('col-end', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['col-end-auto'],
       css`
         @theme {
           --grid-column-end-auto: 3;
         }
         @tailwind utilities;
       `,
-      ['col-end-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1722,14 +1721,14 @@ test('row', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['row-auto'],
       css`
         @theme {
           --grid-row-auto: 9;
         }
         @tailwind utilities;
       `,
-      ['row-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1746,13 +1745,7 @@ test('row', async () => {
 
 test('row-start', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --grid-row-start-custom: 1 row-start;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'row-start-auto',
         'row-start-4',
@@ -1761,6 +1754,12 @@ test('row-start', async () => {
         '-row-start-4',
         'row-start-custom',
       ],
+      css`
+        @theme {
+          --grid-row-start-custom: 1 row-start;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1807,14 +1806,14 @@ test('row-start', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['row-start-auto'],
       css`
         @theme {
           --grid-row-start-auto: 11;
         }
         @tailwind utilities;
       `,
-      ['row-start-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1831,14 +1830,14 @@ test('row-start', async () => {
 
 test('row-end', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['row-end-auto', 'row-end-4', 'row-end-99', 'row-end-[123]', '-row-end-4', 'row-end-custom'],
       css`
         @theme {
           --grid-row-end-custom: 1 row-end;
         }
         @tailwind utilities;
       `,
-      ['row-end-auto', 'row-end-4', 'row-end-99', 'row-end-[123]', '-row-end-4', 'row-end-custom'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1885,14 +1884,14 @@ test('row-end', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['row-end-auto'],
       css`
         @theme {
           --grid-row-end-auto: 13;
         }
         @tailwind utilities;
       `,
-      ['row-end-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2007,14 +2006,14 @@ test('clear', async () => {
 
 test('margin', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['m-auto', 'm-4', 'm-[4px]', '-m-4', '-m-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['m-auto', 'm-4', 'm-[4px]', '-m-4', '-m-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2050,14 +2049,7 @@ test('margin', async () => {
 
 test('mx', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mx-auto',
         'mx-1',
@@ -2071,6 +2063,13 @@ test('mx', async () => {
         'mx-[var(--my-var)]',
         '-mx-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2138,14 +2137,7 @@ test('mx', async () => {
 
 test('my', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'my-1',
         'my-99',
@@ -2159,6 +2151,13 @@ test('my', async () => {
         'my-[var(--my-var)]',
         '-my-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2226,14 +2225,7 @@ test('my', async () => {
 
 test('mt', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mt-1',
         'mt-99',
@@ -2247,6 +2239,13 @@ test('mt', async () => {
         'mt-[var(--my-var)]',
         '-mt-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2314,14 +2313,7 @@ test('mt', async () => {
 
 test('ms', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'ms-1',
         'ms-99',
@@ -2335,6 +2327,13 @@ test('ms', async () => {
         'ms-[var(--my-var)]',
         '-ms-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2402,14 +2401,7 @@ test('ms', async () => {
 
 test('me', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'me-1',
         'me-99',
@@ -2423,6 +2415,13 @@ test('me', async () => {
         'me-[var(--my-var)]',
         '-me-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2490,14 +2489,7 @@ test('me', async () => {
 
 test('mbs', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mbs-1',
         'mbs-99',
@@ -2511,6 +2503,13 @@ test('mbs', async () => {
         'mbs-[var(--my-var)]',
         '-mbs-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2578,14 +2577,7 @@ test('mbs', async () => {
 
 test('mbe', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mbe-1',
         'mbe-99',
@@ -2599,6 +2591,13 @@ test('mbe', async () => {
         'mbe-[var(--my-var)]',
         '-mbe-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2666,14 +2665,7 @@ test('mbe', async () => {
 
 test('mr', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mr-1',
         'mr-99',
@@ -2687,6 +2679,13 @@ test('mr', async () => {
         'mr-[var(--my-var)]',
         '-mr-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2754,14 +2753,7 @@ test('mr', async () => {
 
 test('mb', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mb-1',
         'mb-99',
@@ -2775,6 +2767,13 @@ test('mb', async () => {
         'mb-[var(--my-var)]',
         '-mb-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2842,14 +2841,7 @@ test('mb', async () => {
 
 test('ml', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --spacing-big: 100rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'ml-1',
         'ml-99',
@@ -2863,6 +2855,13 @@ test('ml', async () => {
         'ml-[var(--my-var)]',
         '-ml-[var(--my-var)]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --spacing-big: 100rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2930,14 +2929,14 @@ test('ml', async () => {
 
 test('margin sort order', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['mb-4', 'me-4', 'mx-4', 'ml-4', 'ms-4', 'm-4', 'mr-4', 'mt-4', 'my-4'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['mb-4', 'me-4', 'mx-4', 'ml-4', 'ms-4', 'm-4', 'mr-4', 'mt-4', 'my-4'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3065,14 +3064,14 @@ test('line-clamp', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['line-clamp-none'],
       css`
         @theme {
           --line-clamp-none: 0;
         }
         @tailwind utilities;
       `,
-      ['line-clamp-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3269,14 +3268,14 @@ test('field-sizing', async () => {
 
 test('aspect-ratio', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['aspect-video', 'aspect-[10/9]', 'aspect-4/3', 'aspect-8.5/11'],
       css`
         @theme {
           --aspect-video: 16 / 9;
         }
         @tailwind utilities;
       `,
-      ['aspect-video', 'aspect-[10/9]', 'aspect-4/3', 'aspect-8.5/11'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3321,13 +3320,7 @@ test('aspect-ratio', async () => {
 
 test('size', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'size-auto',
         'size-full',
@@ -3338,6 +3331,12 @@ test('size', async () => {
         'size-1/2',
         'size-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3410,14 +3409,7 @@ test('size', async () => {
 
 test('width', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --width-xl: 36rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'w-full',
         'w-auto',
@@ -3433,6 +3425,13 @@ test('width', async () => {
         'w-1/2',
         'w-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --width-xl: 36rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3523,14 +3522,7 @@ test('width', async () => {
 
 test('min-width', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --container-xl: 36rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'min-w-full',
         'min-w-auto',
@@ -3541,6 +3533,13 @@ test('min-width', async () => {
         'min-w-xl',
         'min-w-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --container-xl: 36rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3601,7 +3600,8 @@ test('min-width', async () => {
 
 test('max-width', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['max-w-none', 'max-w-full', 'max-w-max', 'max-w-fit', 'max-w-4', 'max-w-xl', 'max-w-[4px]'],
       css`
         @theme {
           --spacing-4: 1rem;
@@ -3609,7 +3609,6 @@ test('max-width', async () => {
         }
         @tailwind utilities;
       `,
-      ['max-w-none', 'max-w-full', 'max-w-max', 'max-w-fit', 'max-w-4', 'max-w-xl', 'max-w-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3667,13 +3666,7 @@ test('max-width', async () => {
 
 test('height', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'h-full',
         'h-auto',
@@ -3689,6 +3682,12 @@ test('height', async () => {
         'h-1/2',
         'h-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3778,13 +3777,7 @@ test('height', async () => {
 
 test('min-height', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'min-h-full',
         'min-h-auto',
@@ -3799,6 +3792,12 @@ test('min-height', async () => {
         'min-h-4',
         'min-h-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3878,13 +3877,7 @@ test('min-height', async () => {
 
 test('max-height', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'max-h-none',
         'max-h-full',
@@ -3899,6 +3892,12 @@ test('max-height', async () => {
         'max-h-4',
         'max-h-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -3979,14 +3978,7 @@ test('max-height', async () => {
 
 test('inline-size', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --container-xl: 36rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'inline-full',
         'inline-auto',
@@ -4002,6 +3994,13 @@ test('inline-size', async () => {
         'inline-1/2',
         'inline-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --container-xl: 36rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -4091,14 +4090,7 @@ test('inline-size', async () => {
 
 test('min-inline-size', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --container-xl: 36rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'min-inline-full',
         'min-inline-auto',
@@ -4109,6 +4101,13 @@ test('min-inline-size', async () => {
         'min-inline-xl',
         'min-inline-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --container-xl: 36rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -4169,14 +4168,7 @@ test('min-inline-size', async () => {
 
 test('max-inline-size', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-          --container-xl: 36rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'max-inline-none',
         'max-inline-full',
@@ -4186,6 +4178,13 @@ test('max-inline-size', async () => {
         'max-inline-xl',
         'max-inline-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+          --container-xl: 36rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -4243,13 +4242,7 @@ test('max-inline-size', async () => {
 
 test('block-size', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'block-full',
         'block-auto',
@@ -4265,6 +4258,12 @@ test('block-size', async () => {
         'block-1/2',
         'block-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -4353,13 +4352,7 @@ test('block-size', async () => {
 
 test('min-block-size', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'min-block-full',
         'min-block-auto',
@@ -4374,6 +4367,12 @@ test('min-block-size', async () => {
         'min-block-4',
         'min-block-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -4453,13 +4452,7 @@ test('min-block-size', async () => {
 
 test('max-block-size', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing-4: 1rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'max-block-none',
         'max-block-full',
@@ -4474,6 +4467,12 @@ test('max-block-size', async () => {
         'max-block-4',
         'max-block-[4px]',
       ],
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -4555,7 +4554,8 @@ test('max-block-size', async () => {
 describe('container', () => {
   test('creates the right media queries and sorts it before width', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['w-1/2', 'container', 'max-w-[var(--breakpoint-sm)]'],
         css`
           @theme {
             --breakpoint-sm: 40rem;
@@ -4566,7 +4566,6 @@ describe('container', () => {
           }
           @tailwind utilities;
         `,
-        ['w-1/2', 'container', 'max-w-[var(--breakpoint-sm)]'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4621,7 +4620,8 @@ describe('container', () => {
 
   test('sorts breakpoints based on unit and then in ascending aOrder', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['container'],
         css`
           @theme reference {
             --breakpoint-lg: 64rem;
@@ -4634,7 +4634,6 @@ describe('container', () => {
           }
           @tailwind utilities;
         `,
-        ['container'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4689,7 +4688,8 @@ describe('container', () => {
 
   test('custom `@utility container` always follow the core utility ', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['w-1/2', 'container', 'max-w-[var(--breakpoint-sm)]'],
         css`
           @theme {
             --breakpoint-sm: 40rem;
@@ -4709,7 +4709,6 @@ describe('container', () => {
             }
           }
         `,
-        ['w-1/2', 'container', 'max-w-[var(--breakpoint-sm)]'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -4903,14 +4902,14 @@ test('flex-grow', async () => {
 
 test('flex-basis', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['basis-auto', 'basis-full', 'basis-xl', 'basis-11/12', 'basis-[123px]'],
       css`
         @theme {
           --container-xl: 36rem;
         }
         @tailwind utilities;
       `,
-      ['basis-auto', 'basis-full', 'basis-xl', 'basis-11/12', 'basis-[123px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -5015,14 +5014,14 @@ test('border-collapse', async () => {
 
 test('border-spacing', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['border-spacing-1', 'border-spacing-[123px]'],
       css`
         @theme {
           --spacing-1: 0.25rem;
         }
         @tailwind utilities;
       `,
-      ['border-spacing-1', 'border-spacing-[123px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -5077,14 +5076,14 @@ test('border-spacing', async () => {
 
 test('border-spacing-x', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['border-spacing-x-1', 'border-spacing-x-[123px]'],
       css`
         @theme {
           --spacing-1: 0.25rem;
         }
         @tailwind utilities;
       `,
-      ['border-spacing-x-1', 'border-spacing-x-[123px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -5137,14 +5136,14 @@ test('border-spacing-x', async () => {
 
 test('border-spacing-y', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['border-spacing-y-1', 'border-spacing-y-[123px]'],
       css`
         @theme {
           --spacing-1: 0.25rem;
         }
         @tailwind utilities;
       `,
-      ['border-spacing-y-1', 'border-spacing-y-[123px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -5276,14 +5275,14 @@ test('origin', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['origin-top'],
       css`
         @theme {
           --transform-origin-top: 10px 20px;
         }
         @tailwind utilities;
       `,
-      ['origin-top'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -5379,14 +5378,14 @@ test('perspective-origin', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['perspective-origin-top'],
       css`
         @theme {
           --perspective-origin-top: 10px 20px;
         }
         @tailwind utilities;
       `,
-      ['perspective-origin-top'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -5562,14 +5561,14 @@ test('translate-x', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['translate-x-full', '-translate-x-full', 'translate-x-px', '-translate-x-[var(--value)]'],
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
-      ['translate-x-full', '-translate-x-full', 'translate-x-px', '-translate-x-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -5710,14 +5709,14 @@ test('translate-y', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['translate-y-full', '-translate-y-full', 'translate-y-px', '-translate-y-[var(--value)]'],
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
-      ['translate-y-full', '-translate-y-full', 'translate-y-px', '-translate-y-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -6901,11 +6900,11 @@ test('transform', async () => {
 
 test('zoom', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['zoom-50', 'zoom-100', 'zoom-[var(--zoom)]'],
       css`
         @tailwind utilities;
       `,
-      ['zoom-50', 'zoom-100', 'zoom-[var(--zoom)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -6929,7 +6928,8 @@ test('zoom', async () => {
 
 test('perspective', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['perspective-normal', 'perspective-dramatic', 'perspective-none', 'perspective-[456px]'],
       css`
         @theme {
           --perspective-dramatic: 100px;
@@ -6937,7 +6937,6 @@ test('perspective', async () => {
         }
         @tailwind utilities;
       `,
-      ['perspective-normal', 'perspective-dramatic', 'perspective-none', 'perspective-[456px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -6977,14 +6976,14 @@ test('perspective', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['perspective-none'],
       css`
         @theme {
           --perspective-none: 400px;
         }
         @tailwind utilities;
       `,
-      ['perspective-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7001,13 +7000,7 @@ test('perspective', async () => {
 
 test('cursor', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --cursor-custom: url(/my-cursor.png);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'cursor-auto',
         'cursor-default',
@@ -7048,6 +7041,12 @@ test('cursor', async () => {
         'cursor-[var(--value)]',
         'cursor-custom',
       ],
+      css`
+        @theme {
+          --cursor-custom: url(/my-cursor.png);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7648,14 +7647,14 @@ test('scroll-snap-stop', async () => {
 
 test('scroll-m', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-m-4', 'scroll-m-[4px]', '-scroll-m-4', '-scroll-m-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-m-4', 'scroll-m-[4px]', '-scroll-m-4', '-scroll-m-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7693,14 +7692,14 @@ test('scroll-m', async () => {
 
 test('scroll-mx', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-mx-4', 'scroll-mx-[4px]', '-scroll-mx-4', '-scroll-mx-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-mx-4', 'scroll-mx-[4px]', '-scroll-mx-4', '-scroll-mx-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7738,14 +7737,14 @@ test('scroll-mx', async () => {
 
 test('scroll-my', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-my-4', 'scroll-my-[4px]', '-scroll-my-4', '-scroll-my-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-my-4', 'scroll-my-[4px]', '-scroll-my-4', '-scroll-my-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7783,14 +7782,14 @@ test('scroll-my', async () => {
 
 test('scroll-ms', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-ms-4', 'scroll-ms-[4px]', '-scroll-ms-4', '-scroll-ms-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-ms-4', 'scroll-ms-[4px]', '-scroll-ms-4', '-scroll-ms-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7828,14 +7827,14 @@ test('scroll-ms', async () => {
 
 test('scroll-me', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-me-4', 'scroll-me-[4px]', '-scroll-me-4', '-scroll-me-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-me-4', 'scroll-me-[4px]', '-scroll-me-4', '-scroll-me-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7873,14 +7872,14 @@ test('scroll-me', async () => {
 
 test('scroll-mbs', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-mbs-4', 'scroll-mbs-[4px]', '-scroll-mbs-4', '-scroll-mbs-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-mbs-4', 'scroll-mbs-[4px]', '-scroll-mbs-4', '-scroll-mbs-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7918,14 +7917,14 @@ test('scroll-mbs', async () => {
 
 test('scroll-mbe', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-mbe-4', 'scroll-mbe-[4px]', '-scroll-mbe-4', '-scroll-mbe-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-mbe-4', 'scroll-mbe-[4px]', '-scroll-mbe-4', '-scroll-mbe-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -7963,14 +7962,14 @@ test('scroll-mbe', async () => {
 
 test('scroll-mt', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-mt-4', 'scroll-mt-[4px]', '-scroll-mt-4', '-scroll-mt-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-mt-4', 'scroll-mt-[4px]', '-scroll-mt-4', '-scroll-mt-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8008,14 +8007,14 @@ test('scroll-mt', async () => {
 
 test('scroll-mr', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-mr-4', 'scroll-mr-[4px]', '-scroll-mr-4', '-scroll-mr-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-mr-4', 'scroll-mr-[4px]', '-scroll-mr-4', '-scroll-mr-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8053,14 +8052,14 @@ test('scroll-mr', async () => {
 
 test('scroll-mb', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-mb-4', 'scroll-mb-[4px]', '-scroll-mb-4', '-scroll-mb-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-mb-4', 'scroll-mb-[4px]', '-scroll-mb-4', '-scroll-mb-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8098,14 +8097,14 @@ test('scroll-mb', async () => {
 
 test('scroll-ml', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-ml-4', 'scroll-ml-[4px]', '-scroll-ml-4', '-scroll-ml-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-ml-4', 'scroll-ml-[4px]', '-scroll-ml-4', '-scroll-ml-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8143,14 +8142,14 @@ test('scroll-ml', async () => {
 
 test('scroll-p', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-p-4', 'scroll-p-[4px]', '-scroll-p-4', '-scroll-p-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-p-4', 'scroll-p-[4px]', '-scroll-p-4', '-scroll-p-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8180,14 +8179,14 @@ test('scroll-p', async () => {
 
 test('scroll-px', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-px-4', 'scroll-px-[4px]', '-scroll-px-4', '-scroll-px-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-px-4', 'scroll-px-[4px]', '-scroll-px-4', '-scroll-px-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8217,14 +8216,14 @@ test('scroll-px', async () => {
 
 test('scroll-py', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-py-4', 'scroll-py-[4px]', '-scroll-py-4', '-scroll-py-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-py-4', 'scroll-py-[4px]', '-scroll-py-4', '-scroll-py-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8254,14 +8253,14 @@ test('scroll-py', async () => {
 
 test('scroll-ps', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-ps-4', 'scroll-ps-[4px]', '-scroll-ps-4', '-scroll-ps-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-ps-4', 'scroll-ps-[4px]', '-scroll-ps-4', '-scroll-ps-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8291,14 +8290,14 @@ test('scroll-ps', async () => {
 
 test('scroll-pe', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-pe-4', 'scroll-pe-[4px]', '-scroll-pe-4', '-scroll-pe-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-pe-4', 'scroll-pe-[4px]', '-scroll-pe-4', '-scroll-pe-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8328,14 +8327,14 @@ test('scroll-pe', async () => {
 
 test('scroll-pbs', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-pbs-4', 'scroll-pbs-[4px]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-pbs-4', 'scroll-pbs-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8365,14 +8364,14 @@ test('scroll-pbs', async () => {
 
 test('scroll-pbe', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-pbe-4', 'scroll-pbe-[4px]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-pbe-4', 'scroll-pbe-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8402,14 +8401,14 @@ test('scroll-pbe', async () => {
 
 test('scroll-pt', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-pt-4', 'scroll-pt-[4px]', '-scroll-pt-4', '-scroll-pt-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-pt-4', 'scroll-pt-[4px]', '-scroll-pt-4', '-scroll-pt-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8439,14 +8438,14 @@ test('scroll-pt', async () => {
 
 test('scroll-pr', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-pr-4', 'scroll-pr-[4px]', '-scroll-pr-4', '-scroll-pr-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-pr-4', 'scroll-pr-[4px]', '-scroll-pr-4', '-scroll-pr-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8476,14 +8475,14 @@ test('scroll-pr', async () => {
 
 test('scroll-pb', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-pb-4', 'scroll-pb-[4px]', '-scroll-pb-4', '-scroll-pb-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-pb-4', 'scroll-pb-[4px]', '-scroll-pb-4', '-scroll-pb-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8513,14 +8512,14 @@ test('scroll-pb', async () => {
 
 test('scroll-pl', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['scroll-pl-4', 'scroll-pl-[4px]', '-scroll-pl-4', '-scroll-pl-[var(--value)]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['scroll-pl-4', 'scroll-pl-[4px]', '-scroll-pl-4', '-scroll-pl-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8600,14 +8599,14 @@ test('list', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['list-none'],
       css`
         @theme {
           --list-style-type-none: disc;
         }
         @tailwind utilities;
       `,
-      ['list-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8645,14 +8644,14 @@ test('list-image', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['list-image-none'],
       css`
         @theme {
           --list-style-image-none: url(../foo.png);
         }
         @tailwind utilities;
       `,
-      ['list-image-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8741,14 +8740,7 @@ test('color-scheme', async () => {
 
 test('columns', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --container-3xs: 16rem;
-          --container-7xl: 80rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'columns-auto',
         'columns-3xs',
@@ -8758,6 +8750,13 @@ test('columns', async () => {
         'columns-[123]',
         'columns-[var(--value)]',
       ],
+      css`
+        @theme {
+          --container-3xs: 16rem;
+          --container-7xl: 80rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -8814,14 +8813,14 @@ test('columns', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['columns-auto'],
       css`
         @theme {
           --columns-auto: 3;
         }
         @tailwind utilities;
       `,
-      ['columns-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9064,14 +9063,14 @@ test('auto-cols', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['auto-cols-auto'],
       css`
         @theme {
           --grid-auto-columns-auto: 2fr;
         }
         @tailwind utilities;
       `,
-      ['auto-cols-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9181,14 +9180,14 @@ test('auto-rows', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['auto-rows-auto'],
       css`
         @theme {
           --grid-auto-rows-auto: 2fr;
         }
         @tailwind utilities;
       `,
-      ['auto-rows-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9254,14 +9253,14 @@ test('grid-cols', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['grid-cols-none'],
       css`
         @theme {
           --grid-template-columns-none: 200px 1fr;
         }
         @tailwind utilities;
       `,
-      ['grid-cols-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9327,14 +9326,14 @@ test('grid-rows', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['grid-rows-none'],
       css`
         @theme {
           --grid-template-rows-none: 200px 1fr;
         }
         @tailwind utilities;
       `,
-      ['grid-rows-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9838,14 +9837,14 @@ test('justify-items', async () => {
 
 test('gap', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['gap-4', 'gap-[4px]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['gap-4', 'gap-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9867,14 +9866,14 @@ test('gap', async () => {
 
 test('gap-x', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['gap-x-4', 'gap-x-[4px]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['gap-x-4', 'gap-x-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9898,14 +9897,14 @@ test('gap-x', async () => {
 
 test('gap-y', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['gap-y-4', 'gap-y-[4px]'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['gap-y-4', 'gap-y-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9929,14 +9928,14 @@ test('gap-y', async () => {
 
 test('space-x', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['space-x-4', 'space-x-[4px]', '-space-x-4'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['space-x-4', 'space-x-[4px]', '-space-x-4'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -9982,14 +9981,14 @@ test('space-x', async () => {
 
 test('space-y', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['space-y-4', 'space-y-[4px]', '-space-y-4'],
       css`
         @theme {
           --spacing-4: 1rem;
         }
         @tailwind utilities;
       `,
-      ['space-y-4', 'space-y-[4px]', '-space-y-4'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -10085,11 +10084,11 @@ test('space-y-reverse', async () => {
 
 test('divide-x', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['divide-x', 'divide-x-4', 'divide-x-123', 'divide-x-[4px]'],
       css`
         @tailwind utilities;
       `,
-      ['divide-x', 'divide-x-4', 'divide-x-123', 'divide-x-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -10160,14 +10159,14 @@ test('divide-x', async () => {
 
 test('divide-x with custom default border width', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['divide-x'],
       css`
         @theme {
           --default-border-width: 2px;
         }
         @tailwind utilities;
       `,
-      ['divide-x'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -10205,11 +10204,11 @@ test('divide-x with custom default border width', async () => {
 
 test('divide-y', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['divide-y', 'divide-y-4', 'divide-y-123', 'divide-y-[4px]'],
       css`
         @tailwind utilities;
       `,
-      ['divide-y', 'divide-y-4', 'divide-y-123', 'divide-y-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -10284,14 +10283,14 @@ test('divide-y', async () => {
 
 test('divide-y with custom default border width', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['divide-y'],
       css`
         @theme {
           --default-border-width: 2px;
         }
         @tailwind utilities;
       `,
-      ['divide-y'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -10428,14 +10427,7 @@ test('divide-style', async () => {
 
 test('accent', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --accent-color-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'accent-red-500',
         'accent-red-500/50',
@@ -10456,6 +10448,13 @@ test('accent', async () => {
         'accent-[#0088cc]/[0.5]',
         'accent-[#0088cc]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --accent-color-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -10618,14 +10617,7 @@ test('accent', async () => {
 
 test('caret', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --caret-color-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'caret-red-500',
         'caret-red-500/50',
@@ -10646,6 +10638,13 @@ test('caret', async () => {
         'caret-[#0088cc]/[0.5]',
         'caret-[#0088cc]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --caret-color-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -10806,14 +10805,7 @@ test('caret', async () => {
 
 test('divide-color', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --border-color-best-blue: #6495ed;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'divide-red-500',
         'divide-red-500/50',
@@ -10834,6 +10826,13 @@ test('divide-color', async () => {
         'divide-[#0088cc]/[0.5]',
         'divide-[#0088cc]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --border-color-best-blue: #6495ed;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -11499,13 +11498,7 @@ test('scrollbar-gutter', async () => {
 
 test('scrollbar-thumb', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'scrollbar-thumb-red-500',
         'scrollbar-thumb-red-500/50',
@@ -11516,6 +11509,12 @@ test('scrollbar-thumb', async () => {
         'scrollbar-thumb-[#0088cc]',
         'scrollbar-thumb-[#0088cc]/50',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -11616,13 +11615,7 @@ test('scrollbar-thumb', async () => {
 
 test('scrollbar-track', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'scrollbar-track-red-500',
         'scrollbar-track-red-500/50',
@@ -11633,6 +11626,12 @@ test('scrollbar-track', async () => {
         'scrollbar-track-[#0088cc]',
         'scrollbar-track-[#0088cc]/50',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -11983,7 +11982,8 @@ test('overflow-wrap', async () => {
 
 test('rounded', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded', 'rounded-full', 'rounded-none', 'rounded-sm', 'rounded-[4px]'],
       css`
         @theme {
           --radius-sm: 0.125rem;
@@ -11991,7 +11991,6 @@ test('rounded', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded', 'rounded-full', 'rounded-none', 'rounded-sm', 'rounded-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12022,14 +12021,14 @@ test('rounded', async () => {
     "
   `)
   expect(
-    await compileCss(
+    await run(
+      ['rounded-full'],
       css`
         @theme {
           --radius-full: 99999px;
         }
         @tailwind utilities;
       `,
-      ['rounded-full'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12060,7 +12059,8 @@ test('rounded', async () => {
 
 test('rounded-s', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-s', 'rounded-s-full', 'rounded-s-none', 'rounded-s-sm', 'rounded-s-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12070,7 +12070,6 @@ test('rounded-s', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-s', 'rounded-s-full', 'rounded-s-none', 'rounded-s-sm', 'rounded-s-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12125,7 +12124,8 @@ test('rounded-s', async () => {
 
 test('rounded-e', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-e', 'rounded-e-full', 'rounded-e-none', 'rounded-e-sm', 'rounded-e-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12135,7 +12135,6 @@ test('rounded-e', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-e', 'rounded-e-full', 'rounded-e-none', 'rounded-e-sm', 'rounded-e-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12190,7 +12189,8 @@ test('rounded-e', async () => {
 
 test('rounded-t', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-t', 'rounded-t-full', 'rounded-t-none', 'rounded-t-sm', 'rounded-t-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12200,7 +12200,6 @@ test('rounded-t', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-t', 'rounded-t-full', 'rounded-t-none', 'rounded-t-sm', 'rounded-t-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12255,7 +12254,8 @@ test('rounded-t', async () => {
 
 test('rounded-r', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-r', 'rounded-r-full', 'rounded-r-none', 'rounded-r-sm', 'rounded-r-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12265,7 +12265,6 @@ test('rounded-r', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-r', 'rounded-r-full', 'rounded-r-none', 'rounded-r-sm', 'rounded-r-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12320,7 +12319,8 @@ test('rounded-r', async () => {
 
 test('rounded-b', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-b', 'rounded-b-full', 'rounded-b-none', 'rounded-b-sm', 'rounded-b-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12330,7 +12330,6 @@ test('rounded-b', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-b', 'rounded-b-full', 'rounded-b-none', 'rounded-b-sm', 'rounded-b-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12385,7 +12384,8 @@ test('rounded-b', async () => {
 
 test('rounded-l', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-l', 'rounded-l-full', 'rounded-l-none', 'rounded-l-sm', 'rounded-l-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12395,7 +12395,6 @@ test('rounded-l', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-l', 'rounded-l-full', 'rounded-l-none', 'rounded-l-sm', 'rounded-l-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12450,7 +12449,8 @@ test('rounded-l', async () => {
 
 test('rounded-ss', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-ss', 'rounded-ss-full', 'rounded-ss-none', 'rounded-ss-sm', 'rounded-ss-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12460,7 +12460,6 @@ test('rounded-ss', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-ss', 'rounded-ss-full', 'rounded-ss-none', 'rounded-ss-sm', 'rounded-ss-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12510,7 +12509,8 @@ test('rounded-ss', async () => {
 
 test('rounded-se', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-se', 'rounded-se-full', 'rounded-se-none', 'rounded-se-sm', 'rounded-se-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12520,7 +12520,6 @@ test('rounded-se', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-se', 'rounded-se-full', 'rounded-se-none', 'rounded-se-sm', 'rounded-se-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12570,7 +12569,8 @@ test('rounded-se', async () => {
 
 test('rounded-ee', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-ee', 'rounded-ee-full', 'rounded-ee-none', 'rounded-ee-sm', 'rounded-ee-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12580,7 +12580,6 @@ test('rounded-ee', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-ee', 'rounded-ee-full', 'rounded-ee-none', 'rounded-ee-sm', 'rounded-ee-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12630,7 +12629,8 @@ test('rounded-ee', async () => {
 
 test('rounded-es', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-es', 'rounded-es-full', 'rounded-es-none', 'rounded-es-sm', 'rounded-es-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12640,7 +12640,6 @@ test('rounded-es', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-es', 'rounded-es-full', 'rounded-es-none', 'rounded-es-sm', 'rounded-es-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12690,7 +12689,8 @@ test('rounded-es', async () => {
 
 test('rounded-tl', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-tl', 'rounded-tl-full', 'rounded-tl-none', 'rounded-tl-sm', 'rounded-tl-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12700,7 +12700,6 @@ test('rounded-tl', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-tl', 'rounded-tl-full', 'rounded-tl-none', 'rounded-tl-sm', 'rounded-tl-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12750,7 +12749,8 @@ test('rounded-tl', async () => {
 
 test('rounded-tr', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-tr', 'rounded-tr-full', 'rounded-tr-none', 'rounded-tr-sm', 'rounded-tr-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12760,7 +12760,6 @@ test('rounded-tr', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-tr', 'rounded-tr-full', 'rounded-tr-none', 'rounded-tr-sm', 'rounded-tr-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12810,7 +12809,8 @@ test('rounded-tr', async () => {
 
 test('rounded-br', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-br', 'rounded-br-full', 'rounded-br-none', 'rounded-br-sm', 'rounded-br-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12820,7 +12820,6 @@ test('rounded-br', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-br', 'rounded-br-full', 'rounded-br-none', 'rounded-br-sm', 'rounded-br-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -12870,7 +12869,8 @@ test('rounded-br', async () => {
 
 test('rounded-bl', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['rounded-bl', 'rounded-bl-full', 'rounded-bl-none', 'rounded-bl-sm', 'rounded-bl-[4px]'],
       css`
         @theme {
           --radius-none: 0px;
@@ -12880,7 +12880,6 @@ test('rounded-bl', async () => {
         }
         @tailwind utilities;
       `,
-      ['rounded-bl', 'rounded-bl-full', 'rounded-bl-none', 'rounded-bl-sm', 'rounded-bl-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -13049,7 +13048,8 @@ for (let prefix of prefixes) {
     classes.push(`${prefix}-[color:var(--my-color)]/50`)
 
     expect(
-      await compileCss(
+      await run(
+        classes,
         css`
           @theme {
             --radius-none: 0px;
@@ -13060,7 +13060,6 @@ for (let prefix of prefixes) {
           }
           @tailwind utilities;
         `,
-        classes,
       ),
     ).toMatchSnapshot()
 
@@ -13086,14 +13085,14 @@ for (let prefix of prefixes) {
 
 test('border with custom default border width', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['border'],
       css`
         @theme {
           --default-border-width: 2px;
         }
         @tailwind utilities;
       `,
-      ['border'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -13122,14 +13121,7 @@ test('border with custom default border width', async () => {
 
 test('bg', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --background-color-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // background-color
         'bg-red-500',
@@ -13271,6 +13263,13 @@ test('bg', async () => {
         'bg-repeat-round',
         'bg-repeat-space',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --background-color-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -14188,7 +14187,8 @@ test('bg', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['bg-current/half', 'bg-current/custom', '[color:red]/half'],
       css`
         @theme reference {
           --opacity-half: 0.5;
@@ -14196,7 +14196,6 @@ test('bg', async () => {
         }
         @tailwind utilities;
       `,
-      ['bg-current/half', 'bg-current/custom', '[color:red]/half'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -14235,14 +14234,14 @@ test('bg', async () => {
 
 test('bg-position', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['bg-position-[120px]', 'bg-position-[120px_120px]', 'bg-position-[var(--some-var)]'],
       css`
         @theme {
           --color-red-500: #ef4444;
         }
         @tailwind utilities;
       `,
-      ['bg-position-[120px]', 'bg-position-[120px_120px]', 'bg-position-[var(--some-var)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -14276,14 +14275,14 @@ test('bg-position', async () => {
 
 test('bg-size', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['bg-size-[120px]', 'bg-size-[120px_120px]', 'bg-size-[var(--some-var)]'],
       css`
         @theme {
           --color-red-500: #ef4444;
         }
         @tailwind utilities;
       `,
-      ['bg-size-[120px]', 'bg-size-[120px_120px]', 'bg-size-[var(--some-var)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -14317,13 +14316,7 @@ test('bg-size', async () => {
 
 test('from', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // --tw-gradient-from
         'from-red-500',
@@ -14358,6 +14351,12 @@ test('from', async () => {
         'from-[length:var(--my-position)]',
         'from-[percentage:var(--my-position)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -14702,13 +14701,7 @@ test('from', async () => {
 
 test('via', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // --tw-gradient-stops
         'via-red-500',
@@ -14743,6 +14736,12 @@ test('via', async () => {
         'via-[length:var(--my-position)]',
         'via-[percentage:var(--my-position)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -15105,13 +15104,7 @@ test('via', async () => {
 
 test('to', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // --tw-gradient-to
         'to-red-500',
@@ -15146,6 +15139,12 @@ test('to', async () => {
         'to-[length:var(--my-position)]',
         'to-[percentage:var(--my-position)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -15488,13 +15487,7 @@ test('to', async () => {
 
 test('mask', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // mask-image
         'mask-none',
@@ -15552,6 +15545,12 @@ test('mask', async () => {
         'mask-repeat-round',
         'mask-repeat-space',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -15841,7 +15840,8 @@ test('mask', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['mask-current/half', 'mask-current/custom', '[color:red]/half'],
       css`
         @theme reference {
           --opacity-half: 0.5;
@@ -15849,7 +15849,6 @@ test('mask', async () => {
         }
         @tailwind utilities;
       `,
-      ['mask-current/half', 'mask-current/custom', '[color:red]/half'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -15868,14 +15867,14 @@ test('mask', async () => {
 
 test('mask-position', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['mask-position-[120px]', 'mask-position-[120px_120px]', 'mask-position-[var(--some-var)]'],
       css`
         @theme {
           --color-red-500: #ef4444;
         }
         @tailwind utilities;
       `,
-      ['mask-position-[120px]', 'mask-position-[120px_120px]', 'mask-position-[var(--some-var)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -15913,14 +15912,14 @@ test('mask-position', async () => {
 
 test('mask-size', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['mask-size-[120px]', 'mask-size-[120px_120px]', 'mask-size-[var(--some-var)]'],
       css`
         @theme {
           --color-red-500: #ef4444;
         }
         @tailwind utilities;
       `,
-      ['mask-size-[120px]', 'mask-size-[120px_120px]', 'mask-size-[var(--some-var)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -15958,13 +15957,7 @@ test('mask-size', async () => {
 
 test('mask-t-from', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-t-from-0',
         'mask-t-from-1.5',
@@ -15977,6 +15970,12 @@ test('mask-t-from', async () => {
         'mask-t-from-(color:--my-var)',
         'mask-t-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16178,13 +16177,7 @@ test('mask-t-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-t-from',
         'mask-t-from-2.8175',
@@ -16215,19 +16208,19 @@ test('mask-t-from', async () => {
         '-mask-l-from-[25%]/foo',
         '-mask-l-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-t-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-t-to', async () => {
+  expect(
+    await run(
       [
         'mask-t-to-0',
         'mask-t-to-1.5',
@@ -16240,6 +16233,12 @@ test('mask-t-to', async () => {
         'mask-t-to-(color:--my-var)',
         'mask-t-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16441,13 +16440,7 @@ test('mask-t-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-t-to',
         'mask-t-to-2.8175',
@@ -16478,19 +16471,19 @@ test('mask-t-to', async () => {
         '-mask-l-from-[25%]/foo',
         '-mask-l-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-r-from', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-r-from', async () => {
+  expect(
+    await run(
       [
         'mask-r-from-0',
         'mask-r-from-1.5',
@@ -16504,6 +16497,12 @@ test('mask-r-from', async () => {
         'mask-r-from-(color:--my-var)',
         'mask-r-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16705,13 +16704,7 @@ test('mask-r-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-r-from',
         'mask-r-from-2.8175',
@@ -16742,19 +16735,19 @@ test('mask-r-from', async () => {
         '-mask-r-from-[25%]/foo',
         '-mask-r-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-r-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-r-to', async () => {
+  expect(
+    await run(
       [
         'mask-r-to-0',
         'mask-r-to-1.5',
@@ -16768,6 +16761,12 @@ test('mask-r-to', async () => {
         'mask-r-to-(color:--my-var)',
         'mask-r-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16969,13 +16968,7 @@ test('mask-r-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-r-to',
         'mask-r-to-2.8175',
@@ -17006,19 +16999,19 @@ test('mask-r-to', async () => {
         '-mask-r-to-[25%]/foo',
         '-mask-r-to-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-b-from', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-b-from', async () => {
+  expect(
+    await run(
       [
         'mask-b-from-0',
         'mask-b-from-1.5',
@@ -17032,6 +17025,12 @@ test('mask-b-from', async () => {
         'mask-b-from-(color:--my-var)',
         'mask-b-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -17233,13 +17232,7 @@ test('mask-b-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-b-from',
         'mask-b-from-2.8175',
@@ -17270,19 +17263,19 @@ test('mask-b-from', async () => {
         '-mask-b-from-[25%]/foo',
         '-mask-b-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-b-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-b-to', async () => {
+  expect(
+    await run(
       [
         'mask-b-to-0',
         'mask-b-to-1.5',
@@ -17296,6 +17289,12 @@ test('mask-b-to', async () => {
         'mask-b-to-(color:--my-var)',
         'mask-b-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -17497,13 +17496,7 @@ test('mask-b-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-b-to',
         'mask-b-to-2.8175',
@@ -17534,19 +17527,19 @@ test('mask-b-to', async () => {
         '-mask-b-to-[25%]/foo',
         '-mask-b-to-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-l-from', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-l-from', async () => {
+  expect(
+    await run(
       [
         'mask-l-from-0',
         'mask-l-from-1.5',
@@ -17560,6 +17553,12 @@ test('mask-l-from', async () => {
         'mask-l-from-(color:--my-var)',
         'mask-l-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -17761,13 +17760,7 @@ test('mask-l-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-l-from',
         'mask-l-from-2.8175',
@@ -17798,19 +17791,19 @@ test('mask-l-from', async () => {
         '-mask-l-from-[25%]/foo',
         '-mask-l-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-l-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-l-to', async () => {
+  expect(
+    await run(
       [
         'mask-l-to-0',
         'mask-l-to-1.5',
@@ -17824,6 +17817,12 @@ test('mask-l-to', async () => {
         'mask-l-to-(color:--my-var)',
         'mask-l-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18025,13 +18024,7 @@ test('mask-l-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-l-to',
         'mask-l-to-2.8175',
@@ -18062,19 +18055,19 @@ test('mask-l-to', async () => {
         '-mask-l-to-[25%]/foo',
         '-mask-l-to-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-x-from', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-x-from', async () => {
+  expect(
+    await run(
       [
         'mask-x-from-0',
         'mask-x-from-1.5',
@@ -18088,6 +18081,12 @@ test('mask-x-from', async () => {
         'mask-x-from-(color:--my-var)',
         'mask-x-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18335,13 +18334,7 @@ test('mask-x-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-x-from',
         'mask-x-from-2.8175',
@@ -18372,19 +18365,19 @@ test('mask-x-from', async () => {
         '-mask-x-from-[25%]/foo',
         '-mask-x-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-x-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-x-to', async () => {
+  expect(
+    await run(
       [
         'mask-x-to-0',
         'mask-x-to-1.5',
@@ -18398,6 +18391,12 @@ test('mask-x-to', async () => {
         'mask-x-to-(color:--my-var)',
         'mask-x-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18645,13 +18644,7 @@ test('mask-x-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-x-to',
         'mask-x-to-2.8175',
@@ -18682,19 +18675,19 @@ test('mask-x-to', async () => {
         '-mask-x-to-[25%]/foo',
         '-mask-x-to-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-y-from', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-y-from', async () => {
+  expect(
+    await run(
       [
         'mask-y-from-0',
         'mask-y-from-1.5',
@@ -18708,6 +18701,12 @@ test('mask-y-from', async () => {
         'mask-y-from-(color:--my-var)',
         'mask-y-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18955,13 +18954,7 @@ test('mask-y-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-y-from',
         'mask-y-from-2.8175',
@@ -18992,19 +18985,19 @@ test('mask-y-from', async () => {
         '-mask-y-from-[25%]/foo',
         '-mask-y-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-y-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-y-to', async () => {
+  expect(
+    await run(
       [
         'mask-y-to-0',
         'mask-y-to-1.5',
@@ -19018,6 +19011,12 @@ test('mask-y-to', async () => {
         'mask-y-to-(color:--my-var)',
         'mask-y-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -19265,13 +19264,7 @@ test('mask-y-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-y-to',
         'mask-y-to-2.8175',
@@ -19302,17 +19295,23 @@ test('mask-y-to', async () => {
         '-mask-y-to-[25%]/foo',
         '-mask-y-to-[-25%]/foo',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('mask-linear', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['mask-linear-45', 'mask-linear-[3rad]', '-mask-linear-45'],
       css`
         @tailwind utilities;
       `,
-      ['mask-linear-45', 'mask-linear-[3rad]', '-mask-linear-45'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -19434,13 +19433,7 @@ test('mask-linear', async () => {
 
 test('mask-linear-from', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-linear-from-0',
         'mask-linear-from-1.5',
@@ -19454,6 +19447,12 @@ test('mask-linear-from', async () => {
         'mask-linear-from-(color:--my-var)',
         'mask-linear-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -19634,13 +19633,7 @@ test('mask-linear-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-linear-from',
         'mask-linear-from-2.8175',
@@ -19671,19 +19664,19 @@ test('mask-linear-from', async () => {
         '-mask-linear-from-[25%]/foo',
         '-mask-linear-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-linear-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-linear-to', async () => {
+  expect(
+    await run(
       [
         'mask-linear-to-0',
         'mask-linear-to-1.5',
@@ -19697,6 +19690,12 @@ test('mask-linear-to', async () => {
         'mask-linear-to-(color:--my-var)',
         'mask-linear-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -19877,13 +19876,7 @@ test('mask-linear-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-linear-to',
         'mask-linear-to-2.8175',
@@ -19914,16 +19907,19 @@ test('mask-linear-to', async () => {
         '-mask-linear-to-[25%]/foo',
         '-mask-linear-to-[-25%]/foo',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('mask-radial', async () => {
   expect(
-    await compileCss(
-      css`
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-circle',
         'mask-ellipse',
@@ -19933,6 +19929,9 @@ test('mask-radial', async () => {
         'mask-radial-farthest-corner',
         'mask-radial-[25%_25%]',
       ],
+      css`
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -20071,13 +20070,7 @@ test('mask-radial', async () => {
 
 test('mask-radial-at', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-radial-at-top',
         'mask-radial-at-top-left',
@@ -20089,6 +20082,12 @@ test('mask-radial-at', async () => {
         'mask-radial-at-right',
         'mask-radial-at-[25%]',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -20172,13 +20171,7 @@ test('mask-radial-at', async () => {
 
 test('mask-radial-from', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-radial-from-0',
         'mask-radial-from-1.5',
@@ -20192,6 +20185,12 @@ test('mask-radial-from', async () => {
         'mask-radial-from-(color:--my-var)',
         'mask-radial-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -20386,13 +20385,7 @@ test('mask-radial-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-radial-from',
         'mask-radial-from-2.8175',
@@ -20423,19 +20416,19 @@ test('mask-radial-from', async () => {
         '-mask-radial-from-[25%]/foo',
         '-mask-radial-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-radial-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-radial-to', async () => {
+  expect(
+    await run(
       [
         'mask-radial-to-0',
         'mask-radial-to-1.5',
@@ -20449,6 +20442,12 @@ test('mask-radial-to', async () => {
         'mask-radial-to-(color:--my-var)',
         'mask-radial-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -20643,13 +20642,7 @@ test('mask-radial-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-radial-to',
         'mask-radial-to-2.8175',
@@ -20680,17 +20673,23 @@ test('mask-radial-to', async () => {
         '-mask-radial-to-[25%]/foo',
         '-mask-radial-to-[-25%]/foo',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('mask-conic', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['mask-conic-45', 'mask-conic-[3rad]', '-mask-conic-45'],
       css`
         @tailwind utilities;
       `,
-      ['mask-conic-45', 'mask-conic-[3rad]', '-mask-conic-45'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -20812,13 +20811,7 @@ test('mask-conic', async () => {
 
 test('mask-conic-from', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-conic-from-0',
         'mask-conic-from-1.5',
@@ -20832,6 +20825,12 @@ test('mask-conic-from', async () => {
         'mask-conic-from-(color:--my-var)',
         'mask-conic-from-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -21012,13 +21011,7 @@ test('mask-conic-from', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-conic-from',
         'mask-conic-from-2.8175',
@@ -21049,19 +21042,19 @@ test('mask-conic-from', async () => {
         '-mask-conic-from-[25%]/foo',
         '-mask-conic-from-[-25%]/foo',
       ],
-    ),
-  ).toEqual('')
-})
-
-test('mask-conic-to', async () => {
-  expect(
-    await compileCss(
       css`
         @theme {
           --spacing: 0.25rem;
         }
         @tailwind utilities;
       `,
+    ),
+  ).toEqual('')
+})
+
+test('mask-conic-to', async () => {
+  expect(
+    await run(
       [
         'mask-conic-to-0',
         'mask-conic-to-1.5',
@@ -21075,6 +21068,12 @@ test('mask-conic-to', async () => {
         'mask-conic-to-(color:--my-var)',
         'mask-conic-to-(length:--my-var)',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -21255,13 +21254,7 @@ test('mask-conic-to', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'mask-conic-to',
         'mask-conic-to-2.8175',
@@ -21292,6 +21285,12 @@ test('mask-conic-to', async () => {
         '-mask-conic-to-[25%]/foo',
         '-mask-conic-to-[-25%]/foo',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
@@ -21788,14 +21787,7 @@ test('mix-blend', async () => {
 
 test('fill', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --fill-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'fill-red-500',
         'fill-red-500/50',
@@ -21816,6 +21808,13 @@ test('fill', async () => {
         'fill-[#0088cc]/[0.5]',
         'fill-[#0088cc]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --fill-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -21963,14 +21962,7 @@ test('fill', async () => {
 
 test('stroke', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --stroke-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // Color
         'stroke-red-500',
@@ -22012,6 +22004,13 @@ test('stroke', async () => {
         'stroke-[length:var(--my-width)]',
         'stroke-[percentage:var(--my-width)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --stroke-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22395,14 +22394,14 @@ test('object', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['object-center'],
       css`
         @theme {
           --object-position-center: top left;
         }
         @tailwind utilities;
       `,
-      ['object-center'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22419,7 +22418,8 @@ test('object', async () => {
 
 test('p', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['p-1', 'p-4', 'p-99', 'p-big', 'p-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22427,7 +22427,6 @@ test('p', async () => {
         }
         @tailwind utilities;
       `,
-      ['p-1', 'p-4', 'p-99', 'p-big', 'p-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22462,7 +22461,8 @@ test('p', async () => {
 
 test('px', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['px-1', 'px-99', 'px-2.5', 'px-big', 'px-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22470,7 +22470,6 @@ test('px', async () => {
         }
         @tailwind utilities;
       `,
-      ['px-1', 'px-99', 'px-2.5', 'px-big', 'px-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22505,7 +22504,8 @@ test('px', async () => {
 
 test('py', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['py-1', 'py-4', 'py-99', 'py-big', 'py-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22513,7 +22513,6 @@ test('py', async () => {
         }
         @tailwind utilities;
       `,
-      ['py-1', 'py-4', 'py-99', 'py-big', 'py-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22548,7 +22547,8 @@ test('py', async () => {
 
 test('pt', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['pt-1', 'pt-4', 'pt-99', 'pt-big', 'pt-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22556,7 +22556,6 @@ test('pt', async () => {
         }
         @tailwind utilities;
       `,
-      ['pt-1', 'pt-4', 'pt-99', 'pt-big', 'pt-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22591,7 +22590,8 @@ test('pt', async () => {
 
 test('ps', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['ps-1', 'ps-4', 'ps-99', 'ps-big', 'ps-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22599,7 +22599,6 @@ test('ps', async () => {
         }
         @tailwind utilities;
       `,
-      ['ps-1', 'ps-4', 'ps-99', 'ps-big', 'ps-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22634,7 +22633,8 @@ test('ps', async () => {
 
 test('pe', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['pe-1', 'pe-4', 'pe-99', 'pe-big', 'pe-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22642,7 +22642,6 @@ test('pe', async () => {
         }
         @tailwind utilities;
       `,
-      ['pe-1', 'pe-4', 'pe-99', 'pe-big', 'pe-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22677,7 +22676,8 @@ test('pe', async () => {
 
 test('pbs', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['pbs-1', 'pbs-4', 'pbs-99', 'pbs-big', 'pbs-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22685,7 +22685,6 @@ test('pbs', async () => {
         }
         @tailwind utilities;
       `,
-      ['pbs-1', 'pbs-4', 'pbs-99', 'pbs-big', 'pbs-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22720,7 +22719,8 @@ test('pbs', async () => {
 
 test('pbe', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['pbe-1', 'pbe-4', 'pbe-99', 'pbe-big', 'pbe-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22728,7 +22728,6 @@ test('pbe', async () => {
         }
         @tailwind utilities;
       `,
-      ['pbe-1', 'pbe-4', 'pbe-99', 'pbe-big', 'pbe-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22763,7 +22762,8 @@ test('pbe', async () => {
 
 test('pr', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['pr-1', 'pr-4', 'pr-99', 'pr-big', 'pr-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22771,7 +22771,6 @@ test('pr', async () => {
         }
         @tailwind utilities;
       `,
-      ['pr-1', 'pr-4', 'pr-99', 'pr-big', 'pr-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22806,7 +22805,8 @@ test('pr', async () => {
 
 test('pb', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['pb-1', 'pb-4', 'pb-99', 'pb-big', 'pb-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22814,7 +22814,6 @@ test('pb', async () => {
         }
         @tailwind utilities;
       `,
-      ['pb-1', 'pb-4', 'pb-99', 'pb-big', 'pb-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -22849,7 +22848,8 @@ test('pb', async () => {
 
 test('pl', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['pl-1', 'pl-4', 'pl-99', 'pl-big', 'pl-[4px]'],
       css`
         @theme {
           --spacing: 0.25rem;
@@ -22857,7 +22857,6 @@ test('pl', async () => {
         }
         @tailwind utilities;
       `,
-      ['pl-1', 'pl-4', 'pl-99', 'pl-big', 'pl-[4px]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -23035,16 +23034,7 @@ test('align', async () => {
 
 test('font', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --font-sans:
-            ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-            'Segoe UI Symbol', 'Noto Color Emoji';
-          --font-weight-bold: 650;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // font-family
         'font-sans',
@@ -23059,6 +23049,15 @@ test('font', async () => {
         'font-[100]',
         'font-[number:var(--my-weight)]',
       ],
+      css`
+        @theme {
+          --font-sans:
+            ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+            'Segoe UI Symbol', 'Noto Color Emoji';
+          --font-weight-bold: 650;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -23119,16 +23118,7 @@ test('font', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme reference {
-          --font-sans:
-            ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-            'Segoe UI Symbol', 'Noto Color Emoji';
-          --font-weight-bold: 650;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'font',
         // font-family
@@ -23148,6 +23138,15 @@ test('font', async () => {
         'font-[100]/foo',
         'font-[number:var(--my-weight)]/foo',
       ],
+      css`
+        @theme reference {
+          --font-sans:
+            ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+            'Segoe UI Symbol', 'Noto Color Emoji';
+          --font-weight-bold: 650;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
@@ -23307,13 +23306,7 @@ test('text-decoration-line', async () => {
 
 test('placeholder', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'placeholder-red-500',
         'placeholder-red-500/50',
@@ -23333,6 +23326,12 @@ test('placeholder', async () => {
         'placeholder-[#0088cc]/[0.5]',
         'placeholder-[#0088cc]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -23474,14 +23473,7 @@ test('placeholder', async () => {
 
 test('decoration', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --text-decoration-color-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // text-decoration-color
         'decoration-red-500',
@@ -23528,6 +23520,13 @@ test('decoration', async () => {
         'decoration-[length:var(--my-thickness)]',
         'decoration-[percentage:var(--my-thickness)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --text-decoration-color-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -23840,14 +23839,14 @@ test('decoration', async () => {
 
 test('animate', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['animate-spin', 'animate-none', 'animate-[bounce_1s_infinite]', 'animate-not-found'],
       css`
         @theme {
           --animate-spin: spin 1s linear infinite;
         }
         @tailwind utilities;
       `,
-      ['animate-spin', 'animate-none', 'animate-[bounce_1s_infinite]', 'animate-not-found'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -23883,14 +23882,14 @@ test('animate', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['animate-none'],
       css`
         @theme {
           --animate-none: bounce 1s infinite;
         }
         @tailwind utilities;
       `,
-      ['animate-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -23907,19 +23906,7 @@ test('animate', async () => {
 
 test('filter', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --blur-xl: 24px;
-          --color-red-500: #ef4444;
-          --drop-shadow: 0 1px 1px rgb(0 0 0 / 0.05);
-          --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
-        }
-        @theme inline {
-          --drop-shadow-multi: 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'filter',
         'filter-none',
@@ -23958,6 +23945,18 @@ test('filter', async () => {
         'sepia-[50%]',
         'sepia-[var(--value)]',
       ],
+      css`
+        @theme {
+          --blur-xl: 24px;
+          --color-red-500: #ef4444;
+          --drop-shadow: 0 1px 1px rgb(0 0 0 / 0.05);
+          --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
+        }
+        @theme inline {
+          --drop-shadow-multi: 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -24336,14 +24335,14 @@ test('filter', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['blur-none'],
       css`
         @theme {
           --blur-none: 2px;
         }
         @tailwind utilities;
       `,
-      ['blur-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -24447,13 +24446,7 @@ test('filter', async () => {
 
 test('backdrop-filter', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --blur-xl: 24px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'backdrop-filter',
         'backdrop-filter-none',
@@ -24489,6 +24482,12 @@ test('backdrop-filter', async () => {
         'backdrop-sepia-[50%]',
         'backdrop-sepia-[var(--value)]',
       ],
+      css`
+        @theme {
+          --blur-xl: 24px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -24827,14 +24826,14 @@ test('backdrop-filter', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['backdrop-blur-none'],
       css`
         @theme {
           --backdrop-blur-none: 2px;
         }
         @tailwind utilities;
       `,
-      ['backdrop-blur-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -24914,7 +24913,17 @@ test('backdrop-filter', async () => {
 
 test('transition', async () => {
   expect(
-    await compileCss(
+    await run(
+      [
+        'transition',
+        'transition-none',
+        'transition-all',
+        'transition-transform',
+        'transition-shadow',
+        'transition-colors',
+        'transition-opacity',
+        'transition-[var(--value)]',
+      ],
       css`
         @theme {
           --default-transition-timing-function: ease;
@@ -24926,16 +24935,6 @@ test('transition', async () => {
         }
         @tailwind utilities;
       `,
-      [
-        'transition',
-        'transition-none',
-        'transition-all',
-        'transition-transform',
-        'transition-shadow',
-        'transition-colors',
-        'transition-opacity',
-        'transition-[var(--value)]',
-      ],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -24994,7 +24993,8 @@ test('transition', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['transition', 'transition-all', 'transition-colors'],
       css`
         @theme inline {
           --default-transition-timing-function: ease;
@@ -25002,7 +25002,6 @@ test('transition', async () => {
         }
         @tailwind utilities;
       `,
-      ['transition', 'transition-all', 'transition-colors'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25027,11 +25026,11 @@ test('transition', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['transition-all'],
       css`
         @tailwind utilities;
       `,
-      ['transition-all'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25062,14 +25061,14 @@ test('transition', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['transition-colors'],
       css`
         @theme {
           --transition-property-colors: transform;
         }
         @tailwind utilities;
       `,
-      ['transition-colors'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25179,7 +25178,8 @@ test('duration', async () => {
 
 test('ease', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['ease-in', 'ease-out', 'ease-[var(--value)]'],
       css`
         @theme {
           --ease-in: cubic-bezier(0.4, 0, 1, 1);
@@ -25187,7 +25187,6 @@ test('ease', async () => {
         }
         @tailwind utilities;
       `,
-      ['ease-in', 'ease-out', 'ease-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25237,14 +25236,14 @@ test('ease', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['ease-linear'],
       css`
         @theme {
           --ease-linear: steps(4);
         }
         @tailwind utilities;
       `,
-      ['ease-linear'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25427,14 +25426,14 @@ test('contain', async () => {
 
 test('content', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['content-slash', 'content-["hello_world"]'],
       css`
         @theme {
           --content-slash: '/';
         }
         @tailwind utilities;
       `,
-      ['content-slash', 'content-["hello_world"]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25500,7 +25499,8 @@ test('forced-color-adjust', async () => {
 
 test('leading', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['leading-tight', 'leading-6', 'leading-[var(--value)]'],
       css`
         @theme {
           --leading-tight: 1.25;
@@ -25508,7 +25508,6 @@ test('leading', async () => {
         }
         @tailwind utilities;
       `,
-      ['leading-tight', 'leading-6', 'leading-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25559,14 +25558,14 @@ test('leading', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['leading-none'],
       css`
         @theme {
           --leading-none: 2;
         }
         @tailwind utilities;
       `,
-      ['leading-none'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25597,7 +25596,8 @@ test('leading', async () => {
 
 test('tracking', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['tracking-normal', 'tracking-wide', 'tracking-[var(--value)]', '-tracking-[var(--value)]'],
       css`
         @theme {
           --tracking-normal: 0em;
@@ -25605,7 +25605,6 @@ test('tracking', async () => {
         }
         @tailwind utilities;
       `,
-      ['tracking-normal', 'tracking-wide', 'tracking-[var(--value)]', '-tracking-[var(--value)]'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -25806,14 +25805,7 @@ test('font-variant-numeric', async () => {
 
 test('outline', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --outline-color-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'outline',
         'outline-hidden',
@@ -25863,6 +25855,13 @@ test('outline', async () => {
         'outline-[length:var(--my-width)]',
         'outline-[percentage:var(--my-width)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --outline-color-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -26114,14 +26113,14 @@ test('outline', async () => {
     "
   `)
   expect(
-    await compileCss(
+    await run(
+      ['outline'],
       css`
         @theme {
           --default-outline-width: 2px;
         }
         @tailwind utilities;
       `,
-      ['outline'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -26274,12 +26273,7 @@ test('opacity', async () => {
 
 test('underline-offset', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'underline-offset-auto',
         'underline-offset-4',
@@ -26289,6 +26283,11 @@ test('underline-offset', async () => {
         'underline-offset-[var(--value)]',
         '-underline-offset-[var(--value)]',
       ],
+      css`
+        @theme {
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -26338,14 +26337,14 @@ test('underline-offset', async () => {
   ).toEqual('')
 
   expect(
-    await compileCss(
+    await run(
+      ['underline-offset-auto'],
       css`
         @theme {
           --text-underline-offset-auto: 4px;
         }
         @tailwind utilities;
       `,
-      ['underline-offset-auto'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -26362,18 +26361,7 @@ test('underline-offset', async () => {
 
 test('text', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --spacing: 0.25rem;
-          --color-red-500: #ef4444;
-          --text-color-blue-500: #3b82f6;
-          --text-sm: 0.875rem;
-          --text-sm--line-height: 1.25rem;
-          --leading-snug: 1.375;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // color
         'text-red-500',
@@ -26427,6 +26415,17 @@ test('text', async () => {
         'text-[clamp(1rem,var(--size),3rem)]',
         'text-[clamp(1rem,var(--size),3rem)]/9',
       ],
+      css`
+        @theme {
+          --spacing: 0.25rem;
+          --color-red-500: #ef4444;
+          --text-color-blue-500: #3b82f6;
+          --text-sm: 0.875rem;
+          --text-sm--line-height: 1.25rem;
+          --leading-snug: 1.375;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -26702,13 +26701,7 @@ test('text', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme inline reference {
-          --text-sm: 0.875rem;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'text',
         // color
@@ -26734,21 +26727,19 @@ test('text', async () => {
         '-text-sm/[4px]',
         'text-[10px]/foo',
       ],
+      css`
+        @theme inline reference {
+          --text-sm: 0.875rem;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('text-shadow', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --text-shadow-2xs: 0px 1px 0px rgb(0 0 0 / 0.1);
-          --text-shadow-sm: 0px 1px 2px rgb(0 0 0 / 0.06), 0px 2px 2px rgb(0 0 0 / 0.06);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // Shadows
         'text-shadow-2xs',
@@ -26788,6 +26779,14 @@ test('text-shadow', async () => {
         'text-shadow-[color:var(--value)]/[0.5]',
         'text-shadow-[color:var(--value)]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --text-shadow-2xs: 0px 1px 0px rgb(0 0 0 / 0.1);
+          --text-shadow-sm: 0px 1px 2px rgb(0 0 0 / 0.06), 0px 2px 2px rgb(0 0 0 / 0.06);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -27105,16 +27104,7 @@ test('text-shadow', async () => {
 
 test('shadow', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --box-shadow-color-blue-500: #3b82f6;
-          --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-          --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // Shadows
         'shadow-sm',
@@ -27155,6 +27145,15 @@ test('shadow', async () => {
         'shadow-[color:var(--value)]/[0.5]',
         'shadow-[color:var(--value)]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --box-shadow-color-blue-500: #3b82f6;
+          --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+          --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -27580,15 +27579,7 @@ test('shadow', async () => {
 
 test('inset-shadow', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --inset-shadow: inset 0 2px 4px rgb(0 0 0 / 0.05);
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // Shadows
         'inset-shadow',
@@ -27630,6 +27621,14 @@ test('inset-shadow', async () => {
         'inset-shadow-[color:var(--value)]/[0.5]',
         'inset-shadow-[color:var(--value)]/[50%]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --inset-shadow: inset 0 2px 4px rgb(0 0 0 / 0.05);
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -28064,14 +28063,7 @@ test('inset-shadow', async () => {
 
 test('ring', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --ring-color-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // ring color
         'ring-inset',
@@ -28111,6 +28103,13 @@ test('ring', async () => {
         'ring-[12px]',
         'ring-[length:var(--my-width)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --ring-color-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -28434,14 +28433,14 @@ test('ring', async () => {
     "
   `)
   expect(
-    await compileCss(
+    await run(
+      ['ring'],
       css`
         @theme {
           --default-ring-width: 2px;
         }
         @tailwind utilities;
       `,
-      ['ring'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -28591,13 +28590,7 @@ test('ring', async () => {
 
 test('inset-ring', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // ring color
         'inset-ring-red-500',
@@ -28635,6 +28628,12 @@ test('inset-ring', async () => {
         'inset-ring-[12px]',
         'inset-ring-[length:var(--my-width)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -28987,14 +28986,7 @@ test('inset-ring', async () => {
 
 test('ring-offset', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --color-red-500: #ef4444;
-          --ring-offset-color-blue-500: #3b82f6;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         // ring color
         'ring-offset-inset',
@@ -29031,6 +29023,13 @@ test('ring-offset', async () => {
         'ring-offset-[12px]',
         'ring-offset-[length:var(--my-width)]',
       ],
+      css`
+        @theme {
+          --color-red-500: #ef4444;
+          --ring-offset-color-blue-500: #3b82f6;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -29303,7 +29302,8 @@ test('@container', async () => {
 describe('spacing utilities', () => {
   test('`--spacing: initial` disables the spacing multiplier', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['px-1', 'px-4'],
         css`
           @theme {
             --spacing: initial;
@@ -29311,7 +29311,6 @@ describe('spacing utilities', () => {
           }
           @tailwind utilities;
         `,
-        ['px-1', 'px-4'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29328,7 +29327,8 @@ describe('spacing utilities', () => {
 
   test('`--spacing-*: initial` disables the spacing multiplier', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['px-1', 'px-4'],
         css`
           @theme {
             --spacing-*: initial;
@@ -29336,7 +29336,6 @@ describe('spacing utilities', () => {
           }
           @tailwind utilities;
         `,
-        ['px-1', 'px-4'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29353,14 +29352,14 @@ describe('spacing utilities', () => {
 
   test('only multiples of 0.25 with no trailing zeroes are supported with the spacing multiplier', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['px-0.25', 'px-1.5', 'px-2.75', 'px-0.375', 'px-2.50', 'px-.75'],
         css`
           @theme {
             --spacing: 4px;
           }
           @tailwind utilities;
         `,
-        ['px-0.25', 'px-1.5', 'px-2.75', 'px-0.375', 'px-2.50', 'px-.75'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29385,21 +29384,22 @@ describe('spacing utilities', () => {
 
   test('spacing utilities must have a value', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['px'],
         css`
           @theme reference {
             --spacing: 4px;
           }
           @tailwind utilities;
         `,
-        ['px'],
       ),
     ).toEqual('')
   })
 
   test('--spacing-* variables take precedence over --container-* variables', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['w-sm', 'max-w-sm', 'min-w-sm', 'basis-sm'],
         css`
           @theme {
             --spacing-sm: 8px;
@@ -29407,7 +29407,6 @@ describe('spacing utilities', () => {
           }
           @tailwind utilities;
         `,
-        ['w-sm', 'max-w-sm', 'min-w-sm', 'basis-sm'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29480,7 +29479,8 @@ describe('custom utilities', () => {
 
   test('custom static utility', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-trim', 'lg:text-trim'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -29495,7 +29495,6 @@ describe('custom utilities', () => {
             text-box-edge: cap alphabetic;
           }
         `,
-        ['text-trim', 'lg:text-trim'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29532,14 +29531,14 @@ describe('custom utilities', () => {
     `
 
     // `foo` is not used yet:
-    expect(await compileCss(input, [])).toMatchInlineSnapshot(`
+    expect(await run([], input)).toMatchInlineSnapshot(`
       "
       @layer utilities;
       "
     `)
 
     // `foo` is used, and the CSS variable is emitted:
-    expect(await compileCss(input, ['foo'])).toMatchInlineSnapshot(`
+    expect(await run(['foo'], input)).toMatchInlineSnapshot(`
       "
       @layer utilities {
         .foo {
@@ -29556,7 +29555,8 @@ describe('custom utilities', () => {
 
   test('custom static utility (negative)', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['-example', 'lg:-example'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -29566,7 +29566,6 @@ describe('custom utilities', () => {
             value: -1;
           }
         `,
-        ['-example', 'lg:-example'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29581,7 +29580,8 @@ describe('custom utilities', () => {
 
   test('Multiple static utilities are merged', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['really-round'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -29596,7 +29596,6 @@ describe('custom utilities', () => {
             border-radius: 30rem;
           }
         `,
-        ['really-round'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29612,7 +29611,8 @@ describe('custom utilities', () => {
 
   test('custom utilities support some special characters', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['push-1/2', 'push-50%'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -29626,7 +29626,6 @@ describe('custom utilities', () => {
             right: 50%;
           }
         `,
-        ['push-1/2', 'push-50%'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29641,7 +29640,8 @@ describe('custom utilities', () => {
 
   test('can override specific versions of a functional utility with a static utility', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['text-sm'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -29658,7 +29658,6 @@ describe('custom utilities', () => {
             text-rendering: optimizeLegibility;
           }
         `,
-        ['text-sm'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29677,7 +29676,8 @@ describe('custom utilities', () => {
 
   test('can override the default value of a functional utility', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['rounded', 'rounded-xl', 'rounded-[33px]'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -29691,7 +29691,6 @@ describe('custom utilities', () => {
             border-radius: 50rem;
           }
         `,
-        ['rounded', 'rounded-xl', 'rounded-[33px]'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29714,7 +29713,8 @@ describe('custom utilities', () => {
 
   test('custom utilities are sorted by used properties', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['top-[100px]', 'push-left', 'right-[100px]', 'bottom-[100px]'],
         css`
           @layer utilities {
             @tailwind utilities;
@@ -29724,7 +29724,6 @@ describe('custom utilities', () => {
             right: 100%;
           }
         `,
-        ['top-[100px]', 'push-left', 'right-[100px]', 'bottom-[100px]'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29777,7 +29776,8 @@ describe('custom utilities', () => {
 
   test('custom utilities work with `@apply`', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['foo', 'hover:foo', 'bar'],
         css`
           @utility foo {
             @apply flex flex-col underline;
@@ -29793,7 +29793,6 @@ describe('custom utilities', () => {
 
           @tailwind utilities;
         `,
-        ['foo', 'hover:foo', 'bar'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29824,7 +29823,8 @@ describe('custom utilities', () => {
 
   test('referencing custom utilities in custom utilities via `@apply` should work', async () => {
     expect(
-      await compileCss(
+      await run(
+        ['bar'],
         css`
           @utility foo {
             @apply flex flex-col underline;
@@ -29836,7 +29836,6 @@ describe('custom utilities', () => {
 
           @tailwind utilities;
         `,
-        ['bar'],
       ),
     ).toMatchInlineSnapshot(`
       "
@@ -29857,7 +29856,8 @@ describe('custom utilities', () => {
 
   test('custom utilities with `@apply` causing circular dependencies should error', async () => {
     await expect(() =>
-      compileCss(
+      run(
+        ['foo', 'bar'],
         css`
           @utility foo {
             @apply flex-wrap hover:bar;
@@ -29869,7 +29869,6 @@ describe('custom utilities', () => {
 
           @tailwind utilities;
         `,
-        ['foo', 'bar'],
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: You cannot \`@apply\` the \`hover:bar\` utility here because it creates a circular dependency.]`,
@@ -29878,7 +29877,8 @@ describe('custom utilities', () => {
 
   test('custom utilities with `@apply` causing circular dependencies should error (deeply nesting)', async () => {
     await expect(() =>
-      compileCss(
+      run(
+        ['foo', 'bar'],
         css`
           @utility foo {
             .bar {
@@ -29900,7 +29900,6 @@ describe('custom utilities', () => {
 
           @tailwind utilities;
         `,
-        ['foo', 'bar'],
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: You cannot \`@apply\` the \`hover:bar\` utility here because it creates a circular dependency.]`,
@@ -29909,7 +29908,8 @@ describe('custom utilities', () => {
 
   test('custom utilities with `@apply` causing circular dependencies should error (multiple levels)', async () => {
     await expect(() =>
-      compileCss(
+      run(
+        ['foo', 'bar'],
         css`
           body {
             @apply foo;
@@ -29929,7 +29929,6 @@ describe('custom utilities', () => {
 
           @tailwind utilities;
         `,
-        ['foo', 'bar'],
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: You cannot \`@apply\` the \`hover:bar\` utility here because it creates a circular dependency.]`,
@@ -29946,7 +29945,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example', 'example-foo'])).toEqual('')
+      expect(await run(['example', 'example-foo'], input)).toEqual('')
     })
 
     test('functional utilities must resolve at least one `--value(…)`', async () => {
@@ -29958,7 +29957,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-1', 'example-2'])).toMatchInlineSnapshot(`
+      expect(await run(['example-1', 'example-2'], input)).toMatchInlineSnapshot(`
         "
         .example-1 {
           --resolved-value: 1;
@@ -29970,7 +29969,7 @@ describe('custom utilities', () => {
         "
       `)
 
-      expect(await compileCss(input, ['example', 'example-foo', 'example-2.5'])).toEqual('')
+      expect(await run(['example', 'example-foo', 'example-2.5'], input)).toEqual('')
     })
 
     test('resolving values from `@theme`', async () => {
@@ -29989,7 +29988,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-1', 'example-2', 'example-4', 'example-a']))
+      expect(await run(['example-1', 'example-2', 'example-4', 'example-a'], input))
         .toMatchInlineSnapshot(`
           "
           .example-1 {
@@ -30009,7 +30008,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-3', 'example-gitlab'])).toEqual('')
+      expect(await run(['example-3', 'example-gitlab'], input)).toEqual('')
     })
 
     test('functional utility with double-dash separator', async () => {
@@ -30027,8 +30026,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['border--0', 'border--1', 'border--2']))
-        .toMatchInlineSnapshot(`
+      expect(await run(['border--0', 'border--1', 'border--2'], input)).toMatchInlineSnapshot(`
           "
           .border--0 {
             border-color: var(--color-border-0, #e5e7eb);
@@ -30043,7 +30041,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['border--3'])).toEqual('')
+      expect(await run(['border--3'], input)).toEqual('')
     })
 
     test('resolving values from `@theme`, with `--example-*` syntax', async () => {
@@ -30066,7 +30064,7 @@ describe('custom utilities', () => {
           @tailwind utilities;
         `
 
-      expect(await compileCss(input, ['example-1', 'example-2', 'example-4', 'example-a']))
+      expect(await run(['example-1', 'example-2', 'example-4', 'example-a'], input))
         .toMatchInlineSnapshot(`
           "
           .example-1 {
@@ -30086,7 +30084,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-3', 'example-gitlab'])).toEqual('')
+      expect(await run(['example-3', 'example-gitlab'], input)).toEqual('')
     })
 
     test('resolving values from `@theme`, with `--example-\\*` syntax (prettier friendly)', async () => {
@@ -30105,7 +30103,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-1', 'example-2', 'example-4', 'example-a']))
+      expect(await run(['example-1', 'example-2', 'example-4', 'example-a'], input))
         .toMatchInlineSnapshot(`
           "
           .example-1 {
@@ -30125,7 +30123,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-3', 'example-gitlab'])).toEqual('')
+      expect(await run(['example-3', 'example-gitlab'], input)).toEqual('')
     })
 
     test('resolving bare values', async () => {
@@ -30137,8 +30135,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-1', 'example-76', 'example-971']))
-        .toMatchInlineSnapshot(`
+      expect(await run(['example-1', 'example-76', 'example-971'], input)).toMatchInlineSnapshot(`
           "
           .example-1 {
             --resolved-value: 1;
@@ -30153,7 +30150,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-foo'])).toEqual('')
+      expect(await run(['example-foo'], input)).toEqual('')
     })
 
     test('bare values with unsupported data types should result in a warning', async () => {
@@ -30166,7 +30163,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['paint-#0088cc', 'paint-red'])).toEqual('')
+      expect(await run(['paint-#0088cc', 'paint-red'], input)).toEqual('')
       expect(spy.mock.calls).toMatchInlineSnapshot(`
         [
           [
@@ -30193,14 +30190,14 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-revert'])).toMatchInlineSnapshot(`
+      expect(await run(['example-revert'], input)).toMatchInlineSnapshot(`
         "
         .example-revert {
           --resolved-value: revert;
         }
         "
       `)
-      expect(await compileCss(input, ['example-initial'])).toEqual('')
+      expect(await run(['example-initial'], input)).toEqual('')
     })
 
     test('resolving bare values with constraints for integer, percentage, and ratio', async () => {
@@ -30214,7 +30211,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-1', 'example-0.5', 'example-20%', 'example-2/3']))
+      expect(await run(['example-1', 'example-0.5', 'example-20%', 'example-2/3'], input))
         .toMatchInlineSnapshot(`
           "
           .example-0\\.5 {
@@ -30235,13 +30232,10 @@ describe('custom utilities', () => {
           "
         `)
       expect(
-        await compileCss(input, [
-          'example-1.23',
-          'example-12.34%',
-          'example-1.2/3',
-          'example-1/2.3',
-          'example-1.2/3.4',
-        ]),
+        await run(
+          ['example-1.23', 'example-12.34%', 'example-1.2/3', 'example-1/2.3', 'example-1.2/3.4'],
+          input,
+        ),
       ).toEqual('')
     })
 
@@ -30255,7 +30249,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-#0088cc', 'example-foo'])).toEqual('')
+      expect(await run(['example-#0088cc', 'example-foo'], input)).toEqual('')
       expect(
         `\n${spy.mock.calls
           .map((c) => c.join(' '))
@@ -30284,13 +30278,16 @@ describe('custom utilities', () => {
       `
 
       expect(
-        await compileCss(input, [
-          'example-[1]',
-          'example-[76]',
-          'example-[971]',
-          'example-[integer:var(--my-value)]',
-          'example-(integer:my-value)',
-        ]),
+        await run(
+          [
+            'example-[1]',
+            'example-[76]',
+            'example-[971]',
+            'example-[integer:var(--my-value)]',
+            'example-(integer:my-value)',
+          ],
+          input,
+        ),
       ).toMatchInlineSnapshot(`
         "
         .example-\\[1\\] {
@@ -30311,14 +30308,17 @@ describe('custom utilities', () => {
         "
       `)
       expect(
-        await compileCss(input, [
-          'example-[#0088cc]',
-          'example-[1px]',
-          'example-[var(--my-value)]',
-          'example-(--my-value)',
-          'example-[color:var(--my-value)]',
-          'example-(color:--my-value)',
-        ]),
+        await run(
+          [
+            'example-[#0088cc]',
+            'example-[1px]',
+            'example-[var(--my-value)]',
+            'example-(--my-value)',
+            'example-[color:var(--my-value)]',
+            'example-(color:--my-value)',
+          ],
+          input,
+        ),
       ).toEqual('')
     })
 
@@ -30332,13 +30332,16 @@ describe('custom utilities', () => {
       `
 
       expect(
-        await compileCss(input, [
-          'example-[1]',
-          'example-[76]',
-          'example-[971]',
-          'example-[var(--my-value)]',
-          'example-(--my-value)',
-        ]),
+        await run(
+          [
+            'example-[1]',
+            'example-[76]',
+            'example-[971]',
+            'example-[var(--my-value)]',
+            'example-(--my-value)',
+          ],
+          input,
+        ),
       ).toMatchInlineSnapshot(`
         "
         .example-\\(--my-value\\) {
@@ -30374,13 +30377,16 @@ describe('custom utilities', () => {
       `
 
       expect(
-        await compileCss(input, [
-          'example-[1]',
-          'example-[76]',
-          'example-[971]',
-          'example-[var(--my-value)]',
-          'example-(--my-value)',
-        ]),
+        await run(
+          [
+            'example-[1]',
+            'example-[76]',
+            'example-[971]',
+            'example-[var(--my-value)]',
+            'example-(--my-value)',
+          ],
+          input,
+        ),
       ).toMatchInlineSnapshot(`
         "
         .example-\\(--my-value\\) {
@@ -30416,13 +30422,16 @@ describe('custom utilities', () => {
       `
 
       expect(
-        await compileCss(input, [
-          'example-[1]',
-          'example-[76]',
-          'example-[971]',
-          'example-[var(--my-value)]',
-          'example-(--my-value)',
-        ]),
+        await run(
+          [
+            'example-[1]',
+            'example-[76]',
+            'example-[971]',
+            'example-[var(--my-value)]',
+            'example-(--my-value)',
+          ],
+          input,
+        ),
       ).toMatchInlineSnapshot(`
         "
         .example-\\(--my-value\\) {
@@ -30463,8 +30472,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-a', 'example-76', 'example-[123]']))
-        .toMatchInlineSnapshot(`
+      expect(await run(['example-a', 'example-76', 'example-[123]'], input)).toMatchInlineSnapshot(`
           "
           .example-76 {
             --resolved-value: 76;
@@ -30479,7 +30487,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-[#0088cc]', 'example-[1px]'])).toEqual('')
+      expect(await run(['example-[#0088cc]', 'example-[1px]'], input)).toEqual('')
     })
 
     test('in combination with calc to produce different data types of values', async () => {
@@ -30497,7 +30505,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-full', 'example-12', 'example-[20%]']))
+      expect(await run(['example-full', 'example-12', 'example-[20%]'], input))
         .toMatchInlineSnapshot(`
           "
           .example-12 {
@@ -30513,7 +30521,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-half', 'example-[#0088cc]'])).toEqual('')
+      expect(await run(['example-half', 'example-[#0088cc]'], input)).toEqual('')
     })
 
     test('shorthand if resulting values are of the same type', async () => {
@@ -30530,7 +30538,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-37', 'example-[50%]', 'example-full']))
+      expect(await run(['example-37', 'example-[50%]', 'example-full'], input))
         .toMatchInlineSnapshot(`
           "
           .example-37 {
@@ -30546,7 +30554,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-foo', 'example-[13px]'])).toEqual('')
+      expect(await run(['example-foo', 'example-[13px]'], input)).toEqual('')
     })
 
     test('negative values', async () => {
@@ -30567,14 +30575,17 @@ describe('custom utilities', () => {
       `
 
       expect(
-        await compileCss(input, [
-          'example-full',
-          '-example-full',
-          'example-[10px]',
-          '-example-[10px]',
-          'example-[20%]',
-          '-example-[20%]',
-        ]),
+        await run(
+          [
+            'example-full',
+            '-example-full',
+            'example-[10px]',
+            '-example-[10px]',
+            'example-[20%]',
+            '-example-[20%]',
+          ],
+          input,
+        ),
       ).toMatchInlineSnapshot(`
         "
         .-example-\\[10px\\] {
@@ -30602,7 +30613,7 @@ describe('custom utilities', () => {
         }
         "
       `)
-      expect(await compileCss(input, ['example-10'])).toEqual('')
+      expect(await run(['example-10'], input)).toEqual('')
     })
 
     test('using the same value multiple times', async () => {
@@ -30615,7 +30626,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-12'])).toMatchInlineSnapshot(`
+      expect(await run(['example-12'], input)).toMatchInlineSnapshot(`
         "
         .example-12 {
           --resolved-value: calc(var(--spacing) * 12)
@@ -30638,7 +30649,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-12'])).toMatchInlineSnapshot(`
+      expect(await run(['example-12'], input)).toMatchInlineSnapshot(`
         "
         :root, :host {
           --spacing: 4px;
@@ -30664,7 +30675,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-12'])).toMatchInlineSnapshot(`
+      expect(await run(['example-12'], input)).toMatchInlineSnapshot(`
         "
         .example-12 {
           margin: 48px;
@@ -30682,7 +30693,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example', 'example-123'])).toMatchInlineSnapshot(`
+      expect(await run(['example', 'example-123'], input)).toMatchInlineSnapshot(`
         "
         .example {
           --resolved-value: 4;
@@ -30694,7 +30705,7 @@ describe('custom utilities', () => {
         "
       `)
 
-      expect(await compileCss(input, ['example-foo'])).toEqual('')
+      expect(await run(['example-foo'], input)).toEqual('')
     })
 
     test('functional utilities can use `--default(…)` in complex expressions', async () => {
@@ -30706,7 +30717,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example', 'example-123'])).toMatchInlineSnapshot(`
+      expect(await run(['example', 'example-123'], input)).toMatchInlineSnapshot(`
         "
         .example {
           --resolved-value: calc(4 * 2);
@@ -30718,7 +30729,7 @@ describe('custom utilities', () => {
         "
       `)
 
-      expect(await compileCss(input, ['example-foo'])).toEqual('')
+      expect(await run(['example-foo'], input)).toEqual('')
     })
 
     test('functional utilities can use `--default(…)` with `--modifier(…)`', async () => {
@@ -30731,7 +30742,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example', 'example/25'])).toMatchInlineSnapshot(`
+      expect(await run(['example', 'example/25'], input)).toMatchInlineSnapshot(`
         "
         .example\\/25 {
           --resolved-value: 4;
@@ -30744,7 +30755,7 @@ describe('custom utilities', () => {
         "
       `)
 
-      expect(await compileCss(input, ['example/foo'])).toEqual('')
+      expect(await run(['example/foo'], input)).toEqual('')
     })
 
     test('functional utilities can use `--default(…)` in `--modifier(…)`', async () => {
@@ -30757,7 +30768,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-123', 'example-123/25'])).toMatchInlineSnapshot(`
+      expect(await run(['example-123', 'example-123/25'], input)).toMatchInlineSnapshot(`
         "
         .example-123 {
           --resolved-value: 123;
@@ -30771,7 +30782,7 @@ describe('custom utilities', () => {
         "
       `)
 
-      expect(await compileCss(input, ['example-123/foo'])).toEqual('')
+      expect(await run(['example-123/foo'], input)).toEqual('')
     })
 
     test('functional utilities can use `--default(…)` in `--value(…)` and `--modifier(…)`', async () => {
@@ -30784,7 +30795,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example', 'example/1', 'example-1', 'example-1/1']))
+      expect(await run(['example', 'example/1', 'example-1', 'example-1/1'], input))
         .toMatchInlineSnapshot(`
           "
           .example {
@@ -30809,7 +30820,7 @@ describe('custom utilities', () => {
           "
         `)
 
-      expect(await compileCss(input, ['example-123/foo'])).toEqual('')
+      expect(await run(['example-123/foo'], input)).toEqual('')
     })
 
     test('modifiers', async () => {
@@ -30830,14 +30841,17 @@ describe('custom utilities', () => {
       `
 
       expect(
-        await compileCss(input, [
-          'example-sm',
-          'example-sm/7',
-          'example-[12px]',
-          'example-[12px]/[16px]',
-          'example-sm/literal',
-          'example-sm/literal-2',
-        ]),
+        await run(
+          [
+            'example-sm',
+            'example-sm/7',
+            'example-[12px]',
+            'example-[12px]/[16px]',
+            'example-sm/literal',
+            'example-sm/literal-2',
+          ],
+          input,
+        ),
       ).toMatchInlineSnapshot(`
         "
         .example-\\[12px\\]\\/\\[16px\\] {
@@ -30872,12 +30886,10 @@ describe('custom utilities', () => {
         "
       `)
       expect(
-        await compileCss(input, [
-          'example-foo',
-          'example-foo/[12px]',
-          'example-foo/12',
-          'example-sm/unknown-literal',
-        ]),
+        await run(
+          ['example-foo', 'example-foo/[12px]', 'example-foo/12', 'example-sm/unknown-literal'],
+          input,
+        ),
       ).toEqual('')
     })
 
@@ -30894,7 +30906,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-video', 'example-1/1', 'example-[7/9]']))
+      expect(await run(['example-video', 'example-1/1', 'example-[7/9]'], input))
         .toMatchInlineSnapshot(`
           "
           .example-1\\/1 {
@@ -30910,7 +30922,7 @@ describe('custom utilities', () => {
           }
           "
         `)
-      expect(await compileCss(input, ['example-foo'])).toEqual('')
+      expect(await run(['example-foo'], input)).toEqual('')
     })
 
     test('resolve theme values with sub-namespace (--text- * --line-height)', async () => {
@@ -30929,7 +30941,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-xs', 'example-xs/6'])).toMatchInlineSnapshot(`
+      expect(await run(['example-xs', 'example-xs/6'], input)).toMatchInlineSnapshot(`
         "
         .example-xs\\/6 {
           font-size: var(--text-xs, .75rem);
@@ -30943,7 +30955,7 @@ describe('custom utilities', () => {
         }
         "
       `)
-      expect(await compileCss(input, ['example-foo', 'example-xs/foo'])).toEqual('')
+      expect(await run(['example-foo', 'example-xs/foo'], input)).toEqual('')
     })
 
     test('resolve theme values with sub-namespace (--text-\\* --line-height)', async () => {
@@ -30962,7 +30974,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-xs', 'example-xs/6'])).toMatchInlineSnapshot(`
+      expect(await run(['example-xs', 'example-xs/6'], input)).toMatchInlineSnapshot(`
         "
         .example-xs\\/6 {
           font-size: var(--text-xs, .75rem);
@@ -30976,7 +30988,7 @@ describe('custom utilities', () => {
         }
         "
       `)
-      expect(await compileCss(input, ['example-foo', 'example-xs/foo'])).toEqual('')
+      expect(await run(['example-foo', 'example-xs/foo'], input)).toEqual('')
     })
 
     test('resolve theme values with sub-namespace (--value(--text --line-height))', async () => {
@@ -30995,7 +31007,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-xs', 'example-xs/6'])).toMatchInlineSnapshot(`
+      expect(await run(['example-xs', 'example-xs/6'], input)).toMatchInlineSnapshot(`
         "
         .example-xs\\/6 {
           font-size: var(--text-xs, .75rem);
@@ -31009,7 +31021,7 @@ describe('custom utilities', () => {
         }
         "
       `)
-      expect(await compileCss(input, ['example-foo', 'example-xs/foo'])).toEqual('')
+      expect(await run(['example-foo', 'example-xs/foo'], input)).toEqual('')
     })
 
     test('resolve theme values with sub-namespace (--value(--text-*--line-height))', async () => {
@@ -31028,7 +31040,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-xs', 'example-xs/6'])).toMatchInlineSnapshot(`
+      expect(await run(['example-xs', 'example-xs/6'], input)).toMatchInlineSnapshot(`
         "
         .example-xs\\/6 {
           font-size: var(--text-xs, .75rem);
@@ -31042,7 +31054,7 @@ describe('custom utilities', () => {
         }
         "
       `)
-      expect(await compileCss(input, ['example-foo', 'example-xs/foo'])).toEqual('')
+      expect(await run(['example-foo', 'example-xs/foo'], input)).toEqual('')
     })
 
     test('variables used in `@utility` will not be emitted if the utility is not used', async () => {
@@ -31060,7 +31072,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['flex'])).toMatchInlineSnapshot(`
+      expect(await run(['flex'], input)).toMatchInlineSnapshot(`
         "
         .flex {
           display: flex;
@@ -31084,7 +31096,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['example-foo'])).toMatchInlineSnapshot(`
+      expect(await run(['example-foo'], input)).toMatchInlineSnapshot(`
         "
         :root, :host {
           --example-foo: red;
@@ -31121,7 +31133,7 @@ describe('custom utilities', () => {
         @tailwind utilities;
       `
 
-      expect(await compileCss(input, ['mask-r-20%'])).toMatchInlineSnapshot(`
+      expect(await run(['mask-r-20%'], input)).toMatchInlineSnapshot(`
         "
         .mask-r-20\\% {
           --mask-right: linear-gradient(to left, transparent, black 20%);
@@ -31147,7 +31159,7 @@ describe('custom utilities', () => {
       @tailwind utilities;
     `
 
-    expect(await compileCss(input, ['example-a'])).toMatchInlineSnapshot(`
+    expect(await run(['example-a'], input)).toMatchInlineSnapshot(`
       "
       :root, :host {
         --example-a: 8;
@@ -31173,7 +31185,7 @@ describe('custom utilities', () => {
       @tailwind utilities;
     `
 
-    expect(await compileCss(input, ['example-a'])).toMatchInlineSnapshot(`
+    expect(await run(['example-a'], input)).toMatchInlineSnapshot(`
       "
       .example-a {
         --resolved-value: var(--example-a, 8);
@@ -31195,7 +31207,7 @@ describe('custom utilities', () => {
       @tailwind utilities;
     `
 
-    expect(await compileCss(input, ['example-a'])).toMatchInlineSnapshot(`
+    expect(await run(['example-a'], input)).toMatchInlineSnapshot(`
       "
       .example-a {
         --resolved-value: 8;
@@ -31217,7 +31229,7 @@ describe('custom utilities', () => {
       @tailwind utilities;
     `
 
-    expect(await compileCss(input, ['example-a'])).toMatchInlineSnapshot(`
+    expect(await run(['example-a'], input)).toMatchInlineSnapshot(`
       "
       .example-a {
         --resolved-value: 8;
@@ -31244,7 +31256,7 @@ describe('custom utilities', () => {
       @tailwind utilities;
     `
 
-    expect(await compileCss(input, ['example-xs'])).toMatchInlineSnapshot(`
+    expect(await run(['example-xs'], input)).toMatchInlineSnapshot(`
       "
       .example-xs {
         font-size: var(--text-xs, .75rem);
@@ -31272,7 +31284,7 @@ describe('custom utilities', () => {
       @tailwind utilities;
     `
 
-    expect(await compileCss(input, ['example-xs'])).toMatchInlineSnapshot(`
+    expect(await run(['example-xs'], input)).toMatchInlineSnapshot(`
       "
       .example-xs {
         font-size: .75rem;
@@ -31300,7 +31312,7 @@ describe('custom utilities', () => {
       @tailwind utilities;
     `
 
-    expect(await compileCss(input, ['foo-red-500', 'foo-123'])).toMatchInlineSnapshot(`
+    expect(await run(['foo-red-500', 'foo-123'], input)).toMatchInlineSnapshot(`
       "
       :root, :host {
         --color-red-500: #ef4444;

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15937,6 +15937,13 @@ test('mask-size', async () => {
 })
 
 test('mask-t-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -15951,12 +15958,7 @@ test('mask-t-from', async () => {
         'mask-t-from-(color:--my-var)',
         'mask-t-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16189,17 +16191,19 @@ test('mask-t-from', async () => {
         '-mask-l-from-[25%]/foo',
         '-mask-l-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-t-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -16214,12 +16218,7 @@ test('mask-t-to', async () => {
         'mask-t-to-(color:--my-var)',
         'mask-t-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16452,17 +16451,19 @@ test('mask-t-to', async () => {
         '-mask-l-from-[25%]/foo',
         '-mask-l-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-r-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -16478,12 +16479,7 @@ test('mask-r-from', async () => {
         'mask-r-from-(color:--my-var)',
         'mask-r-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16716,17 +16712,19 @@ test('mask-r-from', async () => {
         '-mask-r-from-[25%]/foo',
         '-mask-r-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-r-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -16742,12 +16740,7 @@ test('mask-r-to', async () => {
         'mask-r-to-(color:--my-var)',
         'mask-r-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -16980,17 +16973,19 @@ test('mask-r-to', async () => {
         '-mask-r-to-[25%]/foo',
         '-mask-r-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-b-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -17006,12 +17001,7 @@ test('mask-b-from', async () => {
         'mask-b-from-(color:--my-var)',
         'mask-b-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -17244,17 +17234,19 @@ test('mask-b-from', async () => {
         '-mask-b-from-[25%]/foo',
         '-mask-b-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-b-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -17270,12 +17262,7 @@ test('mask-b-to', async () => {
         'mask-b-to-(color:--my-var)',
         'mask-b-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -17508,17 +17495,19 @@ test('mask-b-to', async () => {
         '-mask-b-to-[25%]/foo',
         '-mask-b-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-l-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -17534,12 +17523,7 @@ test('mask-l-from', async () => {
         'mask-l-from-(color:--my-var)',
         'mask-l-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -17772,17 +17756,19 @@ test('mask-l-from', async () => {
         '-mask-l-from-[25%]/foo',
         '-mask-l-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-l-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -17798,12 +17784,7 @@ test('mask-l-to', async () => {
         'mask-l-to-(color:--my-var)',
         'mask-l-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18036,17 +18017,19 @@ test('mask-l-to', async () => {
         '-mask-l-to-[25%]/foo',
         '-mask-l-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-x-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -18062,12 +18045,7 @@ test('mask-x-from', async () => {
         'mask-x-from-(color:--my-var)',
         'mask-x-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18346,17 +18324,19 @@ test('mask-x-from', async () => {
         '-mask-x-from-[25%]/foo',
         '-mask-x-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-x-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -18372,12 +18352,7 @@ test('mask-x-to', async () => {
         'mask-x-to-(color:--my-var)',
         'mask-x-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18656,17 +18631,19 @@ test('mask-x-to', async () => {
         '-mask-x-to-[25%]/foo',
         '-mask-x-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-y-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -18682,12 +18659,7 @@ test('mask-y-from', async () => {
         'mask-y-from-(color:--my-var)',
         'mask-y-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -18966,17 +18938,19 @@ test('mask-y-from', async () => {
         '-mask-y-from-[25%]/foo',
         '-mask-y-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-y-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -18992,12 +18966,7 @@ test('mask-y-to', async () => {
         'mask-y-to-(color:--my-var)',
         'mask-y-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -19276,12 +19245,7 @@ test('mask-y-to', async () => {
         '-mask-y-to-[25%]/foo',
         '-mask-y-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
@@ -19407,6 +19371,13 @@ test('mask-linear', async () => {
 })
 
 test('mask-linear-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -19422,12 +19393,7 @@ test('mask-linear-from', async () => {
         'mask-linear-from-(color:--my-var)',
         'mask-linear-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -19639,17 +19605,19 @@ test('mask-linear-from', async () => {
         '-mask-linear-from-[25%]/foo',
         '-mask-linear-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-linear-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -19665,12 +19633,7 @@ test('mask-linear-to', async () => {
         'mask-linear-to-(color:--my-var)',
         'mask-linear-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -19882,12 +19845,7 @@ test('mask-linear-to', async () => {
         '-mask-linear-to-[25%]/foo',
         '-mask-linear-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
@@ -20140,6 +20098,13 @@ test('mask-radial-at', async () => {
 })
 
 test('mask-radial-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -20155,12 +20120,7 @@ test('mask-radial-from', async () => {
         'mask-radial-from-(color:--my-var)',
         'mask-radial-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -20386,17 +20346,19 @@ test('mask-radial-from', async () => {
         '-mask-radial-from-[25%]/foo',
         '-mask-radial-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-radial-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -20412,12 +20374,7 @@ test('mask-radial-to', async () => {
         'mask-radial-to-(color:--my-var)',
         'mask-radial-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -20643,12 +20600,7 @@ test('mask-radial-to', async () => {
         '-mask-radial-to-[25%]/foo',
         '-mask-radial-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
@@ -20774,6 +20726,13 @@ test('mask-conic', async () => {
 })
 
 test('mask-conic-from', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -20789,12 +20748,7 @@ test('mask-conic-from', async () => {
         'mask-conic-from-(color:--my-var)',
         'mask-conic-from-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -21006,17 +20960,19 @@ test('mask-conic-from', async () => {
         '-mask-conic-from-[25%]/foo',
         '-mask-conic-from-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })
 
 test('mask-conic-to', async () => {
+  let input = css`
+    @theme {
+      --spacing: 0.25rem;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -21032,12 +20988,7 @@ test('mask-conic-to', async () => {
         'mask-conic-to-(color:--my-var)',
         'mask-conic-to-(length:--my-var)',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -21249,12 +21200,7 @@ test('mask-conic-to', async () => {
         '-mask-conic-to-[25%]/foo',
         '-mask-conic-to-[-25%]/foo',
       ],
-      css`
-        @theme {
-          --spacing: 0.25rem;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -6899,14 +6899,7 @@ test('transform', async () => {
 })
 
 test('zoom', async () => {
-  expect(
-    await run(
-      ['zoom-50', 'zoom-100', 'zoom-[var(--zoom)]'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(await run(['zoom-50', 'zoom-100', 'zoom-[var(--zoom)]'])).toMatchInlineSnapshot(`
     "
     .zoom-50 {
       zoom: 50%;
@@ -10083,14 +10076,8 @@ test('space-y-reverse', async () => {
 })
 
 test('divide-x', async () => {
-  expect(
-    await run(
-      ['divide-x', 'divide-x-4', 'divide-x-123', 'divide-x-[4px]'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(await run(['divide-x', 'divide-x-4', 'divide-x-123', 'divide-x-[4px]']))
+    .toMatchInlineSnapshot(`
     "
     @layer properties {
       @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
@@ -10203,14 +10190,8 @@ test('divide-x with custom default border width', async () => {
 })
 
 test('divide-y', async () => {
-  expect(
-    await run(
-      ['divide-y', 'divide-y-4', 'divide-y-123', 'divide-y-[4px]'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(await run(['divide-y', 'divide-y-4', 'divide-y-123', 'divide-y-[4px]']))
+    .toMatchInlineSnapshot(`
     "
     @layer properties {
       @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
@@ -19306,14 +19287,8 @@ test('mask-y-to', async () => {
 })
 
 test('mask-linear', async () => {
-  expect(
-    await run(
-      ['mask-linear-45', 'mask-linear-[3rad]', '-mask-linear-45'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(await run(['mask-linear-45', 'mask-linear-[3rad]', '-mask-linear-45']))
+    .toMatchInlineSnapshot(`
     "
     @layer properties {
       @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
@@ -19919,20 +19894,15 @@ test('mask-linear-to', async () => {
 
 test('mask-radial', async () => {
   expect(
-    await run(
-      [
-        'mask-circle',
-        'mask-ellipse',
-        'mask-radial-closest-side',
-        'mask-radial-farthest-side',
-        'mask-radial-closest-corner',
-        'mask-radial-farthest-corner',
-        'mask-radial-[25%_25%]',
-      ],
-      css`
-        @tailwind utilities;
-      `,
-    ),
+    await run([
+      'mask-circle',
+      'mask-ellipse',
+      'mask-radial-closest-side',
+      'mask-radial-farthest-side',
+      'mask-radial-closest-corner',
+      'mask-radial-farthest-corner',
+      'mask-radial-[25%_25%]',
+    ]),
   ).toMatchInlineSnapshot(`
     "
     @layer properties {
@@ -20684,14 +20654,8 @@ test('mask-radial-to', async () => {
 })
 
 test('mask-conic', async () => {
-  expect(
-    await run(
-      ['mask-conic-45', 'mask-conic-[3rad]', '-mask-conic-45'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(await run(['mask-conic-45', 'mask-conic-[3rad]', '-mask-conic-45']))
+    .toMatchInlineSnapshot(`
     "
     @layer properties {
       @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
@@ -25025,14 +24989,7 @@ test('transition', async () => {
     "
   `)
 
-  expect(
-    await run(
-      ['transition-all'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
-  ).toMatchInlineSnapshot(`
+  expect(await run(['transition-all'])).toMatchInlineSnapshot(`
     "
     .transition-all {
       transition-property: all;

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -659,12 +659,12 @@ test('group-[...]', async () => {
   `)
 
   expect(
-    await run(
-      ['group-[]:flex', 'group-hover/[]:flex', 'group-[@media_foo]:flex', 'group-[>img]:flex'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
+    await run([
+      'group-[]:flex',
+      'group-hover/[]:flex',
+      'group-[@media_foo]:flex',
+      'group-[>img]:flex',
+    ]),
   ).toEqual('')
 })
 
@@ -755,12 +755,7 @@ test('peer-[...]', async () => {
   `)
 
   expect(
-    await run(
-      ['peer-[]:flex', 'peer-hover/[]:flex', 'peer-[@media_foo]:flex', 'peer-[>img]:flex'],
-      css`
-        @tailwind utilities;
-      `,
-    ),
+    await run(['peer-[]:flex', 'peer-hover/[]:flex', 'peer-[@media_foo]:flex', 'peer-[>img]:flex']),
   ).toEqual('')
 })
 
@@ -2722,7 +2717,7 @@ test('variants with the same root are sorted deterministically', async () => {
   ])
 
   for (let classList of classLists) {
-    expect(await run(classList, '@tailwind utilities;')).toMatchInlineSnapshot(`
+    expect(await run(classList)).toMatchInlineSnapshot(`
       "
       .data-active\\:flex[data-active], .data-focus\\:flex[data-focus], .data-hover\\:flex[data-hover], .data-\\[bar\\]\\:flex[data-bar], .data-\\[baz\\]\\:flex[data-baz], .data-\\[foo\\]\\:flex[data-foo] {
         display: flex;

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -2249,6 +2249,14 @@ test('nth', async () => {
 })
 
 test('container queries', async () => {
+  let input = css`
+    @theme {
+      --container-lg: 1024px;
+      --container-foo-bar: 1440px;
+    }
+    @tailwind utilities;
+  `
+
   expect(
     await run(
       [
@@ -2273,13 +2281,7 @@ test('container queries', async () => {
         '@max-foo-bar:flex',
         '@max-foo-bar/name:flex',
       ],
-      css`
-        @theme {
-          --container-lg: 1024px;
-          --container-foo-bar: 1440px;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2404,13 +2406,7 @@ test('container queries', async () => {
         '@-max-foo-bar:flex',
         '@-max-foo-bar/name:flex',
       ],
-      css`
-        @theme {
-          --container-lg: 1024px;
-          --container-foo-bar: 1440px;
-        }
-        @tailwind utilities;
-      `,
+      input,
     ),
   ).toEqual('')
 })

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import createPlugin from './plugin'
-import { compileCss, pretty, run } from './test-utils/run'
+import { compileCss, run } from './test-utils/run'
 import { Compounds, compoundsForSelectors } from './variants'
 
 const css = String.raw
@@ -2722,9 +2722,7 @@ test('variants with the same root are sorted deterministically', async () => {
   ])
 
   for (let classList of classLists) {
-    let output = await compileCss('@tailwind utilities;', classList)
-
-    expect(pretty(output)).toMatchInlineSnapshot(`
+    expect(await compileCss('@tailwind utilities;', classList)).toMatchInlineSnapshot(`
       "
       .data-active\\:flex[data-active], .data-focus\\:flex[data-focus], .data-hover\\:flex[data-hover], .data-\\[bar\\]\\:flex[data-bar], .data-\\[baz\\]\\:flex[data-baz], .data-\\[foo\\]\\:flex[data-foo] {
         display: flex;
@@ -2755,25 +2753,25 @@ test('matchVariant sorts deterministically', async () => {
   ])
 
   for (let classList of classLists) {
-    let output = await compileCss('@tailwind utilities; @plugin "./plugin.js";', classList, {
-      async loadModule(id: string) {
-        return {
-          path: '',
-          base: '/',
-          module: createPlugin(({ matchVariant }) => {
-            matchVariant('is-data', (value) => `&:is([data-${value}])`, {
-              values: {
-                DEFAULT: 'default',
-                foo: 'foo',
-                bar: 'bar',
-              },
-            })
-          }),
-        }
-      },
-    })
-
-    expect(pretty(output)).toMatchInlineSnapshot(`
+    expect(
+      await compileCss('@tailwind utilities; @plugin "./plugin.js";', classList, {
+        async loadModule(_id: string) {
+          return {
+            path: '',
+            base: '/',
+            module: createPlugin(({ matchVariant }) => {
+              matchVariant('is-data', (value) => `&:is([data-${value}])`, {
+                values: {
+                  DEFAULT: 'default',
+                  foo: 'foo',
+                  bar: 'bar',
+                },
+              })
+            }),
+          }
+        },
+      }),
+    ).toMatchInlineSnapshot(`
       "
       .is-data\\:flex[data-default], .is-data-foo\\:flex[data-foo], .is-data-bar\\:flex[data-bar], .is-data-\\[potato\\]\\:flex[data-potato], .is-data-\\[sandwich\\]\\:flex[data-sandwich] {
         display: flex;

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import createPlugin from './plugin'
-import { compileCss, run } from './test-utils/run'
+import { run } from './test-utils/run'
 import { Compounds, compoundsForSelectors } from './variants'
 
 const css = String.raw
@@ -659,18 +659,26 @@ test('group-[...]', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['group-[]:flex', 'group-hover/[]:flex', 'group-[@media_foo]:flex', 'group-[>img]:flex'],
       css`
         @tailwind utilities;
       `,
-      ['group-[]:flex', 'group-hover/[]:flex', 'group-[@media_foo]:flex', 'group-[>img]:flex'],
     ),
   ).toEqual('')
 })
 
 test('group-*', async () => {
   expect(
-    await compileCss(
+    await run(
+      [
+        'group-hover:flex',
+        'group-focus:flex',
+        'group-hocus:flex',
+
+        'group-hover:group-focus:flex',
+        'group-focus:group-hover:flex',
+      ],
       css`
         @custom-variant hocus {
           &:hover,
@@ -680,14 +688,6 @@ test('group-*', async () => {
         }
         @tailwind utilities;
       `,
-      [
-        'group-hover:flex',
-        'group-focus:flex',
-        'group-hocus:flex',
-
-        'group-hover:group-focus:flex',
-        'group-focus:group-hover:flex',
-      ],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -714,7 +714,8 @@ test('group-*', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['group-custom-at-rule:flex', 'group-nested-selectors:flex'],
       css`
         @custom-variant custom-at-rule (@media foo);
         @custom-variant nested-selectors {
@@ -726,7 +727,6 @@ test('group-*', async () => {
         }
         @tailwind utilities;
       `,
-      ['group-custom-at-rule:flex', 'group-nested-selectors:flex'],
     ),
   ).toEqual('')
 })
@@ -755,18 +755,25 @@ test('peer-[...]', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['peer-[]:flex', 'peer-hover/[]:flex', 'peer-[@media_foo]:flex', 'peer-[>img]:flex'],
       css`
         @tailwind utilities;
       `,
-      ['peer-[]:flex', 'peer-hover/[]:flex', 'peer-[@media_foo]:flex', 'peer-[>img]:flex'],
     ),
   ).toEqual('')
 })
 
 test('peer-*', async () => {
   expect(
-    await compileCss(
+    await run(
+      [
+        'peer-hover:flex',
+        'peer-focus:flex',
+        'peer-hocus:flex',
+        'peer-hover:peer-focus:flex',
+        'peer-focus:peer-hover:flex',
+      ],
       css`
         @custom-variant hocus {
           &:hover,
@@ -776,13 +783,6 @@ test('peer-*', async () => {
         }
         @tailwind utilities;
       `,
-      [
-        'peer-hover:flex',
-        'peer-focus:flex',
-        'peer-hocus:flex',
-        'peer-hover:peer-focus:flex',
-        'peer-focus:peer-hover:flex',
-      ],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -809,7 +809,8 @@ test('peer-*', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      ['peer-custom-at-rule:flex', 'peer-nested-selectors:flex'],
       css`
         @custom-variant custom-at-rule (@media foo);
         @custom-variant nested-selectors {
@@ -821,7 +822,6 @@ test('peer-*', async () => {
         }
         @tailwind utilities;
       `,
-      ['peer-custom-at-rule:flex', 'peer-nested-selectors:flex'],
     ),
   ).toEqual('')
 })
@@ -915,7 +915,8 @@ test('print', async () => {
 
 test('default breakpoints', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['sm:flex', 'md:flex', 'lg:flex', 'xl:flex', '2xl:flex'],
       css`
         @theme {
           /* Breakpoints */
@@ -927,7 +928,6 @@ test('default breakpoints', async () => {
         }
         @tailwind utilities;
       `,
-      ['sm:flex', 'md:flex', 'lg:flex', 'xl:flex', '2xl:flex'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -963,7 +963,8 @@ test('default breakpoints', async () => {
     "
   `)
   expect(
-    await compileCss(
+    await run(
+      ['sm/foo:flex', 'md/foo:flex', 'lg/foo:flex', 'xl/foo:flex', '2xl/foo:flex'],
       css`
         @theme reference {
           /* Breakpoints */
@@ -975,21 +976,20 @@ test('default breakpoints', async () => {
         }
         @tailwind utilities;
       `,
-      ['sm/foo:flex', 'md/foo:flex', 'lg/foo:flex', 'xl/foo:flex', '2xl/foo:flex'],
     ),
   ).toEqual('')
 })
 
 test('custom breakpoint', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['10xl:flex'],
       css`
         @theme {
           --breakpoint-10xl: 5000px;
         }
         @tailwind utilities;
       `,
-      ['10xl:flex'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1004,7 +1004,8 @@ test('custom breakpoint', async () => {
 
 test('max-*', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['max-lg:flex', 'max-sm:flex', 'max-md:flex'],
       css`
         @theme {
           /* Explicitly ordered in a strange way */
@@ -1014,7 +1015,6 @@ test('max-*', async () => {
         }
         @tailwind utilities;
       `,
-      ['max-lg:flex', 'max-sm:flex', 'max-md:flex'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1038,7 +1038,8 @@ test('max-*', async () => {
     "
   `)
   expect(
-    await compileCss(
+    await run(
+      ['max-lg/foo:flex', 'max-sm/foo:flex', 'max-md/foo:flex'],
       css`
         @theme reference {
           /* Explicitly ordered in a strange way */
@@ -1048,14 +1049,14 @@ test('max-*', async () => {
         }
         @tailwind utilities;
       `,
-      ['max-lg/foo:flex', 'max-sm/foo:flex', 'max-md/foo:flex'],
     ),
   ).toEqual('')
 })
 
 test('min-*', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['min-lg:flex', 'min-sm:flex', 'min-md:flex'],
       css`
         @theme {
           /* Explicitly ordered in a strange way */
@@ -1065,7 +1066,6 @@ test('min-*', async () => {
         }
         @tailwind utilities;
       `,
-      ['min-lg:flex', 'min-sm:flex', 'min-md:flex'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1089,7 +1089,8 @@ test('min-*', async () => {
     "
   `)
   expect(
-    await compileCss(
+    await run(
+      ['min-lg/foo:flex', 'min-sm/foo:flex', 'min-md/foo:flex'],
       css`
         @theme reference {
           /* Explicitly ordered in a strange way */
@@ -1099,14 +1100,14 @@ test('min-*', async () => {
         }
         @tailwind utilities;
       `,
-      ['min-lg/foo:flex', 'min-sm/foo:flex', 'min-md/foo:flex'],
     ),
   ).toEqual('')
 })
 
 test('sorting stacked min-* and max-* variants', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['min-sm:max-lg:flex', 'min-sm:max-xl:flex', 'min-md:max-lg:flex', 'min-xs:max-sm:flex'],
       css`
         @theme {
           /* Explicitly ordered in a strange way */
@@ -1118,7 +1119,6 @@ test('sorting stacked min-* and max-* variants', async () => {
         }
         @tailwind utilities;
       `,
-      ['min-sm:max-lg:flex', 'min-sm:max-xl:flex', 'min-md:max-lg:flex', 'min-xs:max-sm:flex'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1157,7 +1157,8 @@ test('sorting stacked min-* and max-* variants', async () => {
 
 test('stacked min-* and max-* variants should come after unprefixed variants', async () => {
   expect(
-    await compileCss(
+    await run(
+      ['sm:flex', 'min-sm:max-lg:flex', 'md:flex', 'min-md:max-lg:flex'],
       css`
         @theme {
           /* Explicitly ordered in a strange way */
@@ -1167,7 +1168,6 @@ test('stacked min-* and max-* variants should come after unprefixed variants', a
         }
         @tailwind utilities;
       `,
-      ['sm:flex', 'min-sm:max-lg:flex', 'md:flex', 'min-md:max-lg:flex'],
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1200,16 +1200,7 @@ test('stacked min-* and max-* variants should come after unprefixed variants', a
 
 test('min, max and unprefixed breakpoints', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          /* Explicitly ordered in a strange way */
-          --breakpoint-sm: 640px;
-          --breakpoint-lg: 1024px;
-          --breakpoint-md: 768px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'max-lg-sm-potato:flex',
         'min-lg-sm-potato:flex',
@@ -1226,6 +1217,15 @@ test('min, max and unprefixed breakpoints', async () => {
         'sm:flex',
         'lg:flex',
       ],
+      css`
+        @theme {
+          /* Explicitly ordered in a strange way */
+          --breakpoint-sm: 640px;
+          --breakpoint-lg: 1024px;
+          --breakpoint-md: 768px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1507,30 +1507,7 @@ test('supports', async () => {
 
 test('not', async () => {
   expect(
-    await compileCss(
-      css`
-        @custom-variant hocus {
-          &:hover,
-          &:focus {
-            @slot;
-          }
-        }
-
-        @custom-variant device-hocus {
-          @media (hover: hover) {
-            &:hover,
-            &:focus {
-              @slot;
-            }
-          }
-        }
-
-        @theme {
-          --breakpoint-sm: 640px;
-        }
-
-        @tailwind utilities;
-      `,
+    await run(
       [
         'not-[:checked]:flex',
         'not-[@media_print]:flex',
@@ -1612,6 +1589,29 @@ test('not', async () => {
         'not-max-sm:flex',
         'not-max-[130px]:flex',
       ],
+      css`
+        @custom-variant hocus {
+          &:hover,
+          &:focus {
+            @slot;
+          }
+        }
+
+        @custom-variant device-hocus {
+          @media (hover: hover) {
+            &:hover,
+            &:focus {
+              @slot;
+            }
+          }
+        }
+
+        @theme {
+          --breakpoint-sm: 640px;
+        }
+
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1776,7 +1776,46 @@ test('not', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      [
+        'not-[>img]:flex',
+        'not-[+img]:flex',
+        'not-[~img]:flex',
+        'not-[:checked]/foo:flex',
+        'not-[@media_screen,print]:flex',
+        'not-[@media_not_screen,print]:flex',
+        'not-[@media_not_screen,not_print]:flex',
+
+        'not-nested-at-rules:flex',
+        'not-nested-style-rules:flex',
+        'not-multiple-media-conditions:flex',
+        'not-starting:flex',
+
+        'not-parallel-style-rules:flex',
+        'not-parallel-at-rules:flex',
+        'not-parallel-mixed-rules:flex',
+
+        // The following built-in variants don't have not-* versions because
+        // there is no sensible negative version of them.
+
+        // These just don't make sense as not-*
+        'not-force:flex',
+        'not-*:flex',
+
+        // These contain pseudo-elements
+        'not-first-letter:flex',
+        'not-first-line:flex',
+        'not-marker:flex',
+        'not-selection:flex',
+        'not-file:flex',
+        'not-placeholder:flex',
+        'not-backdrop:flex',
+        'not-before:flex',
+        'not-after:flex',
+
+        // This is not a conditional at rule
+        'not-starting:flex',
+      ],
       css`
         @custom-variant nested-at-rules {
           @media foo {
@@ -1823,45 +1862,6 @@ test('not', async () => {
         }
         @tailwind utilities;
       `,
-      [
-        'not-[>img]:flex',
-        'not-[+img]:flex',
-        'not-[~img]:flex',
-        'not-[:checked]/foo:flex',
-        'not-[@media_screen,print]:flex',
-        'not-[@media_not_screen,print]:flex',
-        'not-[@media_not_screen,not_print]:flex',
-
-        'not-nested-at-rules:flex',
-        'not-nested-style-rules:flex',
-        'not-multiple-media-conditions:flex',
-        'not-starting:flex',
-
-        'not-parallel-style-rules:flex',
-        'not-parallel-at-rules:flex',
-        'not-parallel-mixed-rules:flex',
-
-        // The following built-in variants don't have not-* versions because
-        // there is no sensible negative version of them.
-
-        // These just don't make sense as not-*
-        'not-force:flex',
-        'not-*:flex',
-
-        // These contain pseudo-elements
-        'not-first-letter:flex',
-        'not-first-line:flex',
-        'not-marker:flex',
-        'not-selection:flex',
-        'not-file:flex',
-        'not-placeholder:flex',
-        'not-backdrop:flex',
-        'not-before:flex',
-        'not-after:flex',
-
-        // This is not a conditional at rule
-        'not-starting:flex',
-      ],
     ),
   ).toEqual('')
 })
@@ -1887,16 +1887,7 @@ test('in', async () => {
 
 test('has', async () => {
   expect(
-    await compileCss(
-      css`
-        @custom-variant hocus {
-          &:hover,
-          &:focus {
-            @slot;
-          }
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         'has-checked:flex',
         'has-[:checked]:flex',
@@ -1932,6 +1923,15 @@ test('has', async () => {
         'peer-has-hocus:flex',
         'peer-has-hocus/sibling-name:flex',
       ],
+      css`
+        @custom-variant hocus {
+          &:hover,
+          &:focus {
+            @slot;
+          }
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -1942,7 +1942,13 @@ test('has', async () => {
   `)
 
   expect(
-    await compileCss(
+    await run(
+      [
+        'has-[:checked]/foo:flex',
+        'has-[@media_print]:flex',
+        'has-custom-at-rule:flex',
+        'has-nested-selectors:flex',
+      ],
       css`
         @custom-variant custom-at-rule (@media foo);
         @custom-variant nested-selectors {
@@ -1954,12 +1960,6 @@ test('has', async () => {
         }
         @tailwind utilities;
       `,
-      [
-        'has-[:checked]/foo:flex',
-        'has-[@media_print]:flex',
-        'has-custom-at-rule:flex',
-        'has-nested-selectors:flex',
-      ],
     ),
   ).toEqual('')
 })
@@ -2255,14 +2255,7 @@ test('nth', async () => {
 
 test('container queries', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --container-lg: 1024px;
-          --container-foo-bar: 1440px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         '@lg:flex',
         '@lg/name:flex',
@@ -2285,6 +2278,13 @@ test('container queries', async () => {
         '@max-foo-bar:flex',
         '@max-foo-bar/name:flex',
       ],
+      css`
+        @theme {
+          --container-lg: 1024px;
+          --container-foo-bar: 1440px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2386,14 +2386,7 @@ test('container queries', async () => {
     "
   `)
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --container-lg: 1024px;
-          --container-foo-bar: 1440px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         '@-lg:flex',
         '@-lg/name:flex',
@@ -2416,23 +2409,20 @@ test('container queries', async () => {
         '@-max-foo-bar:flex',
         '@-max-foo-bar/name:flex',
       ],
+      css`
+        @theme {
+          --container-lg: 1024px;
+          --container-foo-bar: 1440px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toEqual('')
 })
 
 test('variant order', async () => {
   expect(
-    await compileCss(
-      css`
-        @theme {
-          --breakpoint-sm: 640px;
-          --breakpoint-md: 768px;
-          --breakpoint-lg: 1024px;
-          --breakpoint-xl: 1280px;
-          --breakpoint-2xl: 1536px;
-        }
-        @tailwind utilities;
-      `,
+    await run(
       [
         '[&_p]:flex',
         '2xl:flex',
@@ -2509,6 +2499,16 @@ test('variant order', async () => {
         'visited:flex',
         'xl:flex',
       ],
+      css`
+        @theme {
+          --breakpoint-sm: 640px;
+          --breakpoint-md: 768px;
+          --breakpoint-lg: 1024px;
+          --breakpoint-xl: 1280px;
+          --breakpoint-2xl: 1536px;
+        }
+        @tailwind utilities;
+      `,
     ),
   ).toMatchInlineSnapshot(`
     "
@@ -2722,7 +2722,7 @@ test('variants with the same root are sorted deterministically', async () => {
   ])
 
   for (let classList of classLists) {
-    expect(await compileCss('@tailwind utilities;', classList)).toMatchInlineSnapshot(`
+    expect(await run(classList, '@tailwind utilities;')).toMatchInlineSnapshot(`
       "
       .data-active\\:flex[data-active], .data-focus\\:flex[data-focus], .data-hover\\:flex[data-hover], .data-\\[bar\\]\\:flex[data-bar], .data-\\[baz\\]\\:flex[data-baz], .data-\\[foo\\]\\:flex[data-foo] {
         display: flex;
@@ -2754,7 +2754,7 @@ test('matchVariant sorts deterministically', async () => {
 
   for (let classList of classLists) {
     expect(
-      await compileCss('@tailwind utilities; @plugin "./plugin.js";', classList, {
+      await run(classList, '@tailwind utilities; @plugin "./plugin.js";', {
         async loadModule(_id: string) {
           return {
             path: '',


### PR DESCRIPTION
This PR does some cleanup work in the tests such that every test is using the custom test helpers instead of creating the compiler itself and using other test helpers such as `optimizeCss` or `pretty`.

For tests we have some helpers that introduce a small layer of indirection. While you typically want to avoid indirection, this one allows us to keep the tests the same whenever we make changes to the internals.

It also allows us to run through the full core flow where we have to setup a compiler, pass in the CSS, compile the candidates, optimize the CSS and pretty print it for snapshot purposes.

Our tests often look like this when you are testing some candidates:
```ts
test('…', async () => {
  expect(await run(['flex', 'hover:flex'])).toMatchInlineSnapshot(`
    "
    .flex {
      display: flex;
    }

    @media (hover: hover) {
      .hover\\:flex:hover {
        display: flex;
      }
    }
    "
  `)
})
```

If you need to compile some CSS, we used the following:
```ts
test('…', async () => {
  expect(
    await compileCss(css`
      @tailwind utilities;
      .foo {
        @apply flex;
      }
    `),
  ).toMatchInlineSnapshot(`
    "
    .foo {
      display: flex;
    }
    "
  `)
})
```

With this PR, I normalized the tests by changing the signatures of those tests slightly:
```ts
export async function run(
  // A list of candidates
  candidates: string[],

  // Optionally, custom CSS
  input = css`
    @tailwind utilities;
  `,

  // Optionally, custom compile options
  options: Parameters<typeof compile>[1] = {},
) {
  let { build } = await compile(input, options)
  return pretty(optimize(build(candidates)).code)
}

// Same as above, but without the candidates
export async function compileCss(css: string, options: Parameters<typeof compile>[1] = {}) {
  return run([], css, options)
}
```

They are very similar, but if we migrate _everything_ to `run`, then there will be situations where you have to use:
```ts
test('…', async () => {
  expect(
    await run(
      [],
      css`
        @tailwind utilities;
        .foo {
          @apply flex;
        }
      `,
    ),
  ).toMatchInlineSnapshot(`
    "
    .foo {
      display: flex;
    }
    "
  `)
})
```

Which is a little bit confusing because what does `[]` even mean?

The next big change is that a lot of the tests were manually setting up the compiler, passing in the CSS and compiler options, then building the candidates, then manually optimizing the CSS and then manually pretty printing the resulting CSS for snapshot purposes.

Other tests, didn't use all those steps and skipped the optimization step for example. This means that not all tests were testing the end-to-end core workflow.

This PR uses the tests helpers wherever we could. This now also means that our tests look the same as much as possible.

The biggest goal of this was to get everything in a similar state. Future PRs that add additional optimizations will now see those optimizations reflected in the actual test output.

## Test plan

1. All tests still pass
   - Some test _output_ has changed because the `optimizeCss` will now kick in. But this reflects production better anyway.
2. No source code was changed

