### PR TITLE
fix: trigger full rebuild when a tracked dependency is deleted

### DIFF
--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -479,9 +479,10 @@ async function createWatchers(dirs: string[], cb: (files: string[]) => void) {
 
       await Promise.all(
         events.map(async (event) => {
-          // We don't handle deleted content files (they remain in the candidate
-          // cache), but we do track deleted config/plugin dependencies so that
-          // a full rebuild can surface the missing file error.
+          // We track deleted files so that a full rebuild can surface missing
+          // file errors (e.g. a deleted config dependency). Deleted content files
+          // are also tracked here but are harmless — they still hit the candidate
+          // cache so scanFiles returns empty and we bail early.
           if (event.type === 'delete') {
             files.add(event.path)
             return

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -479,10 +479,13 @@ async function createWatchers(dirs: string[], cb: (files: string[]) => void) {
 
       await Promise.all(
         events.map(async (event) => {
-          // We currently don't handle deleted files because it doesn't influence
-          // the CSS output. This is because we currently keep all scanned
-          // candidates in a cache for performance reasons.
-          if (event.type === 'delete') return
+          // We don't handle deleted content files (they remain in the candidate
+          // cache), but we do track deleted config/plugin dependencies so that
+          // a full rebuild can surface the missing file error.
+          if (event.type === 'delete') {
+            files.add(event.path)
+            return
+          }
 
           // Ignore directory changes. We only care about file changes
           let stats: Stats | null = null


### PR DESCRIPTION
## Fix

Fixes #20113

### Problem

When a file in the CLI watcher's tracked full-rebuild dependency set (e.g., a config dependency like `my-color.js`) is deleted, the watcher does not trigger a rebuild. This happens because **all** delete events are unconditionally dropped at L485:

```typescript
if (event.type === 'delete') return
```

This means deleting `my-color.js` (which is imported by `tailwind.config.js`) silently keeps the stale CSS output instead of surfacing the missing dependency error.

### Solution

Instead of unconditionally returning on delete events, add the deleted file path to the tracked files set before returning:

```typescript
if (event.type === 'delete') {
  files.add(event.path)
  return
}
```

This allows the `handle` callback (L260-346) to properly detect deleted files that are in `fullRebuildPaths` and trigger a full rebuild. The full rebuild will then fail with the appropriate "missing module" error, alerting the user.

### Test Plan

Follow the reproduction steps from #20113:

1. Create a project with `tailwind.config.js` importing `my-color.js`
2. Run `tailwindcss --input src/index.css --output dist/out.css --watch`
3. Delete `my-color.js`

**Before fix:** No rebuild triggered, stale CSS kept.
**After fix:** Full rebuild triggered, error about missing `my-color.js` is shown.
