### PR TITLE
Stop tracking deleted scanner files

### DIFF
--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -424,6 +424,11 @@ impl Scanner {
             }
         }
 
+        // Forget files that were tracked during a previous scan but no longer
+        // appear in the current source walk.
+        self.files.retain(|file| seen_files.contains(file));
+        self.mtimes.retain(|file, _| seen_files.contains(file));
+
         // Read + preprocess all discovered files in parallel
         let scanned_blobs: Vec<Vec<u8>> = content_paths
             .into_par_iter()

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -142,6 +142,20 @@ mod scanner {
         scan_with_globs(paths_with_content, vec!["@source '**/*'"])
     }
 
+    fn scanned_files(scanner: &mut Scanner, base: &Path) -> Vec<String> {
+        let base_dir =
+            format!("{}{}", dunce::canonicalize(base).unwrap().display(), "/").replace('\\', "/");
+
+        let mut files = scanner
+            .get_files()
+            .iter()
+            // Normalize paths to use unix style separators
+            .map(|file| file.replace('\\', "/").replace(&base_dir, ""))
+            .collect::<Vec<_>>();
+        files.sort();
+        files
+    }
+
     #[test]
     fn it_should_work_with_a_set_of_root_files() {
         let ScanResult {
@@ -838,6 +852,43 @@ mod scanner {
                 "content-['project-b/sub1/sub2/new.html']"
             ]
         );
+    }
+
+    #[test]
+    fn it_should_stop_tracking_deleted_files() {
+        // Create a temporary working directory
+        let dir = tempdir().unwrap().into_path();
+
+        // Initialize this directory as a git repository
+        let _ = Command::new("git").arg("init").current_dir(&dir).output();
+
+        // Create files
+        create_files_in(
+            &dir,
+            &[
+                ("src/index.html", "content-['src/index.html']"),
+                ("src/assets/icon.svg", "<svg></svg>"),
+            ],
+        );
+
+        let sources = vec![public_source_entry_from_pattern(
+            dir.clone(),
+            "@source '**/*'",
+        )];
+
+        let mut scanner = Scanner::new(sources);
+        let _ = scanner.scan();
+
+        assert_eq!(
+            scanned_files(&mut scanner, &dir),
+            vec!["src/assets/icon.svg", "src/index.html"]
+        );
+
+        fs::remove_file(dir.join("src/assets/icon.svg")).unwrap();
+
+        let _ = scanner.scan();
+
+        assert_eq!(scanned_files(&mut scanner, &dir), vec!["src/index.html"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #17532.

- Removes files from the scanner's tracked file set when they disappear from a later source walk.
- Drops stale mtime entries at the same time so deleted assets are not passed back to integrations as watched files.

## Test plan

- `CARGO_BUILD_JOBS=1 cargo test -p tailwindcss-oxide --test scanner it_should_stop_tracking_deleted_files -- --nocapture`