### PR TITLE
Improve parsing of shadow values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalization: don't crash when plugin utilities throw for unsupported values ([#20052](https://github.com/tailwindlabs/tailwindcss/pull/20052))
 - Allow `@apply` to be used with CSS mixins ([#19427](https://github.com/tailwindlabs/tailwindcss/pull/19427))
 - Ensure `not-*` correctly negates `@container` queries, including `style(…)` queries ([#20059](https://github.com/tailwindlabs/tailwindcss/pull/20059))
+- Ensure `drop-shadow-*` color utilities work with custom shadow values containing `calc(…)` ([#20080](https://github.com/tailwindlabs/tailwindcss/pull/20080))
 
 ## [4.3.0] - 2026-05-08
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -23847,6 +23847,7 @@ test('filter', async () => {
         'drop-shadow-red-500/50',
         'drop-shadow-none',
         'drop-shadow-inherit',
+        'drop-shadow-calc',
         'saturate-0',
         'saturate-[1.75]',
         'saturate-[var(--value)]',
@@ -23857,10 +23858,12 @@ test('filter', async () => {
       ],
       css`
         @theme {
+          --spacing: 0.25rem;
           --blur-xl: 24px;
           --color-red-500: #ef4444;
           --drop-shadow: 0 1px 1px rgb(0 0 0 / 0.05);
           --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
+          --drop-shadow-calc: 0 0 calc(1 * var(--spacing)) black;
         }
         @theme inline {
           --drop-shadow-multi: 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1);
@@ -23891,10 +23894,12 @@ test('filter', async () => {
     }
 
     :root, :host {
+      --spacing: .25rem;
       --blur-xl: 24px;
       --color-red-500: #ef4444;
       --drop-shadow: 0 1px 1px #0000000d;
       --drop-shadow-xl: 0 9px 7px #0000001a;
+      --drop-shadow-calc: 0 0 calc(1 * var(--spacing)) black;
     }
 
     .blur-\\[4px\\] {
@@ -23948,6 +23953,12 @@ test('filter', async () => {
     .drop-shadow-\\[0_0_red\\] {
       --tw-drop-shadow-size: drop-shadow(0 0 var(--tw-drop-shadow-color, red));
       --tw-drop-shadow: var(--tw-drop-shadow-size);
+      filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
+    }
+
+    .drop-shadow-calc {
+      --tw-drop-shadow-size: drop-shadow(0 0 calc(1 * var(--spacing)) var(--tw-drop-shadow-color, black));
+      --tw-drop-shadow: drop-shadow(var(--drop-shadow-calc));
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
     }
 

--- a/packages/tailwindcss/src/utils/is-color.ts
+++ b/packages/tailwindcss/src/utils/is-color.ts
@@ -202,3 +202,7 @@ export function isColor(value: string): boolean {
     value.charCodeAt(0) === HASH || IS_COLOR_FN.test(value) || NAMED_COLORS.has(value.toLowerCase())
   )
 }
+
+export function isNamedColor(value: string): boolean {
+  return NAMED_COLORS.has(value.toLowerCase())
+}

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { cartesian } from '../cartesian'
 import { replaceAlpha } from '../utilities'
 import { replaceShadowColors } from './replace-shadow-colors'
 
@@ -38,6 +39,59 @@ describe('without replacer', () => {
   it('should handle four values with currentcolor', () => {
     let parsed = replaceShadowColors('1px 2px 3px 4px', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px 2px 3px 4px var(--tw-shadow-color, currentcolor)"`)
+  })
+
+  it('should find the color regardless of its position', () => {
+    for (let [x, y, blur, spread, color] of cartesian(
+      ['calc(var(--spacing) * 1)', '1', '--spacing(1)'], // x
+      ['calc(var(--spacing) * 2)', '2', '--spacing(2)'], // y
+      ['calc(var(--spacing) * 3)', '3', '--spacing(3)'], // blur
+      ['calc(var(--spacing) * 4)', '4', '--spacing(4)'], // spread
+      ['black', 'rgb(0, 0, 0)', '#000', '--alpha(var(--color) / 50%)', 'var(--uknown-color)'], // color
+    )) {
+      let expectedColor = `var(--tw-shadow-color, ${color})`
+
+      {
+        let input = `${x} ${color} ${y} ${blur} ${spread}`
+        expect(replaceShadowColors(input, replacer)).toEqual(input.replace(color, expectedColor))
+      }
+
+      {
+        let input = `${x} ${y} ${color} ${blur} ${spread}`
+        expect(replaceShadowColors(input, replacer)).toEqual(input.replace(color, expectedColor))
+      }
+
+      {
+        let input = `${x} ${y} ${blur} ${color} ${spread}`
+        expect(replaceShadowColors(input, replacer)).toEqual(input.replace(color, expectedColor))
+      }
+    }
+  })
+
+  // When using `var(…)`, we don't know the types of the used variables, but we
+  // might be able to find the color itself.
+  it.each([
+    'black', // Named color
+    '#000', // Hex color
+    'rgb(0, 0, 0)', // Color functions
+    '--alpha(var(--color) / 50%)', // Known custom functions
+  ])('should find the color (%s)', (color) => {
+    let expectedColor = `var(--tw-shadow-color, ${color})`
+
+    {
+      let input = `var(--x) var(--y) ${color}`
+      expect(replaceShadowColors(input, replacer)).toEqual(input.replace(color, expectedColor))
+    }
+
+    {
+      let input = `var(--x) var(--y) var(--blur) ${color}`
+      expect(replaceShadowColors(input, replacer)).toEqual(input.replace(color, expectedColor))
+    }
+
+    {
+      let input = `var(--x) var(--y) var(--blur) var(--spread) ${color}`
+      expect(replaceShadowColors(input, replacer)).toEqual(input.replace(color, expectedColor))
+    }
   })
 
   it('should handle multiple shadows', () => {

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -1,5 +1,6 @@
 import * as ValueParser from '../value-parser'
 import { walk, WalkAction } from '../walk'
+import { isNamedColor } from './is-color'
 import { segment } from './segment'
 
 const KEYWORDS = new Set(['inset', 'inherit', 'initial', 'revert', 'unset'])
@@ -50,6 +51,12 @@ export function replaceShadowColors(input: string, replacement: (color: string) 
           if (LENGTH.test(node.value)) {
             lengths++
             return WalkAction.Continue
+          }
+
+          // Must be a color
+          if (node.value[0] === '#' || isNamedColor(node.value)) {
+            replaced = true
+            return WalkAction.ReplaceStop(replaceAst(node))
           }
 
           // We're not sure yet

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -43,12 +43,12 @@ export function replaceShadowColors(input: string, replacement: (color: string) 
       switch (node.kind) {
         case 'word': {
           // Skip known keywords
-          if (KEYWORDS.has(node.value)) {
+          if (KEYWORDS.has(node.value.toLowerCase())) {
             return WalkAction.Continue
           }
 
           // Must be a length
-          if (LENGTH.test(node.value)) {
+          if (LENGTH.test(node.value.toLowerCase())) {
             lengths++
             return WalkAction.Continue
           }
@@ -67,13 +67,13 @@ export function replaceShadowColors(input: string, replacement: (color: string) 
 
         case 'function': {
           // Must be a color
-          if (COLOR_FUNCTIONS.has(node.value)) {
+          if (COLOR_FUNCTIONS.has(node.value.toLowerCase())) {
             replaced = true
             return WalkAction.ReplaceStop(replaceAst(node))
           }
 
           // Must be a length
-          if (LENGTH_FUNCTIONS.has(node.value)) {
+          if (LENGTH_FUNCTIONS.has(node.value.toLowerCase())) {
             lengths++
             return WalkAction.Skip
           }

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -8,6 +8,8 @@ const LENGTH_FUNCTIONS = new Set(['calc', 'clamp', 'max', 'min', '--spacing'])
 const COLOR_FUNCTIONS = new Set([
   'color',
   'color-mix',
+  'contrast-color',
+  'device-cmyk',
   'hsl',
   'hsla',
   'hwb',

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.ts
@@ -1,47 +1,125 @@
+import * as ValueParser from '../value-parser'
+import { walk, WalkAction } from '../walk'
 import { segment } from './segment'
 
 const KEYWORDS = new Set(['inset', 'inherit', 'initial', 'revert', 'unset'])
-const LENGTH = /^-?(\d+|\.\d+)(.*?)$/g
+const LENGTH_FUNCTIONS = new Set(['calc', 'clamp', 'max', 'min', '--spacing'])
+const COLOR_FUNCTIONS = new Set([
+  'color',
+  'color-mix',
+  'hsl',
+  'hsla',
+  'hwb',
+  'lab',
+  'lch',
+  'light-dark',
+  'oklab',
+  'oklch',
+  'rgb',
+  'rgba',
+  '--alpha',
+])
+const LENGTH = /^-?(\d+|\.\d+)(.*?)$/
 
 export function replaceShadowColors(input: string, replacement: (color: string) => string) {
+  function replaceAst(node: ValueParser.ValueAstNode): ValueParser.ValueAstNode[] {
+    let color = ValueParser.toCss([node])
+    let updatedColor = replacement(color)
+    let ast = ValueParser.parse(updatedColor)
+    return ast
+  }
+
   let shadows = segment(input, ',').map((shadow) => {
     shadow = shadow.trim()
-    let parts = segment(shadow, ' ').filter((part) => part.trim() !== '')
-    let color = null
-    let offsetX = null
-    let offsetY = null
+    let ast = ValueParser.parse(shadow)
 
-    for (let part of parts) {
-      if (KEYWORDS.has(part)) {
-        continue
-      } else if (LENGTH.test(part)) {
-        if (offsetX === null) {
-          offsetX = part
-        } else if (offsetY === null) {
-          offsetY = part
+    let unknown: ValueParser.ValueAstNode | null = null
+    let unknowns = 0
+    let lengths = 0
+    let replaced = false
+
+    walk(ast, (node) => {
+      switch (node.kind) {
+        case 'word': {
+          // Skip known keywords
+          if (KEYWORDS.has(node.value)) {
+            return WalkAction.Continue
+          }
+
+          // Must be a length
+          if (LENGTH.test(node.value)) {
+            lengths++
+            return WalkAction.Continue
+          }
+
+          // We're not sure yet
+          unknown = node
+          unknowns++
+          break
         }
 
-        // Reset index, since the regex is stateful.
-        LENGTH.lastIndex = 0
-      } else if (color === null) {
-        color = part
+        case 'function': {
+          // Must be a color
+          if (COLOR_FUNCTIONS.has(node.value)) {
+            replaced = true
+            return WalkAction.ReplaceStop(replaceAst(node))
+          }
+
+          // Must be a length
+          if (LENGTH_FUNCTIONS.has(node.value)) {
+            lengths++
+            return WalkAction.Skip
+          }
+
+          // We're not sure yet
+          unknown = node
+          unknowns++
+
+          // We're not interested in the arguments of the function
+          return WalkAction.Skip
+        }
+
+        // Ignore separators
+        case 'separator':
+          return WalkAction.Continue
+
+        default:
+          node satisfies never
       }
+    })
+
+    // We definitely found a color, nothing else to do
+    if (replaced) {
+      return ValueParser.toCss(ast)
     }
 
     // If the x and y offsets were not detected, the shadow is either invalid or
     // using a variable to represent more than one field in the shadow value, so
     // we can't know what to replace.
-    if (offsetX === null || offsetY === null) return shadow
-
-    let replacementColor = replacement(color ?? 'currentcolor')
-
-    if (color !== null) {
-      // If a color was found, replace the color.
-      return shadow.replace(color, replacementColor)
+    if (lengths < 2) {
+      return shadow
     }
+
     // If no color was found, assume the shadow is relying on the browser
     // default shadow color and append the replacement color.
-    return `${shadow} ${replacementColor}`
+    if (unknowns === 0) {
+      return `${shadow} ${replacement('currentcolor')}`
+    }
+
+    // A single left-over, we assume that this is the color
+    if (unknowns === 1) {
+      walk(ast, (node) => {
+        if (node === unknown) {
+          replaced = true
+          return WalkAction.ReplaceStop(replaceAst(node))
+        }
+
+        // Keep the walk top-level only, no need to go into functions
+        return WalkAction.Skip
+      })
+    }
+
+    return replaced ? ValueParser.toCss(ast) : shadow
   })
 
   return shadows.join(', ')


### PR DESCRIPTION
This PR fixes an issue where a `calc(…)` value used in a shadow value was incorrectly marked as the color of that shadow.

We have this feature where we can have colored shadows, this requires us to replace the color in a value with a `var(--tw-shadow-color, <original-value-here>)` such that we can swap out the color.
For this, we have to parse the value and figure out what the color part.

This PR uses the `ValueParser` to parse values, then figure out what the color part is. The biggest reason for this is that we know what a "function" is and what a normal "word" is, which allows us to do more fine-grained checks on a per-type basis.
We tracked a few more functions that we _know_ produce color values, and a few cases that we know produce length values so therefore can't be the color.

Some examples:

- `calc(…)`, `min(…)`, `max(…)`, `clamp(…)`, `--spacing(…)` — these all produce length-values. 
- `color(…)`, `color-mix(…)`, `rgba?(…)`, `--alpha(…)` … — these all produce color values.

Notice that we added `--spacing(…)` and `--alpha(…)` as well, these are custom functions that Tailwind CSS provides, but we know what it will eventually map to internally.

Last but not least, we also detect named colors and hex-based colors.

Fixes: #20065 
Closes: #20074

## Test plan

1. Added an integration test, before the fix the test would've looked lik this:

  ```diff
    .drop-shadow-calc {
  -   --tw-drop-shadow-size: drop-shadow(0 0 calc(1 * var(--spacing)) var(--tw-drop-shadow-color, black));
  +   --tw-drop-shadow-size: drop-shadow(0 0 var(--tw-drop-shadow-color, calc(1 * var(--spacing))) black);
      --tw-drop-shadow: drop-shadow(var(--drop-shadow-calc));
      filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
    }
  ```

2. Added more tests related to the shadow replacement logic itself where we try to infer the color (or the length-values for x, y, blur, spread)
3. All other existing tests pass
