### PR TITLE
Add `--silent` option to suppress output in `@tailwindcss/cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--silent` option to suppress output in `@tailwindcss/cli` ([#20100](https://github.com/tailwindlabs/tailwindcss/pull/20100))
+
 ### Fixed
 
 - Remove deprecation warnings by using `Module#registerHooks` instead of `Module#register` on Node 26+ ([#20028](https://github.com/tailwindlabs/tailwindcss/pull/20028))

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2218,7 +2218,7 @@ test(
 )
 
 test(
-  '--quiet suppresses the "Done in" timing message',
+  'suppress output by using the --silent flag',
   {
     fs: {
       'package.json': json`
@@ -2229,7 +2229,7 @@ test(
           }
         }
       `,
-      'index.css': css` @import 'tailwindcss/utilities'; `,
+      'index.css': css` @import 'tailwindcss/utilities';`,
       'index.html': html`<div class="flex"></div>`,
     },
   },
@@ -2237,11 +2237,26 @@ test(
     let output = await exec('pnpm tailwindcss --input index.css --output dist/loud.css')
     expect(output).toContain('Done in')
 
-    let quietOutput = await exec('pnpm tailwindcss --input index.css --output dist/quiet.css -q')
-    expect(quietOutput).not.toContain('Done in')
-    expect(quietOutput).toContain('tailwindcss v')
+    let silentOutput = await exec(
+      'pnpm tailwindcss --input index.css --output dist/silent.css --silent',
+    )
+    expect(silentOutput).not.toContain('Done in')
+    expect(silentOutput).not.toContain('tailwindcss v')
 
-    await fs.expectFileToContain('dist/quiet.css', [candidate`flex`])
+    expect(await fs.dumpFiles('./dist/*.css')).toMatchInlineSnapshot(`
+      "
+      --- ./dist/loud.css ---
+      .flex {
+        display: flex;
+      }
+
+
+      --- ./dist/silent.css ---
+      .flex {
+        display: flex;
+      }
+      "
+    `)
   },
 )
 

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2218,6 +2218,34 @@ test(
 )
 
 test(
+  '--quiet suppresses the "Done in" timing message',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "tailwindcss": "workspace:^",
+            "@tailwindcss/cli": "workspace:^"
+          }
+        }
+      `,
+      'index.css': css` @import 'tailwindcss/utilities'; `,
+      'index.html': html`<div class="flex"></div>`,
+    },
+  },
+  async ({ fs, exec, expect }) => {
+    let output = await exec('pnpm tailwindcss --input index.css --output dist/loud.css')
+    expect(output).toContain('Done in')
+
+    let quietOutput = await exec('pnpm tailwindcss --input index.css --output dist/quiet.css -q')
+    expect(quietOutput).not.toContain('Done in')
+    expect(quietOutput).toContain('tailwindcss v')
+
+    await fs.expectFileToContain('dist/quiet.css', [candidate`flex`])
+  },
+)
+
+test(
   'changes to CSS files should pick up new CSS variables (if any)',
   {
     fs: {

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -66,10 +66,9 @@ export function options() {
       description: 'Generate a source map',
       default: false,
     },
-    '--quiet': {
+    '--silent': {
       type: 'boolean',
       description: 'Suppress "Done in [x]" build timing messages',
-      alias: '-q',
     },
   } satisfies Arg
 }
@@ -353,7 +352,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
             // disk, and can return early.
             if (newCandidates.length <= 0) {
               let end = process.hrtime.bigint()
-              if (!args['--quiet']) eprintln(`Done in ${formatDuration(end - start)}`)
+              if (!args['--silent']) eprintln(`Done in ${formatDuration(end - start)}`)
               return
             }
 
@@ -371,7 +370,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
           await write(compiledCss, compiledMap, args, I)
 
           let end = process.hrtime.bigint()
-          if (!args['--quiet']) eprintln(`Done in ${formatDuration(end - start)}`)
+          if (!args['--silent']) eprintln(`Done in ${formatDuration(end - start)}`)
         } catch (err) {
           // Catch any errors and print them to stderr, but don't exit the process
           // and keep watching.
@@ -415,7 +414,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
   await write(output, map, args, I)
 
   let end = process.hrtime.bigint()
-  if (!args['--quiet']) eprintln(`Done in ${formatDuration(end - start)}`)
+  if (!args['--silent']) eprintln(`Done in ${formatDuration(end - start)}`)
 }
 
 async function createWatchers(dirs: string[], cb: (files: string[]) => void) {

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -68,7 +68,7 @@ export function options() {
     },
     '--silent': {
       type: 'boolean',
-      description: 'Suppress "Done in [x]" build timing messages',
+      description: 'Suppress non-error output',
     },
   } satisfies Arg
 }

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -85,8 +85,8 @@ async function handleError<T>(fn: () => T): Promise<T> {
 }
 
 export async function handle(args: Result<ReturnType<typeof options>>) {
-  eprintln(header())
-  eprintln()
+  if (!args['--silent']) eprintln(header())
+  if (!args['--silent']) eprintln()
 
   using I = new Instrumentation()
   DEBUG && I.start('[@tailwindcss/cli] (initial build)')

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -66,6 +66,11 @@ export function options() {
       description: 'Generate a source map',
       default: false,
     },
+    '--quiet': {
+      type: 'boolean',
+      description: 'Suppress "Done in [x]" build timing messages',
+      alias: '-q',
+    },
   } satisfies Arg
 }
 
@@ -348,7 +353,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
             // disk, and can return early.
             if (newCandidates.length <= 0) {
               let end = process.hrtime.bigint()
-              eprintln(`Done in ${formatDuration(end - start)}`)
+              if (!args['--quiet']) eprintln(`Done in ${formatDuration(end - start)}`)
               return
             }
 
@@ -366,7 +371,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
           await write(compiledCss, compiledMap, args, I)
 
           let end = process.hrtime.bigint()
-          eprintln(`Done in ${formatDuration(end - start)}`)
+          if (!args['--quiet']) eprintln(`Done in ${formatDuration(end - start)}`)
         } catch (err) {
           // Catch any errors and print them to stderr, but don't exit the process
           // and keep watching.
@@ -410,7 +415,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
   await write(output, map, args, I)
 
   let end = process.hrtime.bigint()
-  eprintln(`Done in ${formatDuration(end - start)}`)
+  if (!args['--quiet']) eprintln(`Done in ${formatDuration(end - start)}`)
 }
 
 async function createWatchers(dirs: string[], cb: (files: string[]) => void) {


### PR DESCRIPTION
Edited by: @RobinMalfait 

This PR adds a new `--silent` option to the `@tailwindcss/cli` to suppress output (except for errors).

## Test plan

- Existing tests pass
- A new integration test for the `--silent` option was added

---

Original:

## Summary

Small change to add a `--quiet` option.

@adamwathan previously said this type of thing [sounded like a good idea](https://github.com/tailwindlabs/tailwindcss/issues/8050#issuecomment-1100164351):

> [I] have made a note about the --silent option idea which I think definitely has value 👍🏻

This is helpful to keep logs high signal in some scenarios. For example, when I want AI to sift through my foreman logs, where "Done in X" becomes the dominant log message over time when running tailwind alongside other things.

## Test plan

I've added an integration test.