### PR TITLE
Fix 'Sourcemap is likely to be incorrect' warnings when using `@tailwindcss/vite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `@apply` to be used with CSS mixins ([#19427](https://github.com/tailwindlabs/tailwindcss/pull/19427))
 - Ensure `not-*` correctly negates `@container` queries, including `style(…)` queries ([#20059](https://github.com/tailwindlabs/tailwindcss/pull/20059))
 - Ensure `drop-shadow-*` color utilities work with custom shadow values containing `calc(…)` ([#20080](https://github.com/tailwindlabs/tailwindcss/pull/20080))
+- Fix 'Sourcemap is likely to be incorrect' warnings when using `@tailwindcss/vite` ([#20103](https://github.com/tailwindlabs/tailwindcss/pull/20103))
 
 ## [4.3.0] - 2026-05-08
 

--- a/integrations/vite/source-maps.test.ts
+++ b/integrations/vite/source-maps.test.ts
@@ -91,3 +91,67 @@ test(
     })
   },
 )
+
+// https://github.com/tailwindlabs/tailwindcss/issues/19930
+test(
+  'production build without Tailwind roots should not result in source map warnings',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^7"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import { defineConfig } from 'vite'
+        import tailwindcss from '@tailwindcss/vite'
+
+        export default defineConfig({
+          plugins: [
+            tailwindcss(),
+            {
+              name: 'inspect-source-map-chain',
+              enforce: 'pre',
+              transform(_, id) {
+                if (id.includes('.css')) {
+                  // Force Rollup to collapse the sourcemap chain during this build.
+                  this.getCombinedSourcemap()
+                }
+              },
+            },
+          ],
+          css: {
+            devSourcemap: true,
+          },
+          build: {
+            sourcemap: true,
+          },
+        })
+      `,
+      'index.html': html`
+        <body>
+          <script type="module" src="./src/index.js"></script>
+          <div>Hello, world!</div>
+        </body>
+      `,
+      'src/index.js': ts` import './index.css' `,
+      'src/index.css': css`
+        body {
+          color: red;
+        }
+      `,
+    },
+  },
+  async ({ exec, expect }) => {
+    let output = await exec('pnpm vite build')
+
+    expect(output).not.toContain('Sourcemap is likely to be incorrect')
+  },
+)

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -241,7 +241,7 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
           let result = await root.generate(src, (file) => this.addWatchFile(file), I)
           if (!result) {
             roots.delete(id)
-            return src
+            return
           }
 
           DEBUG && I.end('[@tailwindcss/vite] Generate CSS (serve)')
@@ -357,7 +357,7 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
           let result = await root.generate(src, (file) => this.addWatchFile(file), I)
           if (!result) {
             roots.delete(id)
-            return src
+            return
           }
           DEBUG && I.end('[@tailwindcss/vite] Generate CSS (build)')
 


### PR DESCRIPTION
This PR fixes an issue where a bunch of warnings would be shown related to sourcemaps.

This happens when we are dealing with CSS files that are _not_ Tailwind CSS roots. In that case, in the `transform` step, we return the `src` of that module as-is because we didn't modify anything. However, when nothing changed, you have to return a `NullValue` such as `undefined`.

So this is a stupid little fix, but it should get rid of a bunch of annoying warnings.

Fixes: #19930

## Test plan

- Added an integration test to mimic the problem
- Other tests still pass
- Tested it against the reproduction provided in #19930


Before:
<img width="1887" height="1763" alt="8oQNG5Lqr2B" src="https://github.com/user-attachments/assets/2d8af456-4176-4f18-92a3-5327e395ac6b" />


After:
<img width="1885" height="1404" alt="8oQND5kWSb4" src="https://github.com/user-attachments/assets/7dd98ea4-126b-45d4-9411-0afbacd2c797" />
