### PR TITLE
Use a finite radius for rounded-full

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -11989,7 +11989,7 @@ test('rounded', async () => {
     }
 
     .rounded-full {
-      border-radius: 3.40282e38px;
+      border-radius: 9999px;
     }
 
     .rounded-none {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2340,7 +2340,7 @@ export function createUtilities(theme: Theme) {
         handle: (value) => properties.map((property) => decl(property, value)),
         staticValues: {
           none: properties.map((property) => decl(property, '0')),
-          full: properties.map((property) => decl(property, 'calc(infinity * 1px)')),
+          full: properties.map((property) => decl(property, '9999px')),
         },
       })
     }


### PR DESCRIPTION
## Summary

Fixes #20125.

`rounded-full` currently emits `calc(infinity * 1px)`. When production optimization runs through Lightning CSS, that value is serialized as an extremely large finite pixel value, which can cause rendering issues in some engines.

This switches the built-in fallback for `rounded-full` to `9999px`, while still allowing users to override it with `--radius-full` in their theme.

## Test plan

- `pnpm exec vitest run packages/tailwindcss/src/utilities.test.ts -t rounded`
- `pnpm exec vitest run packages/tailwindcss/src/utilities.test.ts`
- `pnpm exec prettier --check packages/tailwindcss/src/utilities.ts packages/tailwindcss/src/utilities.test.ts`
- `git diff --check`
- `pnpm build`