### PR TITLE
Add `list`, `compound`, and `complex` Selector nodes

### DIFF
--- a/integrations/cli/plugins.test.ts
+++ b/integrations/cli/plugins.test.ts
@@ -42,8 +42,8 @@ test(
 
     await fs.expectFileToContain('dist/out.css', [
       candidate`prose`,
-      ':where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *))',
-      ':where(tbody td, tfoot td):not(:where([class~="not-prose"],[class~="not-prose"] *))',
+      ':where(h1):not(:where([class~="not-prose"], [class~="not-prose"] *))',
+      ':where(tbody td, tfoot td):not(:where([class~="not-prose"], [class~="not-prose"] *))',
     ])
   },
 )

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -1719,12 +1719,12 @@ function* tryValueReplacements(
 // ----
 
 function isSingleSelector(ast: SelectorParser.SelectorAstNode[]): boolean {
-  return !ast.some((node) => node.kind === 'separator' && node.value.trim() === ',')
+  if (ast.length === 1 && ast[0].kind === 'list') return false
+  return true
 }
 
-function isAttributeSelector(node: SelectorParser.SelectorAstNode): boolean {
-  let value = node.value.trim()
-  return node.kind === 'selector' && value[0] === '[' && value[value.length - 1] === ']'
+function isAttributeSelector(node: SelectorParser.SelectorNode): boolean {
+  return node.value[0] === '[' && node.value[node.value.length - 1] === ']'
 }
 
 function modernizeArbitraryValuesVariant(
@@ -1755,10 +1755,16 @@ function modernizeArbitraryValuesVariant(
       // Expecting a non-relative arbitrary variant
       if (variant.relative) continue
 
-      let ast = SelectorParser.parse(variant.selector.trim())
+      let ast = SelectorParser.parse(variant.selector)
 
       // Expecting a single selector node
       if (!isSingleSelector(ast)) continue
+
+      // Keep the existing arbitrary variant modernizations working on a flat
+      // selector sequence while the parser exposes complex selectors as a node.
+      if (ast.length === 1 && ast[0].kind === 'complex') {
+        ast = ast[0].nodes
+      }
 
       // `[&>*]` can be replaced with `*`
       if (
@@ -1803,17 +1809,19 @@ function modernizeArbitraryValuesVariant(
         parent === null &&
         // [&:has(…)]:flex
         //  ^ ^^^^^^
-        ast.length === 2 &&
-        ast[0].kind === 'selector' &&
-        ast[0].value === '&' &&
-        ast[1].kind === 'function' &&
-        ast[1].value === ':has' &&
-        ast[1].nodes.length === 1 &&
-        ast[1].nodes[0].kind === 'selector'
+        ast.length === 1 &&
+        ast[0].kind === 'compound' &&
+        ast[0].nodes.length === 2 &&
+        ast[0].nodes[0].kind === 'selector' &&
+        ast[0].nodes[0].value === '&' &&
+        ast[0].nodes[1].kind === 'function' &&
+        ast[0].nodes[1].value === ':has' &&
+        ast[0].nodes[1].nodes.length === 1 &&
+        ast[0].nodes[1].nodes[0].kind === 'selector'
       ) {
         replaceObject(
           variant,
-          designSystem.parseVariant(`has-[${SelectorParser.toCss(ast[1].nodes)}]`),
+          designSystem.parseVariant(`has-[${SelectorParser.toCss(ast[0].nodes[1].nodes)}]`),
         )
         continue
       }
@@ -1828,6 +1836,7 @@ function modernizeArbitraryValuesVariant(
         // [[data-visible]___&]:flex
         //  ^^^^^^^^^^^^^^ ^ ^
         ast.length === 3 &&
+        ast[0].kind === 'selector' &&
         ast[1].kind === 'combinator' &&
         ast[1].value.trim() === '' && // Space, but trimmed because there could be multiple spaces
         ast[2].kind === 'selector' &&
@@ -1903,7 +1912,7 @@ function modernizeArbitraryValuesVariant(
         ast[1].kind === 'combinator' &&
         ast[1].value.trim() === '>' &&
         ast[2].kind === 'selector' &&
-        (isAttributeSelector(ast[2]) || ast[2].value[0] === ':')
+        (ast[2].value[0] === ':' || isAttributeSelector(ast[2]))
       ) {
         ast = [ast[2]]
         prefixedVariant = designSystem.parseVariant('*')
@@ -1921,16 +1930,30 @@ function modernizeArbitraryValuesVariant(
         ast[1].kind === 'combinator' &&
         ast[1].value.trim() === '' && // space, but trimmed because there could be multiple spaces
         ast[2].kind === 'selector' &&
-        (isAttributeSelector(ast[2]) || ast[2].value[0] === ':')
+        (ast[2].value[0] === ':' || isAttributeSelector(ast[2]))
       ) {
         ast = [ast[2]]
         prefixedVariant = designSystem.parseVariant('**')
       }
 
-      // Filter out `&`. E.g.: `&[data-foo]` => `[data-foo]`
-      let selectorNodes = ast.filter(
-        (node) => !(node.kind === 'selector' && node.value.trim() === '&'),
-      )
+      let selectorNodes = ast
+      walk(selectorNodes, {
+        enter(node) {
+          // Filter out `&`. E.g.: `&[data-foo]` => `[data-foo]`
+          if (node.kind === 'selector' && node.value === '&') {
+            return WalkAction.Replace([])
+          }
+
+          if (node.kind === 'function') {
+            return WalkAction.Skip
+          }
+        },
+        exit(node) {
+          if (node.kind === 'compound' && node.nodes.length <= 1) {
+            return WalkAction.ReplaceSkip(node.nodes)
+          }
+        },
+      })
 
       // Expecting a single selector (normal selector or attribute selector)
       if (selectorNodes.length !== 1) continue
@@ -1947,7 +1970,7 @@ function modernizeArbitraryValuesVariant(
         }
 
         // Expecting a single attribute selector
-        if (!isAttributeSelector(target.nodes[0])) continue
+        if (target.nodes[0].kind === 'selector' && !isAttributeSelector(target.nodes[0])) continue
 
         // Unwrap the selector from inside `&:is(…)`
         target = target.nodes[0]
@@ -2060,7 +2083,7 @@ function modernizeArbitraryValuesVariant(
       }
 
       // Expecting an attribute selector
-      else if (isAttributeSelector(target)) {
+      else if (target.kind === 'selector' && isAttributeSelector(target)) {
         let attributeSelector = AttributeSelectorParser.parse(target.value)
         if (attributeSelector === null) continue // Invalid attribute selector
 
@@ -2732,8 +2755,13 @@ function createVariantSignatureCache(
           let selectorAst = SelectorParser.parse(node.selector)
           let changed = false
           walk(selectorAst, (node) => {
-            if (node.kind === 'separator' && node.value !== ' ') {
-              node.value = node.value.trim()
+            // Assumption: when we have a list of selectors: `.foo, .bar` we
+            // want to mark this as changed because this will be re-printed as
+            // `.foo,.bar`.
+            //
+            // It could be that this was already optimal, but then this would be
+            // a no-op situation.
+            if (node.kind === 'list') {
               changed = true
             }
 

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -1949,7 +1949,7 @@ function modernizeArbitraryValuesVariant(
           }
         },
         exit(node) {
-          if (node.kind === 'compound' && node.nodes.length <= 1) {
+          if (node.kind === 'compound' && node.nodes.length === 1) {
             return WalkAction.ReplaceSkip(node.nodes)
           }
         },

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -413,12 +413,12 @@ describe('toCss', () => {
   })
 
   it('should print a selector list', () => {
-    expect(toCss(parse('.foo,.bar'))).toBe('.foo,.bar')
+    expect(toCss(parse('.foo,.bar'))).toBe('.foo, .bar')
   })
 
   it('should print a selector list with normalized commas', () => {
-    expect(toCss(parse('.foo, .bar'))).toBe('.foo,.bar')
-    expect(toCss(parse('.foo , .bar'))).toBe('.foo,.bar')
+    expect(toCss(parse('.foo, .bar'))).toBe('.foo, .bar')
+    expect(toCss(parse('.foo , .bar'))).toBe('.foo, .bar')
   })
 
   it('should print an attribute selectors', () => {

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -33,6 +33,63 @@ describe('parse', () => {
     ])
   })
 
+  // We've got 3 options here:
+  //
+  // 1. We could throw, but then it becomes more annoying when you don't have
+  //    control over the CSS (for example when it's coming from a package).
+  // 2. We could parse it and ignore the invalid cases as-if they weren't there.
+  //    Re-printing the AST would turn it into a valid situation.
+  // 3. We could parse the invalid case and turn it into a `compound` such that
+  //    it stays invalid. When we re-print we would re-introduce the error.
+  //
+  // Before this change, we would keep the errors, and pass it along:
+  // - In a browser environment, these would be ignored
+  // - In Lightning CSS, these are thrown out
+  //
+  // For that reason alone, let's go with option 3 for now, such that the
+  // behavior is the same as before. This does mean that we see "weird" empty
+  // compound nodes.
+  it('should safely parse an invalid selector list', () => {
+    expect(parse('.foo,')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'compound', nodes: [] },
+        ],
+      },
+    ])
+    expect(parse(',.foo')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'compound', nodes: [] },
+          { kind: 'selector', value: '.foo' },
+        ],
+      },
+    ])
+    expect(parse(',.foo,')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'compound', nodes: [] },
+          { kind: 'selector', value: '.foo' },
+          { kind: 'compound', nodes: [] },
+        ],
+      },
+    ])
+    expect(parse('.foo,,.bar')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'compound', nodes: [] },
+          { kind: 'selector', value: '.bar' },
+        ],
+      },
+    ])
+  })
+
   it('should parse selector lists with whitespace around the comma', () => {
     expect(parse('.foo, .bar')).toEqual([
       {

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -18,9 +18,110 @@ describe('parse', () => {
 
   it('should parse a selector list', () => {
     expect(parse('.foo,.bar')).toEqual([
-      { kind: 'selector', value: '.foo' },
-      { kind: 'separator', value: ',' },
-      { kind: 'selector', value: '.bar' },
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: '.bar' },
+        ],
+      },
+    ])
+  })
+
+  it('should parse selector lists with whitespace around the comma', () => {
+    expect(parse('.foo, .bar')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: '.bar' },
+        ],
+      },
+    ])
+
+    expect(parse('.foo , .bar')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: '.bar' },
+        ],
+      },
+    ])
+
+    expect(parse('.foo ,.bar')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: '.bar' },
+        ],
+      },
+    ])
+  })
+
+  it('should parse a list of attribute selectors', () => {
+    expect(parse('[foo],[bar]')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '[foo]' },
+          { kind: 'selector', value: '[bar]' },
+        ],
+      },
+    ])
+  })
+
+  it('should parse a list of selectors with just functions', () => {
+    expect(parse(':is(.a),:is(.b)')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'function', value: ':is', nodes: [{ kind: 'selector', value: '.a' }] },
+          { kind: 'function', value: ':is', nodes: [{ kind: 'selector', value: '.b' }] },
+        ],
+      },
+    ])
+  })
+
+  it('should parse selector lists with more than two selectors', () => {
+    expect(parse('.foo,.bar,.baz')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: '.bar' },
+          { kind: 'selector', value: '.baz' },
+        ],
+      },
+    ])
+  })
+
+  it('should group complex selectors in a selector list', () => {
+    expect(parse('.a+.b, .c .d[attr], .e')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          {
+            kind: 'group',
+            nodes: [
+              { kind: 'selector', value: '.a' },
+              { kind: 'combinator', value: '+' },
+              { kind: 'selector', value: '.b' },
+            ],
+          },
+          {
+            kind: 'group',
+            nodes: [
+              { kind: 'selector', value: '.c' },
+              { kind: 'combinator', value: ' ' },
+              { kind: 'selector', value: '.d' },
+              { kind: 'selector', value: '[attr]' },
+            ],
+          },
+          { kind: 'selector', value: '.e' },
+        ],
+      },
     ])
   })
 
@@ -48,6 +149,24 @@ describe('parse', () => {
           },
         ],
         value: ':not',
+      },
+    ])
+  })
+
+  it('should parse selector lists in functions', () => {
+    expect(parse(':is(.foo, .bar)')).toEqual([
+      {
+        kind: 'function',
+        value: ':is',
+        nodes: [
+          {
+            kind: 'list',
+            nodes: [
+              { kind: 'selector', value: '.foo' },
+              { kind: 'selector', value: '.bar' },
+            ],
+          },
+        ],
       },
     ])
   })
@@ -173,6 +292,11 @@ describe('toCss', () => {
 
   it('should print a selector list', () => {
     expect(toCss(parse('.foo,.bar'))).toBe('.foo,.bar')
+  })
+
+  it('should print a selector list with normalized commas', () => {
+    expect(toCss(parse('.foo, .bar'))).toBe('.foo,.bar')
+    expect(toCss(parse('.foo , .bar'))).toBe('.foo,.bar')
   })
 
   it('should print an attribute selectors', () => {

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -9,10 +9,15 @@ describe('parse', () => {
 
   it('should parse a compound selector', () => {
     expect(parse('.foo.bar:hover#id')).toEqual([
-      { kind: 'selector', value: '.foo' },
-      { kind: 'selector', value: '.bar' },
-      { kind: 'selector', value: ':hover' },
-      { kind: 'selector', value: '#id' },
+      {
+        kind: 'compound',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: '.bar' },
+          { kind: 'selector', value: ':hover' },
+          { kind: 'selector', value: '#id' },
+        ],
+      },
     ])
   })
 
@@ -103,20 +108,25 @@ describe('parse', () => {
         kind: 'list',
         nodes: [
           {
-            kind: 'group',
+            kind: 'complex',
+            combinator: '+',
             nodes: [
               { kind: 'selector', value: '.a' },
-              { kind: 'combinator', value: '+' },
               { kind: 'selector', value: '.b' },
             ],
           },
           {
-            kind: 'group',
+            kind: 'complex',
+            combinator: ' ',
             nodes: [
               { kind: 'selector', value: '.c' },
-              { kind: 'combinator', value: ' ' },
-              { kind: 'selector', value: '.d' },
-              { kind: 'selector', value: '[attr]' },
+              {
+                kind: 'compound',
+                nodes: [
+                  { kind: 'selector', value: '.d' },
+                  { kind: 'selector', value: '[attr]' },
+                ],
+              },
             ],
           },
           { kind: 'selector', value: '.e' },
@@ -127,28 +137,43 @@ describe('parse', () => {
 
   it('should combine everything within attribute selectors', () => {
     expect(parse('.foo[bar="baz"]')).toEqual([
-      { kind: 'selector', value: '.foo' },
-      { kind: 'selector', value: '[bar="baz"]' },
+      {
+        kind: 'compound',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: '[bar="baz"]' },
+        ],
+      },
     ])
   })
 
   it('should parse functions', () => {
     expect(parse('.foo:hover:not(.bar:focus)')).toEqual([
-      { kind: 'selector', value: '.foo' },
-      { kind: 'selector', value: ':hover' },
       {
-        kind: 'function',
+        kind: 'compound',
         nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: ':hover' },
           {
-            kind: 'selector',
-            value: '.bar',
-          },
-          {
-            kind: 'selector',
-            value: ':focus',
+            kind: 'function',
+            nodes: [
+              {
+                kind: 'compound',
+                nodes: [
+                  {
+                    kind: 'selector',
+                    value: '.bar',
+                  },
+                  {
+                    kind: 'selector',
+                    value: ':focus',
+                  },
+                ],
+              },
+            ],
+            value: ':not',
           },
         ],
-        value: ':not',
       },
     ])
   })
@@ -173,9 +198,14 @@ describe('parse', () => {
 
   it('should handle next-children combinator', () => {
     expect(parse('.foo + p')).toEqual([
-      { kind: 'selector', value: '.foo' },
-      { kind: 'combinator', value: ' + ' },
-      { kind: 'selector', value: 'p' },
+      {
+        kind: 'complex',
+        combinator: '+',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'selector', value: 'p' },
+        ],
+      },
     ])
   })
 
@@ -201,24 +231,34 @@ describe('parse', () => {
   it('parses &:has(.child:nth-child(2))', () => {
     expect(parse('&:has(.child:nth-child(2))')).toEqual([
       {
-        kind: 'selector',
-        value: '&',
-      },
-      {
-        kind: 'function',
-        value: ':has',
+        kind: 'compound',
         nodes: [
           {
             kind: 'selector',
-            value: '.child',
+            value: '&',
           },
           {
             kind: 'function',
-            value: ':nth-child',
+            value: ':has',
             nodes: [
               {
-                kind: 'value',
-                value: '2',
+                kind: 'compound',
+                nodes: [
+                  {
+                    kind: 'selector',
+                    value: '.child',
+                  },
+                  {
+                    kind: 'function',
+                    value: ':nth-child',
+                    nodes: [
+                      {
+                        kind: 'value',
+                        value: '2',
+                      },
+                    ],
+                  },
+                ],
               },
             ],
           },
@@ -230,20 +270,25 @@ describe('parse', () => {
   it('parses &:has(:nth-child(2))', () => {
     expect(parse('&:has(:nth-child(2))')).toEqual([
       {
-        kind: 'selector',
-        value: '&',
-      },
-      {
-        kind: 'function',
-        value: ':has',
+        kind: 'compound',
         nodes: [
           {
+            kind: 'selector',
+            value: '&',
+          },
+          {
             kind: 'function',
-            value: ':nth-child',
+            value: ':has',
             nodes: [
               {
-                kind: 'value',
-                value: '2',
+                kind: 'function',
+                value: ':nth-child',
+                nodes: [
+                  {
+                    kind: 'value',
+                    value: '2',
+                  },
+                ],
               },
             ],
           },
@@ -254,29 +299,81 @@ describe('parse', () => {
 
   it('parses nesting selector before attribute selector', () => {
     expect(parse('&[data-foo]')).toEqual([
-      { kind: 'selector', value: '&' },
-      { kind: 'selector', value: '[data-foo]' },
+      {
+        kind: 'compound',
+        nodes: [
+          { kind: 'selector', value: '&' },
+          { kind: 'selector', value: '[data-foo]' },
+        ],
+      },
     ])
   })
 
   it('parses nesting selector after an attribute selector', () => {
     expect(parse('[data-foo]&')).toEqual([
-      { kind: 'selector', value: '[data-foo]' },
-      { kind: 'selector', value: '&' },
+      {
+        kind: 'compound',
+        nodes: [
+          { kind: 'selector', value: '[data-foo]' },
+          { kind: 'selector', value: '&' },
+        ],
+      },
     ])
   })
 
   it('parses universal selector before attribute selector', () => {
     expect(parse('*[data-foo]')).toEqual([
-      { kind: 'selector', value: '*' },
-      { kind: 'selector', value: '[data-foo]' },
+      {
+        kind: 'compound',
+        nodes: [
+          { kind: 'selector', value: '*' },
+          { kind: 'selector', value: '[data-foo]' },
+        ],
+      },
     ])
   })
 
   it('parses universal selector after an attribute selector', () => {
     expect(parse('[data-foo]*')).toEqual([
-      { kind: 'selector', value: '[data-foo]' },
-      { kind: 'selector', value: '*' },
+      {
+        kind: 'compound',
+        nodes: [
+          { kind: 'selector', value: '[data-foo]' },
+          { kind: 'selector', value: '*' },
+        ],
+      },
+    ])
+  })
+
+  it('should parse selector lists as real selectors', () => {
+    expect(parse('.foo[attr], .bar#id, .baz + .qux')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          {
+            kind: 'compound',
+            nodes: [
+              { kind: 'selector', value: '.foo' },
+              { kind: 'selector', value: '[attr]' },
+            ],
+          },
+          {
+            kind: 'compound',
+            nodes: [
+              { kind: 'selector', value: '.bar' },
+              { kind: 'selector', value: '#id' },
+            ],
+          },
+          {
+            kind: 'complex',
+            combinator: '+',
+            nodes: [
+              { kind: 'selector', value: '.baz' },
+              { kind: 'selector', value: '.qux' },
+            ],
+          },
+        ],
+      },
     ])
   })
 })

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -102,24 +102,24 @@ describe('parse', () => {
     ])
   })
 
-  it('should group complex selectors in a selector list', () => {
+  it('should group selectors with combinators in a selector list', () => {
     expect(parse('.a+.b, .c .d[attr], .e')).toEqual([
       {
         kind: 'list',
         nodes: [
           {
             kind: 'complex',
-            combinator: '+',
             nodes: [
               { kind: 'selector', value: '.a' },
+              { kind: 'combinator', value: '+' },
               { kind: 'selector', value: '.b' },
             ],
           },
           {
             kind: 'complex',
-            combinator: ' ',
             nodes: [
               { kind: 'selector', value: '.c' },
+              { kind: 'combinator', value: ' ' },
               {
                 kind: 'compound',
                 nodes: [
@@ -130,6 +130,31 @@ describe('parse', () => {
             ],
           },
           { kind: 'selector', value: '.e' },
+        ],
+      },
+    ])
+  })
+
+  it('should parse complex selectors in a selector list', () => {
+    expect(parse('#a.b > .c, .d')).toEqual([
+      {
+        kind: 'list',
+        nodes: [
+          {
+            kind: 'complex',
+            nodes: [
+              {
+                kind: 'compound',
+                nodes: [
+                  { kind: 'selector', value: '#a' },
+                  { kind: 'selector', value: '.b' },
+                ],
+              },
+              { kind: 'combinator', value: '>' },
+              { kind: 'selector', value: '.c' },
+            ],
+          },
+          { kind: 'selector', value: '.d' },
         ],
       },
     ])
@@ -200,9 +225,9 @@ describe('parse', () => {
     expect(parse('.foo + p')).toEqual([
       {
         kind: 'complex',
-        combinator: '+',
         nodes: [
           { kind: 'selector', value: '.foo' },
+          { kind: 'combinator', value: '+' },
           { kind: 'selector', value: 'p' },
         ],
       },
@@ -366,9 +391,9 @@ describe('parse', () => {
           },
           {
             kind: 'complex',
-            combinator: '+',
             nodes: [
               { kind: 'selector', value: '.baz' },
+              { kind: 'combinator', value: '+' },
               { kind: 'selector', value: '.qux' },
             ],
           },

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -9,6 +9,16 @@ export type SelectorFunctionNode = {
   nodes: SelectorAstNode[]
 }
 
+export type SelectorGroupNode = {
+  kind: 'group'
+  nodes: SelectorAstNode[]
+}
+
+export type SelectorListNode = {
+  kind: 'list'
+  nodes: SelectorAstNode[]
+}
+
 export type SelectorNode = {
   kind: 'selector'
   value: string
@@ -27,6 +37,8 @@ export type SelectorSeparatorNode = {
 export type SelectorAstNode =
   | SelectorCombinatorNode
   | SelectorFunctionNode
+  | SelectorGroupNode
+  | SelectorListNode
   | SelectorNode
   | SelectorSeparatorNode
   | SelectorValueNode
@@ -46,16 +58,23 @@ function fun(value: string, nodes: SelectorAstNode[]): SelectorFunctionNode {
   }
 }
 
-function selector(value: string): SelectorNode {
+function group(nodes: SelectorAstNode[]): SelectorGroupNode {
   return {
-    kind: 'selector',
-    value,
+    kind: 'group',
+    nodes,
   }
 }
 
-function separator(value: string): SelectorSeparatorNode {
+function list(nodes: SelectorAstNode[]): SelectorListNode {
   return {
-    kind: 'separator',
+    kind: 'list',
+    nodes,
+  }
+}
+
+function selector(value: string): SelectorNode {
+  return {
+    kind: 'selector',
     value,
   }
 }

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -3,9 +3,13 @@ export type SelectorListNode = {
   nodes: SelectorAstNode[]
 }
 
+export type SelectorCombinatorNode = {
+  kind: 'combinator'
+  value: string
+}
+
 export type SelectorComplexNode = {
   kind: 'complex'
-  combinator: string
   nodes: SelectorAstNode[]
 }
 
@@ -32,16 +36,23 @@ export type SelectorValueNode = {
 
 export type SelectorAstNode =
   | SelectorFunctionNode
+  | SelectorCombinatorNode
   | SelectorComplexNode
   | SelectorCompoundNode
   | SelectorListNode
   | SelectorNode
   | SelectorValueNode
 
-function complex(combinator: string, nodes: SelectorAstNode[]): SelectorComplexNode {
+function combinator(value: string): SelectorCombinatorNode {
+  return {
+    kind: 'combinator',
+    value,
+  }
+}
+
+function complex(nodes: SelectorAstNode[]): SelectorComplexNode {
   return {
     kind: 'complex',
-    combinator,
     nodes,
   }
 }
@@ -87,6 +98,7 @@ export function toCss(ast: SelectorAstNode[]) {
   for (const node of ast) {
     switch (node.kind) {
       case 'selector':
+      case 'combinator':
       case 'value': {
         css += node.value
         break
@@ -95,10 +107,7 @@ export function toCss(ast: SelectorAstNode[]) {
         css += node.value + '(' + toCss(node.nodes) + ')'
         break
       }
-      case 'complex': {
-        css += node.nodes.map((node) => toCss([node])).join(node.combinator)
-        break
-      }
+      case 'complex':
       case 'compound': {
         css += node.nodes.map((node) => toCss([node])).join('')
         break
@@ -139,9 +148,13 @@ export function parse(input: string) {
 
   let target = ast
 
-  let targetStack: SelectorAstNode[][] = []
+  let containsCombinator = false
 
-  let listStack: (SelectorListNode | null)[] = []
+  let contextStack: {
+    target: SelectorAstNode[]
+    currentList: SelectorListNode | null
+    containsCombinator: boolean
+  }[] = []
 
   let currentList: SelectorListNode | null = null
 
@@ -149,22 +162,17 @@ export function parse(input: string) {
 
   let peekChar
 
-  function append(node: SelectorAstNode) {
-    let current = target[target.length - 1]
+  function current(nodes = target): SelectorAstNode {
+    return nodes.length === 1 ? nodes[0] : containsCombinator ? complex(nodes) : compound(nodes)
+  }
 
-    if (current?.kind === 'complex') {
-      let right = current.nodes[1]
-      if (right === undefined) {
-        current.nodes.push(node)
-      } else if (right.kind === 'compound') {
-        right.nodes.push(node)
-      } else {
-        current.nodes[1] = compound([right, node])
-      }
-    } else if (current?.kind === 'compound') {
-      current.nodes.push(node)
-    } else if (current && current.kind !== 'list') {
-      target[target.length - 1] = compound([current, node])
+  function append(node: SelectorAstNode) {
+    let existing = target[target.length - 1]
+
+    if (existing?.kind === 'compound') {
+      existing.nodes.push(node)
+    } else if (existing && existing.kind !== 'list' && existing.kind !== 'combinator') {
+      target[target.length - 1] = compound([existing, node])
     } else {
       target.push(node)
     }
@@ -203,17 +211,20 @@ export function parse(input: string) {
 
         // Add nodes to the current list
         if (currentList) {
-          currentList.nodes.push(target.length === 1 ? target[0] : compound(target))
+          currentList.nodes.push(current())
           target = []
+          containsCombinator = false
         }
 
         // Start a new list
         else {
-          let item = target.length === 1 ? target.pop()! : compound(target.splice(0))
+          let nodes = target.splice(0)
+          let item = current(nodes)
           let node = list([item])
           target.push(node)
           currentList = node
           target = []
+          containsCombinator = false
         }
 
         break
@@ -250,12 +261,16 @@ export function parse(input: string) {
         i = end - 1
 
         let contents = input.slice(start, end)
-        if (contents.trim() === '' && input.charCodeAt(end) === COMMA) {
+        if (
+          contents.trim() === '' &&
+          (target.length === 0 || end >= input.length || input.charCodeAt(end) === COMMA)
+        ) {
           break
         }
 
-        let combinator = contents.trim()
-        target.push(complex(combinator === '' ? ' ' : combinator, [target.pop()!]))
+        let value = contents.trim()
+        target.push(combinator(value === '' ? ' ' : value))
+        containsCombinator = true
 
         break
       }
@@ -311,9 +326,9 @@ export function parse(input: string) {
         }
 
         append(node)
-        targetStack.push(target)
-        listStack.push(currentList)
+        contextStack.push({ target, currentList, containsCombinator })
         target = node.nodes
+        containsCombinator = false
         currentList = null
 
         break
@@ -335,11 +350,15 @@ export function parse(input: string) {
         }
 
         if (currentList) {
-          currentList.nodes.push(target.length === 1 ? target[0] : compound(target))
+          currentList.nodes.push(current())
+        } else if (containsCombinator) {
+          target.splice(0, target.length, complex(target.splice(0)))
         }
 
-        target = targetStack.pop() ?? ast
-        currentList = listStack.pop() ?? null
+        let context = contextStack.pop()
+        target = context?.target ?? ast
+        currentList = context?.currentList ?? null
+        containsCombinator = context?.containsCombinator ?? false
 
         break
       }
@@ -471,7 +490,9 @@ export function parse(input: string) {
   }
 
   if (currentList) {
-    currentList.nodes.push(target.length === 1 ? target[0] : compound(target))
+    currentList.nodes.push(current())
+  } else if (containsCombinator) {
+    target.splice(0, target.length, complex(target.splice(0)))
   }
 
   return ast

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -139,9 +139,13 @@ export function parse(input: string) {
 
   let ast: SelectorAstNode[] = []
 
-  let stack: (SelectorFunctionNode | null)[] = []
+  let target = ast
 
-  let parent = null as SelectorFunctionNode | null
+  let targetStack: SelectorAstNode[][] = []
+
+  let listStack: (SelectorListNode | null)[] = []
+
+  let currentList: SelectorListNode | null = null
 
   let buffer = ''
 
@@ -160,7 +164,42 @@ export function parse(input: string) {
       // .foo > .bar
       //     ^^^
       // ```
-      case COMMA:
+      case COMMA: {
+        // Flush remaining buffer, mark it as a selector
+        //
+        // Combinators are handled separately, and functions end with `)` which
+        // means that the `buffer` will be empty at that point.
+        if (buffer.length > 0) {
+          target.push(selector(buffer))
+          buffer = ''
+        }
+
+        // Skip whitespace
+        for (; i + 1 < input.length; i++) {
+          peekChar = input.charCodeAt(i + 1)
+          if (peekChar !== NEWLINE && peekChar !== SPACE && peekChar !== TAB) {
+            break
+          }
+        }
+
+        // Add nodes to the current list
+        if (currentList) {
+          currentList.nodes.push(target.length === 1 ? target[0] : group(target))
+          target = []
+        }
+
+        // Start a new list
+        else {
+          let item = target.length === 1 ? target.pop()! : group(target.splice(0))
+          let node = list([item])
+          target.push(node)
+          currentList = node
+          target = []
+        }
+
+        break
+      }
+
       case GREATER_THAN:
       case NEWLINE:
       case SPACE:
@@ -169,12 +208,7 @@ export function parse(input: string) {
       case TILDE: {
         // 1. Handle everything before the combinator as a selector
         if (buffer.length > 0) {
-          let node = selector(buffer)
-          if (parent) {
-            parent.nodes.push(node)
-          } else {
-            ast.push(node)
-          }
+          target.push(selector(buffer))
           buffer = ''
         }
 
@@ -198,12 +232,11 @@ export function parse(input: string) {
         i = end - 1
 
         let contents = input.slice(start, end)
-        let node = contents.trim() === ',' ? separator(contents) : combinator(contents)
-        if (parent) {
-          parent.nodes.push(node)
-        } else {
-          ast.push(node)
+        if (contents.trim() === '' && input.charCodeAt(end) === COMMA) {
+          break
         }
+
+        target.push(combinator(contents))
 
         break
       }
@@ -253,22 +286,16 @@ export function parse(input: string) {
           buffer = ''
           i = end
 
-          if (parent) {
-            parent.nodes.push(node)
-          } else {
-            ast.push(node)
-          }
+          target.push(node)
 
           break
         }
 
-        if (parent) {
-          parent.nodes.push(node)
-        } else {
-          ast.push(node)
-        }
-        stack.push(node)
-        parent = node
+        target.push(node)
+        targetStack.push(target)
+        listStack.push(currentList)
+        target = node.nodes
+        currentList = null
 
         break
       }
@@ -282,20 +309,18 @@ export function parse(input: string) {
       //             ^
       // ```
       case CLOSE_PAREN: {
-        let tail = stack.pop()
-
         // Handle everything before the closing paren a selector
         if (buffer.length > 0) {
-          let node = selector(buffer)
-          tail!.nodes.push(node)
+          target.push(selector(buffer))
           buffer = ''
         }
 
-        if (stack.length > 0) {
-          parent = stack[stack.length - 1]
-        } else {
-          parent = null
+        if (currentList) {
+          currentList.nodes.push(target.length === 1 ? target[0] : group(target))
         }
+
+        target = targetStack.pop() ?? ast
+        currentList = listStack.pop() ?? null
 
         break
       }
@@ -314,12 +339,7 @@ export function parse(input: string) {
         // Handle everything before the combinator as a selector and
         // start a new selector
         if (buffer.length > 0) {
-          let node = selector(buffer)
-          if (parent) {
-            parent.nodes.push(node)
-          } else {
-            ast.push(node)
-          }
+          target.push(selector(buffer))
         }
         buffer = input[i]
         break
@@ -336,12 +356,7 @@ export function parse(input: string) {
       case OPEN_BRACKET: {
         // Handle everything before the combinator as a selector
         if (buffer.length > 0) {
-          let node = selector(buffer)
-          if (parent) {
-            parent.nodes.push(node)
-          } else {
-            ast.push(node)
-          }
+          target.push(selector(buffer))
         }
         buffer = ''
 
@@ -408,21 +423,12 @@ export function parse(input: string) {
       case ASTERISK: {
         // 1. Handle everything before the combinator as a selector
         if (buffer.length > 0) {
-          let node = selector(buffer)
-          if (parent) {
-            parent.nodes.push(node)
-          } else {
-            ast.push(node)
-          }
+          target.push(selector(buffer))
           buffer = ''
         }
 
         // 2. Handle the `&` or `*` as a selector on its own
-        if (parent) {
-          parent.nodes.push(selector(input[i]))
-        } else {
-          ast.push(selector(input[i]))
-        }
+        target.push(selector(input[i]))
         break
       }
 
@@ -442,7 +448,11 @@ export function parse(input: string) {
 
   // Collect the remainder as a word
   if (buffer.length > 0) {
-    ast.push(selector(buffer))
+    target.push(selector(buffer))
+  }
+
+  if (currentList) {
+    currentList.nodes.push(target.length === 1 ? target[0] : group(target))
   }
 
   return ast

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -98,11 +98,19 @@ export function toCss(ast: SelectorAstNode[]) {
   for (const node of ast) {
     switch (node.kind) {
       case 'selector':
-      case 'combinator':
       case 'value': {
         css += node.value
         break
       }
+      case 'combinator': {
+        if (node.value === ' ') {
+          css += node.value
+        } else {
+          css += ` ${node.value} `
+        }
+        break
+      }
+
       case 'function': {
         css += node.value + '(' + toCss(node.nodes) + ')'
         break
@@ -113,7 +121,7 @@ export function toCss(ast: SelectorAstNode[]) {
         break
       }
       case 'list': {
-        css += node.nodes.map((node) => toCss([node])).join(',')
+        css += node.nodes.map((node) => toCss([node])).join(', ')
         break
       }
     }

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -1,5 +1,21 @@
-export type SelectorCombinatorNode = {
-  kind: 'combinator'
+export type SelectorListNode = {
+  kind: 'list'
+  nodes: SelectorAstNode[]
+}
+
+export type SelectorComplexNode = {
+  kind: 'complex'
+  combinator: string
+  nodes: SelectorAstNode[]
+}
+
+export type SelectorCompoundNode = {
+  kind: 'compound'
+  nodes: SelectorAstNode[]
+}
+
+export type SelectorNode = {
+  kind: 'selector'
   value: string
 }
 
@@ -9,52 +25,38 @@ export type SelectorFunctionNode = {
   nodes: SelectorAstNode[]
 }
 
-export type SelectorGroupNode = {
-  kind: 'group'
-  nodes: SelectorAstNode[]
-}
-
-export type SelectorListNode = {
-  kind: 'list'
-  nodes: SelectorAstNode[]
-}
-
-export type SelectorNode = {
-  kind: 'selector'
-  value: string
-}
-
 export type SelectorValueNode = {
   kind: 'value'
   value: string
 }
 
 export type SelectorAstNode =
-  | SelectorCombinatorNode
   | SelectorFunctionNode
-  | SelectorGroupNode
+  | SelectorComplexNode
+  | SelectorCompoundNode
   | SelectorListNode
   | SelectorNode
   | SelectorValueNode
 
-function combinator(value: string): SelectorCombinatorNode {
+function complex(combinator: string, nodes: SelectorAstNode[]): SelectorComplexNode {
   return {
-    kind: 'combinator',
-    value,
+    kind: 'complex',
+    combinator,
+    nodes,
+  }
+}
+
+function compound(nodes: SelectorAstNode[]): SelectorCompoundNode {
+  return {
+    kind: 'compound',
+    nodes,
   }
 }
 
 function fun(value: string, nodes: SelectorAstNode[]): SelectorFunctionNode {
   return {
     kind: 'function',
-    value: value,
-    nodes,
-  }
-}
-
-function group(nodes: SelectorAstNode[]): SelectorGroupNode {
-  return {
-    kind: 'group',
+    value,
     nodes,
   }
 }
@@ -84,7 +86,6 @@ export function toCss(ast: SelectorAstNode[]) {
   let css = ''
   for (const node of ast) {
     switch (node.kind) {
-      case 'combinator':
       case 'selector':
       case 'value': {
         css += node.value
@@ -94,8 +95,12 @@ export function toCss(ast: SelectorAstNode[]) {
         css += node.value + '(' + toCss(node.nodes) + ')'
         break
       }
-      case 'group': {
-        css += toCss(node.nodes)
+      case 'complex': {
+        css += node.nodes.map((node) => toCss([node])).join(node.combinator)
+        break
+      }
+      case 'compound': {
+        css += node.nodes.map((node) => toCss([node])).join('')
         break
       }
       case 'list': {
@@ -144,6 +149,27 @@ export function parse(input: string) {
 
   let peekChar
 
+  function append(node: SelectorAstNode) {
+    let current = target[target.length - 1]
+
+    if (current?.kind === 'complex') {
+      let right = current.nodes[1]
+      if (right === undefined) {
+        current.nodes.push(node)
+      } else if (right.kind === 'compound') {
+        right.nodes.push(node)
+      } else {
+        current.nodes[1] = compound([right, node])
+      }
+    } else if (current?.kind === 'compound') {
+      current.nodes.push(node)
+    } else if (current && current.kind !== 'list') {
+      target[target.length - 1] = compound([current, node])
+    } else {
+      target.push(node)
+    }
+  }
+
   for (let i = 0; i < input.length; i++) {
     let currentChar = input.charCodeAt(i)
 
@@ -163,7 +189,7 @@ export function parse(input: string) {
         // Combinators are handled separately, and functions end with `)` which
         // means that the `buffer` will be empty at that point.
         if (buffer.length > 0) {
-          target.push(selector(buffer))
+          append(selector(buffer))
           buffer = ''
         }
 
@@ -177,13 +203,13 @@ export function parse(input: string) {
 
         // Add nodes to the current list
         if (currentList) {
-          currentList.nodes.push(target.length === 1 ? target[0] : group(target))
+          currentList.nodes.push(target.length === 1 ? target[0] : compound(target))
           target = []
         }
 
         // Start a new list
         else {
-          let item = target.length === 1 ? target.pop()! : group(target.splice(0))
+          let item = target.length === 1 ? target.pop()! : compound(target.splice(0))
           let node = list([item])
           target.push(node)
           currentList = node
@@ -201,7 +227,7 @@ export function parse(input: string) {
       case TILDE: {
         // 1. Handle everything before the combinator as a selector
         if (buffer.length > 0) {
-          target.push(selector(buffer))
+          append(selector(buffer))
           buffer = ''
         }
 
@@ -228,7 +254,8 @@ export function parse(input: string) {
           break
         }
 
-        target.push(combinator(contents))
+        let combinator = contents.trim()
+        target.push(complex(combinator === '' ? ' ' : combinator, [target.pop()!]))
 
         break
       }
@@ -278,12 +305,12 @@ export function parse(input: string) {
           buffer = ''
           i = end
 
-          target.push(node)
+          append(node)
 
           break
         }
 
-        target.push(node)
+        append(node)
         targetStack.push(target)
         listStack.push(currentList)
         target = node.nodes
@@ -303,12 +330,12 @@ export function parse(input: string) {
       case CLOSE_PAREN: {
         // Handle everything before the closing paren a selector
         if (buffer.length > 0) {
-          target.push(selector(buffer))
+          append(selector(buffer))
           buffer = ''
         }
 
         if (currentList) {
-          currentList.nodes.push(target.length === 1 ? target[0] : group(target))
+          currentList.nodes.push(target.length === 1 ? target[0] : compound(target))
         }
 
         target = targetStack.pop() ?? ast
@@ -331,7 +358,7 @@ export function parse(input: string) {
         // Handle everything before the combinator as a selector and
         // start a new selector
         if (buffer.length > 0) {
-          target.push(selector(buffer))
+          append(selector(buffer))
         }
         buffer = input[i]
         break
@@ -348,7 +375,7 @@ export function parse(input: string) {
       case OPEN_BRACKET: {
         // Handle everything before the combinator as a selector
         if (buffer.length > 0) {
-          target.push(selector(buffer))
+          append(selector(buffer))
         }
         buffer = ''
 
@@ -415,12 +442,12 @@ export function parse(input: string) {
       case ASTERISK: {
         // 1. Handle everything before the combinator as a selector
         if (buffer.length > 0) {
-          target.push(selector(buffer))
+          append(selector(buffer))
           buffer = ''
         }
 
         // 2. Handle the `&` or `*` as a selector on its own
-        target.push(selector(input[i]))
+        append(selector(input[i]))
         break
       }
 
@@ -440,11 +467,11 @@ export function parse(input: string) {
 
   // Collect the remainder as a word
   if (buffer.length > 0) {
-    target.push(selector(buffer))
+    append(selector(buffer))
   }
 
   if (currentList) {
-    currentList.nodes.push(target.length === 1 ? target[0] : group(target))
+    currentList.nodes.push(target.length === 1 ? target[0] : compound(target))
   }
 
   return ast

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -29,18 +29,12 @@ export type SelectorValueNode = {
   value: string
 }
 
-export type SelectorSeparatorNode = {
-  kind: 'separator'
-  value: string
-}
-
 export type SelectorAstNode =
   | SelectorCombinatorNode
   | SelectorFunctionNode
   | SelectorGroupNode
   | SelectorListNode
   | SelectorNode
-  | SelectorSeparatorNode
   | SelectorValueNode
 
 function combinator(value: string): SelectorCombinatorNode {
@@ -92,7 +86,6 @@ export function toCss(ast: SelectorAstNode[]) {
     switch (node.kind) {
       case 'combinator':
       case 'selector':
-      case 'separator':
       case 'value': {
         css += node.value
         break
@@ -218,7 +211,6 @@ export function parse(input: string) {
         for (; end < input.length; end++) {
           peekChar = input.charCodeAt(end)
           if (
-            peekChar !== COMMA &&
             peekChar !== GREATER_THAN &&
             peekChar !== NEWLINE &&
             peekChar !== SPACE &&

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -99,6 +99,15 @@ export function toCss(ast: SelectorAstNode[]) {
       }
       case 'function': {
         css += node.value + '(' + toCss(node.nodes) + ')'
+        break
+      }
+      case 'group': {
+        css += toCss(node.nodes)
+        break
+      }
+      case 'list': {
+        css += node.nodes.map((node) => toCss([node])).join(',')
+        break
       }
     }
   }


### PR DESCRIPTION
This PR introduces a few more nodes in the `SelectorParser`:

- A `list` node
- A `complex` node
- A `compound` node

These names are closer to the CSS Selector AST names (https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Selectors/Selector_structure), and are also used in other libraries.

The problem today is that there are situations where we parse a selector like: `#a.b > .c, .d` as:
```ts
[
  { kind: 'selector', value: '#a' },
  { kind: 'selector', value: '.b' },
  { kind: 'combinator', value: ' > ' },
  { kind: 'selector', value: '.c' },
  { kind: 'separator', value: ', ' },
  { kind: 'selector', value: '.d' }
]
```

Which is a very simple structure, but this contains a flaw that is annoying to deal with in practice: In order to determine that we are dealing with multiple selectors, we have to loop through the nodes and see if a separator occurs somewhere.

The other fun thing is that we already know the difference between selectors, combinators and separators. So if we tweak this structure a little bit during parsing, then we can answer the question from above in a much simpler way:

With this PR, we will parse the selector as:
```ts
[
  {
    kind: 'list',
    nodes: [
      {
        kind: 'complex',
        nodes: [
          {
            kind: 'compound',
            nodes: [
              { kind: 'selector', value: '#a' },
              { kind: 'selector', value: '.b' }
            ]
          },
          { kind: 'combinator', value: '>' },
          { kind: 'selector', value: '.c' }
        ]
      },
      { kind: 'selector', value: '.d' }
    ]
  }
]
```

It definitely looks more complex, but now that we have a `list` node, we already know that we are dealing with multiple selectors.

If you squint your eyes, in the inner part there is a `compound` selector. This is essentially a node where each sub-node can be squished together with no spaces whatsoever.

The `complex` selector is there just to group everything together. In other tools, a complex selector is often represented as:
```ts
{
  kind: 'complex',
  combinator: '>',
  lhs: { … },
  rhs: { … },
}
```
While I want to have the concept of a `complex` node, I didn't go with this syntax just because I want to keep the concept of `nodes` which means that we don't need any special handling when using `walk` (which loops over `.nodes` internally).

The reason this complex node exists is because otherwise you would end up with this structure:
```ts
[
  {
    kind: 'list',
    nodes: [
      {
        kind: 'compound',
        nodes: [
          { kind: 'selector', value: '#a' },
          { kind: 'selector', value: '.b' }
        ]
      },
      { kind: 'combinator', value: '>' },
      { kind: 'selector', value: '.c' }
      { kind: 'selector', value: '.d' }
    ]
  }
]
```
But if you look at the `list` node now, it's not clear that we are dealing with `2` selectors since there are 4 nodes. We could solve this by re-introducing the separator node (`,`). The fact that the `list` exists tells us that we're dealing with `n` selectors. But to know which selectors we're dealing with, then we have to look for that `,` node again, which introduces the original problem.

This is just an internal refactor to make future changes easier.

## Test plan

1. Everything still works as expected (all tests pass)
2. No public API breaking changes, this parser was never exposed
