### PR TITLE
Do not crash when migrating empty classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow `@variant` to be used inside `addBase` ([#19480](https://github.com/tailwindlabs/tailwindcss/pull/19480))
 - Ensure `@source` globs with symlinks are preserved ([#20203](https://github.com/tailwindlabs/tailwindcss/pull/20203))
 - Ensure later `@source` rules can re-include files excluded by earlier `@source not` rules ([#20203](https://github.com/tailwindlabs/tailwindcss/pull/20203))
+- Upgrade: don't migrate empty class rules to invalid `@utility` rules ([#20205](https://github.com/tailwindlabs/tailwindcss/pull/20205))
 
 ### Changed
 

--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.test.ts
@@ -194,6 +194,56 @@ it('should leave non-class utilities alone', async () => {
   `)
 })
 
+it('should not convert empty classes into `@utility` since that would make them invalid', async () => {
+  expect(
+    await migrate(css`
+      @layer utilities {
+        .good {
+          color: red;
+        }
+
+        .bad-empty {
+        }
+
+        /* Comment above */
+        .bad-with-comment-above {
+        }
+
+        .bad-with-comment-inside {
+          /* Comment inside */
+        }
+
+        .bad-with-comment-below {
+        }
+        /* Comment below */
+      }
+    `),
+  ).toMatchInlineSnapshot(`
+    "
+    @utility good {
+      color: red;
+    }
+
+    @layer utilities {
+      .bad-empty {
+      }
+
+      /* Comment above */
+      .bad-with-comment-above {
+      }
+
+      .bad-with-comment-inside {
+        /* Comment inside */
+      }
+
+      .bad-with-comment-below {
+      }
+      /* Comment below */
+    }
+    "
+  `)
+})
+
 it('should migrate simple `@layer utilities` with nesting to `@utility`', async () => {
   expect(
     await migrate(css`

--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.test.ts
@@ -39,7 +39,7 @@ async function migrate(
     .use(sortBuckets())
     .use(formatNodes())
     .process(stylesheet.root!, { from: expect.getState().testPath })
-    .then((result) => result.css)
+    .then((result) => `\n${result.css.trim()}\n`)
 }
 
 it('should migrate simple `@layer utilities` to `@utility`', async () => {
@@ -52,9 +52,11 @@ it('should migrate simple `@layer utilities` to `@utility`', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       color: red;
-    }"
+    }
+    "
   `)
 })
 
@@ -69,13 +71,15 @@ it('should split multiple selectors in separate utilities', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       color: red;
     }
 
     @utility bar {
       color: red;
-    }"
+    }
+    "
   `)
 })
 
@@ -99,14 +103,16 @@ it('should merge `@utility` with the same name', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       color: red;
       font-weight: bold;
     }
 
     .bar {
       color: blue;
-    }"
+    }
+    "
   `)
 })
 
@@ -149,7 +155,8 @@ it('should leave non-class utilities alone', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       /* 2. */
       /* 2.1. */
       color: red;
@@ -182,7 +189,8 @@ it('should leave non-class utilities alone', async () => {
           font-weight: bold;
         }
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -204,7 +212,8 @@ it('should migrate simple `@layer utilities` with nesting to `@utility`', async 
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       color: red;
 
       &:hover {
@@ -214,7 +223,8 @@ it('should migrate simple `@layer utilities` with nesting to `@utility`', async 
       &:focus {
         color: green;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -232,13 +242,15 @@ it('should migrate multiple simple `@layer utilities` to `@utility`', async () =
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       color: red;
     }
 
     @utility bar {
       color: blue;
-    }"
+    }
+    "
   `)
 })
 
@@ -260,7 +272,8 @@ it('should not migrate Rules inside of Rules to a `@utility`', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       color: red;
     }
 
@@ -270,7 +283,8 @@ it('should not migrate Rules inside of Rules to a `@utility`', async () => {
       .baz {
         color: green;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -286,11 +300,13 @@ it('should invert at-rules to make them migrate-able', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       @media (min-width: 640px) {
         color: red;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -314,7 +330,8 @@ it('should migrate at-rules with multiple utilities and invert them', async () =
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       @media (min-width: 640px) {
         color: red;
       }
@@ -324,7 +341,8 @@ it('should migrate at-rules with multiple utilities and invert them', async () =
       @media (min-width: 640px) {
         color: blue;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -356,7 +374,8 @@ it('should migrate deeply nested at-rules with multiple utilities and invert the
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       @media (min-width: 640px) {
         color: red;
       }
@@ -384,7 +403,8 @@ it('should migrate deeply nested at-rules with multiple utilities and invert the
           }
         }
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -398,11 +418,13 @@ it('should migrate classes with pseudo elements', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility no-scrollbar {
+    "
+    @utility no-scrollbar {
       &::-webkit-scrollbar {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -416,11 +438,13 @@ it('should migrate classes with attribute selectors', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility no-scrollbar {
+    "
+    @utility no-scrollbar {
       &[data-checked=''] {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -434,11 +458,13 @@ it('should migrate classes with element selectors', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility no-scrollbar {
+    "
+    @utility no-scrollbar {
       & main {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -452,11 +478,13 @@ it('should migrate classes attached to an element selector', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility no-scrollbar {
+    "
+    @utility no-scrollbar {
       &main {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -470,11 +498,13 @@ it('should migrate classes with id selectors', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility no-scrollbar {
+    "
+    @utility no-scrollbar {
       &#main {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -488,7 +518,8 @@ it('should migrate classes with another attached class', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility no-scrollbar {
+    "
+    @utility no-scrollbar {
       &.main {
         display: none;
       }
@@ -498,7 +529,8 @@ it('should migrate classes with another attached class', async () => {
       &.no-scrollbar {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -512,7 +544,8 @@ it('should migrate a selector with multiple classes to multiple @utility definit
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       & .bar:hover .baz:focus {
         display: none;
       }
@@ -528,7 +561,8 @@ it('should migrate a selector with multiple classes to multiple @utility definit
       .foo .bar:hover &:focus {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -548,7 +582,8 @@ it('should merge `@utility` definitions with the same name', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility step {
+    "
+    @utility step {
       counter-increment: step;
 
       &:before {
@@ -556,7 +591,8 @@ it('should merge `@utility` definitions with the same name', async () => {
         @apply ml-[-41px];
         content: counter(step);
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -570,7 +606,8 @@ it('should not migrate nested classes inside a `:not(…)`', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       & .bar:not(.qux):has(.baz) {
         display: none;
       }
@@ -586,7 +623,8 @@ it('should not migrate nested classes inside a `:not(…)`', async () => {
       .foo .bar:not(.qux):has(&) {
         display: none;
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -620,7 +658,8 @@ it('should migrate advanced combinations', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@utility foo {
+    "
+    @utility foo {
       @media (width >= 100px) {
         @supports (display: none) {
           & .bar:not(.qux):has(.baz) {
@@ -659,7 +698,8 @@ it('should migrate advanced combinations', async () => {
           }
         }
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -677,12 +717,14 @@ describe('comments', () => {
         }
       `),
     ).toMatchInlineSnapshot(`
-      "/* Start of utilities: */
+      "
+      /* Start of utilities: */
       @utility foo {
         /* Utility #1 */
         /* Declarations: */
         color: red;
-      }"
+      }
+      "
     `)
   })
 
@@ -699,7 +741,8 @@ describe('comments', () => {
         }
       `),
     ).toMatchInlineSnapshot(`
-      "/* Start of utilities: */
+      "
+      /* Start of utilities: */
       @utility foo {
         /* Foo & Bar */
         & .bar {
@@ -713,7 +756,8 @@ describe('comments', () => {
           /* Declarations: */
           color: red;
         }
-      }"
+      }
+      "
     `)
   })
 
@@ -733,7 +777,8 @@ describe('comments', () => {
         }
       `),
     ).toMatchInlineSnapshot(`
-      "/* Start of utilities: */
+      "
+      /* Start of utilities: */
       @utility foo {
         /* Mobile only */
         @media (width <= 640px) {
@@ -741,7 +786,8 @@ describe('comments', () => {
           /* Declarations: */
           color: red;
         }
-      }"
+      }
+      "
     `)
   })
 
@@ -780,7 +826,8 @@ describe('comments', () => {
         /* After */
       `),
     ).toMatchInlineSnapshot(`
-      "/* Tailwind Utilities: */
+      "
+      /* Tailwind Utilities: */
       @utility no-scrollbar {
         /* Chrome, Safari and Opera */
         /* Second comment */
@@ -807,7 +854,8 @@ describe('comments', () => {
       .after {
         /* Inside */
       }
-      /* After */"
+      /* After */
+      "
     `)
   })
 })
@@ -832,7 +880,8 @@ it('should not lose attribute selectors', async () => {
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@layer components {
+    "
+    @layer components {
       #TableOfContents {
         .toc a {
           @apply block max-w-full truncate py-1 pl-2 hover:font-medium hover:no-underline;
@@ -845,7 +894,8 @@ it('should not lose attribute selectors', async () => {
           }
         }
       }
-    }"
+    }
+    "
   `)
 })
 
@@ -863,11 +913,13 @@ describe('layered stylesheets', () => {
         layers: ['utilities'],
       }),
     ).toMatchInlineSnapshot(`
-      "@utility foo {
+      "
+      @utility foo {
         /* Utility #1 */
         /* Declarations: */
         color: red;
-      }"
+      }
+      "
     `)
   })
 
@@ -884,11 +936,13 @@ describe('layered stylesheets', () => {
         layers: ['components'],
       }),
     ).toMatchInlineSnapshot(`
-      "@utility foo {
+      "
+      @utility foo {
         /* Utility #1 */
         /* Declarations: */
         color: red;
-      }"
+      }
+      "
     `)
   })
 
@@ -905,11 +959,13 @@ describe('layered stylesheets', () => {
         layers: ['foo'],
       }),
     ).toMatchInlineSnapshot(`
-      "/* Utility #1 */
+      "
+      /* Utility #1 */
       .foo {
         /* Declarations: */
         color: red;
-      }"
+      }
+      "
     `)
   })
 
@@ -929,7 +985,8 @@ describe('layered stylesheets', () => {
         layers: ['utilities'],
       }),
     ).toMatchInlineSnapshot(`
-      "@utility foo {
+      "
+      @utility foo {
         /* Utility #1 */
         /* Declarations: */
         color: red;
@@ -937,7 +994,8 @@ describe('layered stylesheets', () => {
 
       #main {
         color: red;
-      }"
+      }
+      "
     `)
   })
 
@@ -978,7 +1036,8 @@ describe('layered stylesheets', () => {
         layers: ['utilities'],
       }),
     ).toMatchInlineSnapshot(`
-      "@utility foo {
+      "
+      @utility foo {
         @layer utilities {
           @layer utilities {
             /* Utility #1 */
@@ -1011,7 +1070,8 @@ describe('layered stylesheets', () => {
 
       #secondary {
         color: red;
-      }"
+      }
+      "
     `)
   })
 
@@ -1028,11 +1088,13 @@ describe('layered stylesheets', () => {
         layers: ['utilities'],
       }),
     ).toMatchInlineSnapshot(`
-      "@import 'thing';
+      "
+      @import 'thing';
 
       @utility foo {
         color: red;
-      }"
+      }
+      "
     `)
   })
 
@@ -1049,11 +1111,13 @@ describe('layered stylesheets', () => {
         layers: ['utilities'],
       }),
     ).toMatchInlineSnapshot(`
-      "@charset "utf-8";
+      "
+      @charset "utf-8";
 
       @utility foo {
         color: red;
-      }"
+      }
+      "
     `)
   })
 })

--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.ts
@@ -1,4 +1,4 @@
-import { type AtRule, type Comment, type Plugin, type Rule } from 'postcss'
+import { type AtRule, type Comment, type Container, type Plugin, type Rule } from 'postcss'
 import SelectorParser from 'postcss-selector-parser'
 import { segment } from '../../../../tailwindcss/src/utils/segment'
 import { Stylesheet } from '../../stylesheet'
@@ -43,6 +43,7 @@ export function migrateAtLayerUtilities(stylesheet: Stylesheet): Plugin {
 
     walk(atRule, (node) => {
       if (node.type !== 'rule') return
+      if (isEmpty(node)) return
 
       // Find all the classes in the selector
       SelectorParser((selectors) => {
@@ -184,6 +185,18 @@ export function migrateAtLayerUtilities(stylesheet: Stylesheet): Plugin {
                 toRemove.push(node.parent?.nodes.at(i) as Comment)
               }
             }
+
+            let commentsAfter: Comment[] = []
+            for (let i = idx + 1; i < (node.parent?.nodes.length ?? 0); i++) {
+              if (node.parent?.nodes.at(i)?.type === 'rule') {
+                commentsAfter = []
+                break
+              }
+              if (node.parent?.nodes.at(i)?.type === 'comment') {
+                commentsAfter.push(node.parent?.nodes.at(i) as Comment)
+              }
+            }
+            toRemove.push(...commentsAfter)
           }
           for (let node of toRemove) {
             node.remove()
@@ -231,8 +244,12 @@ export function migrateAtLayerUtilities(stylesheet: Stylesheet): Plugin {
           }
         }
 
-        // Remove empty rules
-        if ((node.type === 'rule' || node.type === 'atrule') && node.nodes?.length === 0) {
+        // Remove empty rules from `@utility` clones and empty wrapper at-rules
+        // from the default `@layer` clone.
+        if (
+          (node.type === 'atrule' && node.nodes?.length === 0) ||
+          (clone !== defaultsAtRule && node.type === 'rule' && node.nodes?.length === 0)
+        ) {
           node.remove()
         }
 
@@ -261,6 +278,11 @@ export function migrateAtLayerUtilities(stylesheet: Stylesheet): Plugin {
       // Remove empty clones entirely
       if (clone.nodes?.length === 0) {
         clones.splice(idx, 1)
+      } else if (clone === defaultsAtRule) {
+        let first = clone.nodes?.[0]
+        if (first) {
+          first.raws.before = first.raws.before?.replace(/\n\s*\n/g, '\n')
+        }
       }
     }
 
@@ -315,4 +337,18 @@ export function migrateAtLayerUtilities(stylesheet: Stylesheet): Plugin {
       }
     },
   }
+}
+
+function isEmpty(node: Container): boolean {
+  // We have no body
+  if (node.nodes === undefined) return false
+
+  // We have a body, but no nodes
+  if (node.nodes.length === 0) return true
+
+  // We have nodes, but they are only comments which we consider empty
+  if (node.nodes.every((child) => child.type === 'comment')) return true
+
+  // Not empty
+  return false
 }


### PR DESCRIPTION
This PR fixes a crash while using `npx @tailwindcss/upgrade` when migrating classes with no body inside of an `@layer utilities`.

When running `npx @tailwindcss/upgrade`, one thing we do is migrate the CSS from:
```css
@layer utilities {
  .foo {
    color: red;
  }
}
```
To:
```css
@utility foo {
  color: red;
}
```

We already have some logic that leaves non-classe (IDs, attribute selectors, ...) alone. But if we are migrating a class that has no body, then we will migrate that as well:
```css
@layer utilities {
  .empty {
  }
}
```
Is turned into:
```css
@utility empty {
}
```

But later in the migration process this will result in an error because a `@utility` has to have at least _some_ nodes.

Ideally, you don't even have CSS that has empty rules since it doesn't have any effect in the browser (except of making your CSS file bigger), but it could be that you don't have control over this file, so a fix is still valid.

This PR solves that by leaving those rules alone, and keep them in an `@layer utilities`.

Fixes: #20204

## Test plan

1. Added a dedicated test for this usecase
