### PR TITLE
Handle CSS math functions in shadow lengths

### DIFF
--- a/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
@@ -45,6 +45,15 @@ describe('without replacer', () => {
     expect(parsed).toMatchInlineSnapshot(
       `"0 0 calc(1 * var(--spacing)) var(--tw-shadow-color, black)"`,
     )
+
+    parsed = replaceShadowColors('0 0 min(1px, 2px) black', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"0 0 min(1px, 2px) var(--tw-shadow-color, black)"`)
+
+    parsed = replaceShadowColors('0 0 max(1px, 2px) black', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"0 0 max(1px, 2px) var(--tw-shadow-color, black)"`)
+
+    parsed = replaceShadowColors('0 0 clamp(1px, 2px, 3px) black', replacer)
+    expect(parsed).toMatchInlineSnapshot(`"0 0 clamp(1px, 2px, 3px) var(--tw-shadow-color, black)"`)
   })
 
   it('should handle multiple shadows', () => {

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
@@ -40,6 +40,13 @@ describe('without replacer', () => {
     expect(parsed).toMatchInlineSnapshot(`"1px 2px 3px 4px var(--tw-shadow-color, currentcolor)"`)
   })
 
+  it('should handle CSS math functions as lengths', () => {
+    let parsed = replaceShadowColors('0 0 calc(1 * var(--spacing)) black', replacer)
+    expect(parsed).toMatchInlineSnapshot(
+      `"0 0 calc(1 * var(--spacing)) var(--tw-shadow-color, black)"`,
+    )
+  })
+
   it('should handle multiple shadows', () => {
     let parsed = replaceShadowColors(
       ['var(--my-shadow)', '1px 1px var(--my-color)', '0 0 1px var(--my-color)'].join(', '),

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -1,7 +1,7 @@
 import { segment } from './segment'
 
 const KEYWORDS = new Set(['inset', 'inherit', 'initial', 'revert', 'unset'])
-const LENGTH = /^-?(\d+|\.\d+)(.*?)$/g
+const LENGTH = /^-?(?:(?:\d+|\.\d+).*|(?:calc|min|max|clamp)\(.*\))$/
 
 export function replaceShadowColors(input: string, replacement: (color: string) => string) {
   let shadows = segment(input, ',').map((shadow) => {
@@ -20,9 +20,6 @@ export function replaceShadowColors(input: string, replacement: (color: string) 
         } else if (offsetY === null) {
           offsetY = part
         }
-
-        // Reset index, since the regex is stateful.
-        LENGTH.lastIndex = 0
       } else if (color === null) {
         color = part
       }


### PR DESCRIPTION
## Summary

Fixes shadow color replacement so CSS math functions like `calc()`, `min()`, `max()`, and `clamp()` are treated as shadow lengths instead of being mistaken for colors. This keeps custom drop-shadow values such as `0 0 calc(1 * var(--spacing)) black` intact when combined with drop-shadow color utilities.

Fixes #20065

## Test plan

- `pnpm exec prettier --check packages/tailwindcss/src/utils/replace-shadow-colors.ts packages/tailwindcss/src/utils/replace-shadow-colors.test.ts`
- `pnpm exec vitest run packages/tailwindcss/src/utils/replace-shadow-colors.test.ts --hideSkippedTests`
- `pnpm exec vitest run packages/tailwindcss/src/utilities.test.ts --hideSkippedTests -t '^filter$'`