### PR TITLE
Remove unused test

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-apply.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-apply.test.ts
@@ -61,21 +61,6 @@ it('should append `!` to each utility, when using `!important`', async () => {
   `)
 })
 
-// TODO: Handle SCSS syntax
-it.skip('should append `!` to each utility, when using `#{!important}`', async () => {
-  expect(
-    await migrate(css`
-      .foo {
-        @apply flex flex-col #{!important};
-      }
-    `),
-  ).toMatchInlineSnapshot(`
-    ".foo {
-      @apply flex! flex-col!;
-    }"
-  `)
-})
-
 it('should move the legacy `!` prefix, to the new `!` postfix notation', async () => {
   expect(
     await migrate(css`


### PR DESCRIPTION
This PR cleans up some old stale test that has been skipped from the beginning.

While this test wants to prove that migrating from Tailwind CSS v3 to Tailwind CSS v4 can handle the `#{!important}` SCSS notation, it doesn't prove that we can migrate an entire SCSS project. SCSS has much more special syntax and we never supported that.

Let's get rid of this test that's doing nothing at the moment. Especially since we don't want to migrate SCSS projects. Enabling this might result in the false sense that we _do_ support SCSS migrations which is not the case.

Closes: #20106
