### PR TITLE
Fix Vite resolution for bare CSS imports

### DIFF
--- a/integrations/vite/resolvers.test.ts
+++ b/integrations/vite/resolvers.test.ts
@@ -585,6 +585,67 @@ test(
 )
 
 test(
+  'resolve bare CSS imports in the same folder',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^8"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
+
+        export default defineConfig({
+          build: { cssMinify: false },
+          plugins: [tailwindcss()],
+        })
+      `,
+      'index.html': html`
+        <html>
+          <head>
+            <link rel="stylesheet" href="./src/index.css" />
+          </head>
+          <body></body>
+        </html>
+      `,
+      'src/index.css': css`
+        @reference 'tailwindcss/theme';
+        @import 'tailwindcss/utilities';
+        @import 'components.css';
+      `,
+      'src/components.css': css`
+        .component-style {
+          color: green;
+        }
+      `,
+    },
+  },
+  async ({ exec, fs, expect }) => {
+    await exec('pnpm vite build')
+
+    expect(
+      (await fs.dumpFiles('./dist/**/*.css')).replace(/-[^/]*\.css/g, '-<hash>.css'),
+    ).toMatchInlineSnapshot(`
+      "
+      --- ./dist/assets/index-<hash>.css ---
+      .component-style {
+        color: green;
+      }
+      "
+    `)
+  },
+)
+
+test(
   'resolve relative JS files correctly',
   {
     fs: {

--- a/integrations/vite/resolvers.test.ts
+++ b/integrations/vite/resolvers.test.ts
@@ -646,6 +646,70 @@ test(
 )
 
 test(
+  'resolve bare CSS imports in the same folder in dev mode',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^8"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
+
+        export default defineConfig({
+          build: { cssMinify: false },
+          plugins: [tailwindcss()],
+        })
+      `,
+      'index.html': html`
+        <html>
+          <head>
+            <link rel="stylesheet" href="./src/index.css" />
+          </head>
+          <body></body>
+        </html>
+      `,
+      'src/index.css': css`
+        @reference 'tailwindcss/theme';
+        @import 'tailwindcss/utilities';
+        @import 'components.css';
+      `,
+      'src/components.css': css`
+        .component-style {
+          color: green;
+        }
+      `,
+    },
+  },
+  async ({ spawn, expect }) => {
+    let process = await spawn('pnpm vite dev')
+    await process.onStdout((m) => m.includes('ready in'))
+
+    let url = ''
+    await process.onStdout((m) => {
+      let match = /Local:\s*(http.*)\//.exec(m)
+      if (match) url = match[1]
+      return Boolean(url)
+    })
+
+    await retryAssertion(async () => {
+      let styles = await fetchStyles(url, '/index.html')
+      expect(styles).toContain('.component-style')
+      expect(styles).toContain('color: green')
+    })
+  },
+)
+
+test(
   'resolve relative JS files correctly',
   {
     fs: {

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -68,6 +68,24 @@ function createCustomResolver(
 
       return resolved
     }
+
+    // Vite can treat a local CSS import without `./` as a package import.
+    // If all resolvers failed, try the importing directory as a final fallback.
+    let localCssFile = path.resolve(base, id)
+    if (
+      id.endsWith('.css') &&
+      !id.startsWith('.') &&
+      !path.isAbsolute(id) &&
+      !id.includes('/') &&
+      !id.includes('\\') &&
+      filter(localCssFile) &&
+      (await fs.stat(localCssFile).then(
+        (s) => s.isFile(),
+        () => false,
+      ))
+    ) {
+      return localCssFile
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #19719.

When Vite's CSS resolver treats a same-folder import like `@import "components.css"` as a package import, Tailwind currently reports that the file cannot be resolved. This keeps the existing Vite resolver flow first, then adds a narrow fallback for bare `.css` filenames that exist next to the importing stylesheet.

## Test plan

- `pnpm build`
- `pnpm run test:integrations vite/resolvers.test.ts -t "resolve bare CSS imports in the same folder"`
- `git diff --check`
- `pnpm exec prettier --check packages/@tailwindcss-vite/src/index.ts`