### PR TITLE
Fix shadow replacer for all `<length>` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalization: don't crash when plugin utilities throw for unsupported values ([#20052](https://github.com/tailwindlabs/tailwindcss/pull/20052))
 - Allow `@apply` to be used with CSS mixins ([#19427](https://github.com/tailwindlabs/tailwindcss/pull/19427))
 - Ensure `not-*` correctly negates `@container` queries, including `style(…)` queries ([#20059](https://github.com/tailwindlabs/tailwindcss/pull/20059))
+- Ensure shadows with math functions parsed correctly ([#20067](https://github.com/tailwindlabs/tailwindcss/pull/20067))
 
 ## [4.3.0] - 2026-05-08
 

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
@@ -35,6 +35,16 @@ describe('without replacer', () => {
     expect(parsed).toMatchInlineSnapshot(`"-0.00 0e-20 0.04px var(--tw-shadow-color, var(--my-color))"`)
   })
 
+  it('should handle zeros in colors (1)', () => {
+    let parsed = replaceShadowColors('1px 2px #000', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"1px 2px var(--tw-shadow-color, #000)"`)
+  })
+
+  it('should handle zeros in colors (2)', () => {
+    let parsed = replaceShadowColors('1px 2px rgb(0 0 0)', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"1px 2px var(--tw-shadow-color, rgb(0 0 0))"`)
+  })
+
   it('should handle two values with currentcolor', () => {
     let parsed = replaceShadowColors('1px 2px', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px 2px var(--tw-shadow-color, currentcolor)"`)

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
@@ -25,9 +25,14 @@ describe('without replacer', () => {
     expect(parsed).toMatchInlineSnapshot(`"0 0 0 var(--tw-shadow-color, var(--my-color))"`)
   })
 
-  it('should handle var color with exotic zero offsets', () => {
+  it('should handle var color with exotic zero offsets (1)', () => {
     let parsed = replaceShadowColors('-0 0e9 0.00 var(--my-color)', replacer)
     expect(parsed).toMatchInlineSnapshot(`"-0 0e9 0.00 var(--tw-shadow-color, var(--my-color))"`)
+  })
+
+  it('should handle var color with exotic zero offsets (2)', () => {
+    let parsed = replaceShadowColors('-0.00 0e-20 0.04px var(--my-color)', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"-0.00 0e-20 0.04px var(--tw-shadow-color, var(--my-color))"`)
   })
 
   it('should handle two values with currentcolor', () => {

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
@@ -25,6 +25,11 @@ describe('without replacer', () => {
     expect(parsed).toMatchInlineSnapshot(`"0 0 0 var(--tw-shadow-color, var(--my-color))"`)
   })
 
+  it('should handle var color with exotic zero offsets', () => {
+    let parsed = replaceShadowColors('-0 0e9 0.00 var(--my-color)', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"-0 0e9 0.00 var(--tw-shadow-color, var(--my-color))"`)
+  })
+
   it('should handle two values with currentcolor', () => {
     let parsed = replaceShadowColors('1px 2px', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px 2px var(--tw-shadow-color, currentcolor)"`)
@@ -48,6 +53,11 @@ describe('without replacer', () => {
     expect(parsed).toMatchInlineSnapshot(
       `"var(--my-shadow), 1px 1px var(--tw-shadow-color, var(--my-color)), 0 0 1px var(--tw-shadow-color, var(--my-color))"`,
     )
+  })
+
+  it('should handle calc()', () => {
+    let parsed = replaceShadowColors('0 0 calc(1 * var(--spacing)) black', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"0 0 calc(1 * var(--spacing)) var(--tw-shadow-color, black)"`)
   })
 })
 

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -21,9 +21,6 @@ export function replaceShadowColors(input: string, replacement: (color: string) 
         } else if (offsetY === null) {
           offsetY = part
         }
-
-        // Reset index, since the regex is stateful.
-        IS_ZERO.lastIndex = 0
       } else if (color === null) {
         color = part
       }

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -1,7 +1,8 @@
+import { isLength } from './infer-data-type'
 import { segment } from './segment'
 
 const KEYWORDS = new Set(['inset', 'inherit', 'initial', 'revert', 'unset'])
-const LENGTH = /^-?(\d+|\.\d+)(.*?)$/g
+const IS_ZERO = /[+-]?0*\.?0+(?:[eE][+-]?\d+)?/
 
 export function replaceShadowColors(input: string, replacement: (color: string) => string) {
   let shadows = segment(input, ',').map((shadow) => {
@@ -14,7 +15,7 @@ export function replaceShadowColors(input: string, replacement: (color: string) 
     for (let part of parts) {
       if (KEYWORDS.has(part)) {
         continue
-      } else if (LENGTH.test(part)) {
+      } else if (isLength(part) || IS_ZERO.test(part)) {
         if (offsetX === null) {
           offsetX = part
         } else if (offsetY === null) {
@@ -22,7 +23,7 @@ export function replaceShadowColors(input: string, replacement: (color: string) 
         }
 
         // Reset index, since the regex is stateful.
-        LENGTH.lastIndex = 0
+        IS_ZERO.lastIndex = 0
       } else if (color === null) {
         color = part
       }

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -2,7 +2,7 @@ import { isLength } from './infer-data-type'
 import { segment } from './segment'
 
 const KEYWORDS = new Set(['inset', 'inherit', 'initial', 'revert', 'unset'])
-const IS_ZERO = /[+-]?0*\.?0+(?:[eE][+-]?\d+)?/
+const IS_ZERO = /^-?0*\.?0+(?:[eE][+-]?\d+)?$/
 
 export function replaceShadowColors(input: string, replacement: (color: string) => string) {
   let shadows = segment(input, ',').map((shadow) => {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

Fixes #20065. As commented, the shadow replacer function does not account for all `<length>`-type values. This PR uses existing logic to test for `<length>` values.

## Test plan

- Added test to cover the `calc()` (perhaps could do with more tests for other kind of `<length>` values).
- Added test to cover valid unitless `0` cases that `isLength` does not cover.
