### PR TITLE
Simplify selector combinators

### DIFF
--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -2759,9 +2759,12 @@ function createVariantSignatureCache(
             // want to mark this as changed because this will be re-printed as
             // `.foo,.bar`.
             //
+            // Similarly, when we receive a combinator like `.foo + .bar`, this
+            // will be printed as `.foo+.bar`.
+            //
             // It could be that this was already optimal, but then this would be
             // a no-op situation.
-            if (node.kind === 'list') {
+            if (node.kind === 'list' || node.kind === 'combinator') {
               changed = true
             }
 

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -1821,7 +1821,7 @@ function modernizeArbitraryValuesVariant(
       ) {
         replaceObject(
           variant,
-          designSystem.parseVariant(`has-[${SelectorParser.toCss(ast[0].nodes[1].nodes)}]`),
+          designSystem.parseVariant(`has-[${SelectorParser.toCss(ast[0].nodes[1].nodes, true)}]`),
         )
         continue
       }
@@ -1850,7 +1850,7 @@ function modernizeArbitraryValuesVariant(
         // that we can convert `[[data-visible]_&]` to `in-[[data-visible]]`.
         //
         // Later this gets converted to `in-data-visible`.
-        replaceObject(variant, designSystem.parseVariant(`in-[${SelectorParser.toCss(ast)}]`))
+        replaceObject(variant, designSystem.parseVariant(`in-[${SelectorParser.toCss(ast, true)}]`))
         continue
       }
 
@@ -1868,7 +1868,7 @@ function modernizeArbitraryValuesVariant(
       ) {
         let targetSignature = signatures.get(designSystem.printVariant(variant))
 
-        let parsed = ValueParser.parse(SelectorParser.toCss(ast))
+        let parsed = ValueParser.parse(SelectorParser.toCss(ast, true))
         let containsNot = false
         walk(parsed, (node) => {
           if (node.kind === 'word' && node.value === 'not') {
@@ -2042,7 +2042,7 @@ function modernizeArbitraryValuesVariant(
                 return `${variantName}-${targetNode.nodes[0].value}`
               }
 
-              return `${variantName}-[${SelectorParser.toCss(targetNode.nodes)}]`
+              return `${variantName}-[${SelectorParser.toCss(targetNode.nodes, true)}]`
             }
           }
 
@@ -2809,7 +2809,7 @@ function createVariantSignatureCache(
           })
 
           if (changed) {
-            node.selector = SelectorParser.toCss(selectorAst)
+            node.selector = SelectorParser.toCss(selectorAst, true)
           }
         }
       })

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -1776,7 +1776,7 @@ function modernizeArbitraryValuesVariant(
         ast[0].kind === 'selector' &&
         ast[0].value === '&' &&
         ast[1].kind === 'combinator' &&
-        ast[1].value.trim() === '>' &&
+        ast[1].value === '>' &&
         ast[2].kind === 'selector' &&
         ast[2].value === '*'
       ) {
@@ -1794,7 +1794,7 @@ function modernizeArbitraryValuesVariant(
         ast[0].kind === 'selector' &&
         ast[0].value === '&' &&
         ast[1].kind === 'combinator' &&
-        ast[1].value.trim() === '' && // space, but trimmed because there could be multiple spaces
+        ast[1].value === ' ' &&
         ast[2].kind === 'selector' &&
         ast[2].value === '*'
       ) {
@@ -1838,7 +1838,7 @@ function modernizeArbitraryValuesVariant(
         ast.length === 3 &&
         ast[0].kind === 'selector' &&
         ast[1].kind === 'combinator' &&
-        ast[1].value.trim() === '' && // Space, but trimmed because there could be multiple spaces
+        ast[1].value === ' ' &&
         ast[2].kind === 'selector' &&
         ast[2].value === '&'
       ) {
@@ -1908,9 +1908,9 @@ function modernizeArbitraryValuesVariant(
         //  ^ ^ ^^^^^^^^^^^^^^
         ast.length === 3 &&
         ast[0].kind === 'selector' &&
-        ast[0].value.trim() === '&' &&
+        ast[0].value === '&' &&
         ast[1].kind === 'combinator' &&
-        ast[1].value.trim() === '>' &&
+        ast[1].value === '>' &&
         ast[2].kind === 'selector' &&
         (ast[2].value[0] === ':' || isAttributeSelector(ast[2]))
       ) {
@@ -1926,9 +1926,9 @@ function modernizeArbitraryValuesVariant(
         //  ^ ^^^^^^^^^^^^^^
         ast.length === 3 &&
         ast[0].kind === 'selector' &&
-        ast[0].value.trim() === '&' &&
+        ast[0].value === '&' &&
         ast[1].kind === 'combinator' &&
-        ast[1].value.trim() === '' && // space, but trimmed because there could be multiple spaces
+        ast[1].value === ' ' &&
         ast[2].kind === 'selector' &&
         (ast[2].value[0] === ':' || isAttributeSelector(ast[2]))
       ) {

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -238,22 +238,16 @@ describe('parse', () => {
           { kind: 'selector', value: ':hover' },
           {
             kind: 'function',
+            value: ':not',
             nodes: [
               {
                 kind: 'compound',
                 nodes: [
-                  {
-                    kind: 'selector',
-                    value: '.bar',
-                  },
-                  {
-                    kind: 'selector',
-                    value: ':focus',
-                  },
+                  { kind: 'selector', value: '.bar' },
+                  { kind: 'selector', value: ':focus' },
                 ],
               },
             ],
-            value: ':not',
           },
         ],
       },
@@ -286,6 +280,30 @@ describe('parse', () => {
           { kind: 'selector', value: '.foo' },
           { kind: 'combinator', value: '+' },
           { kind: 'selector', value: 'p' },
+        ],
+      },
+    ])
+  })
+
+  it('should normalize combinators', () => {
+    expect(parse('.foo + .bar')).toEqual([
+      {
+        kind: 'complex',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'combinator', value: '+' },
+          { kind: 'selector', value: '.bar' },
+        ],
+      },
+    ])
+
+    expect(parse('.foo  \n\t .bar')).toEqual([
+      {
+        kind: 'complex',
+        nodes: [
+          { kind: 'selector', value: '.foo' },
+          { kind: 'combinator', value: ' ' },
+          { kind: 'selector', value: '.bar' },
         ],
       },
     ])

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -519,6 +519,15 @@ describe('toCss', () => {
   it('should print :nth-child()', () => {
     expect(toCss(parse(':nth-child(n+1)'))).toBe(':nth-child(n+1)')
   })
+
+  it('should pretty print a complex selector', () => {
+    expect(toCss(parse('.a+.b, .c .d[attr], .e'))).toBe('.a + .b, .c .d[attr], .e')
+  })
+
+  it('should minify a complex selector during printing', () => {
+    expect(toCss(parse('.a+.b, .c .d[attr], .e'), true)).toBe('.a+.b,.c .d[attr],.e')
+    //                                                                 ^ This space is significant to indicate a descendant combinator
+  })
 })
 
 describe('walk', () => {

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -492,6 +492,7 @@ describe('toCss', () => {
   })
 
   it('should print a selector list with normalized commas', () => {
+    expect(toCss(parse('.foo,.bar'))).toBe('.foo, .bar')
     expect(toCss(parse('.foo, .bar'))).toBe('.foo, .bar')
     expect(toCss(parse('.foo , .bar'))).toBe('.foo, .bar')
     expect(toCss(parse('.foo ,.bar'))).toBe('.foo, .bar')

--- a/packages/tailwindcss/src/selector-parser.test.ts
+++ b/packages/tailwindcss/src/selector-parser.test.ts
@@ -470,12 +470,19 @@ describe('toCss', () => {
   })
 
   it('should print a selector list', () => {
-    expect(toCss(parse('.foo,.bar'))).toBe('.foo, .bar')
+    expect(toCss(parse('.foo, .bar'))).toBe('.foo, .bar')
   })
 
   it('should print a selector list with normalized commas', () => {
     expect(toCss(parse('.foo, .bar'))).toBe('.foo, .bar')
     expect(toCss(parse('.foo , .bar'))).toBe('.foo, .bar')
+    expect(toCss(parse('.foo ,.bar'))).toBe('.foo, .bar')
+  })
+
+  it('should print a selector list but minimized', () => {
+    expect(toCss(parse('.foo, .bar'), true)).toBe('.foo,.bar')
+    expect(toCss(parse('.foo , .bar'), true)).toBe('.foo,.bar')
+    expect(toCss(parse('.foo ,.bar'), true)).toBe('.foo,.bar')
   })
 
   it('should print an attribute selectors', () => {

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -1,3 +1,9 @@
+type Combinator =
+  | ' ' // Descendant combinator
+  | '>' // Child combinator
+  | '+' // Next-sibling combinator
+  | '~' // Subsequent-sibling combinator
+
 export type SelectorListNode = {
   kind: 'list'
   nodes: SelectorAstNode[]
@@ -5,7 +11,7 @@ export type SelectorListNode = {
 
 export type SelectorCombinatorNode = {
   kind: 'combinator'
-  value: string
+  value: Combinator
 }
 
 export type SelectorComplexNode = {
@@ -43,7 +49,7 @@ export type SelectorAstNode =
   | SelectorNode
   | SelectorValueNode
 
-function combinator(value: string): SelectorCombinatorNode {
+function combinator(value: Combinator): SelectorCombinatorNode {
   return {
     kind: 'combinator',
     value,
@@ -276,7 +282,7 @@ export function parse(input: string) {
           break
         }
 
-        target.push(combinator(value === '' ? ' ' : value))
+        target.push(combinator((value === '' ? ' ' : value) as Combinator))
         containsCombinator = true
 
         break

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -93,9 +93,9 @@ function value(value: string): SelectorValueNode {
   }
 }
 
-export function toCss(ast: SelectorAstNode[]) {
+export function toCss(ast: SelectorAstNode[], minify = false) {
   let css = ''
-  for (const node of ast) {
+  for (let node of ast) {
     switch (node.kind) {
       case 'selector':
       case 'value': {
@@ -103,7 +103,7 @@ export function toCss(ast: SelectorAstNode[]) {
         break
       }
       case 'combinator': {
-        if (node.value === ' ') {
+        if (minify || node.value === ' ') {
           css += node.value
         } else {
           css += ` ${node.value} `
@@ -112,16 +112,16 @@ export function toCss(ast: SelectorAstNode[]) {
       }
 
       case 'function': {
-        css += node.value + '(' + toCss(node.nodes) + ')'
+        css += `${node.value}(${toCss(node.nodes, minify)})`
         break
       }
       case 'complex':
       case 'compound': {
-        css += node.nodes.map((node) => toCss([node])).join('')
+        css += toCss(node.nodes, minify)
         break
       }
       case 'list': {
-        css += node.nodes.map((node) => toCss([node])).join(', ')
+        css += node.nodes.map((node) => toCss([node], minify)).join(minify ? ',' : ', ')
         break
       }
     }

--- a/packages/tailwindcss/src/selector-parser.ts
+++ b/packages/tailwindcss/src/selector-parser.ts
@@ -268,15 +268,14 @@ export function parse(input: string) {
         }
         i = end - 1
 
-        let contents = input.slice(start, end)
+        let value = input.slice(start, end).trim()
         if (
-          contents.trim() === '' &&
+          value === '' &&
           (target.length === 0 || end >= input.length || input.charCodeAt(end) === COMMA)
         ) {
           break
         }
 
-        let value = contents.trim()
         target.push(combinator(value === '' ? ' ' : value))
         containsCombinator = true
 


### PR DESCRIPTION
This PR is a follow-up of #20088 to further improve selectors, in particular the `combinator`.

This PR explicitly types the `combinator` as:
```ts
type Combinator =
  | ' ' // Descendant combinator
  | '>' // Child combinator
  | '+' // Next-sibling combinator
  | '~' // Subsequent-sibling combinator
```

This allows us to explicitly test for this pattern in various places, without us having to call `.trim()` first to know what the actual combinator was.

In the selector parser itself, we already did a `.trim()` to know whether we were dealing with a descendant combinator or not. With this PR, we further ensure that there is no whitespace involved aroudn these combinators.

This introduces a small problem because we need to be able to re-print a selector's AST. So if we don't track whitespace, we have to re-introduce it. But there are situations where we don't want it at all (during canonicalization).

To solve this, we introduced a `minify = false` option in the `SelectorParser.toCss`. If it's false (the default), then we introduce whitespace, otherwise we remove all whitespace.

## Test plan

1. All existing tests pass
2. Manual cleanup/trimming of descendants is no longer necessary
