### PR TITLE
docs: fix double word 'to to' in test comment

### DIFF
--- a/packages/tailwindcss/src/canonicalize-candidates.test.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.test.ts
@@ -1220,7 +1220,7 @@ describe.each([['default'], ['with-variant'], ['important'], ['prefix']])('%s', 
     ['w-[calc(100%_-_calc(var(--spacing)*60))]', 'w-[calc(100%-(--spacing(60)))]'],
     ['w-[calc(100%_-_--spacing(60))]', 'w-[calc(100%-(--spacing(60)))]'],
 
-    // No need to to wrap in `(…)` after a `,`
+    // No need to wrap in `(…)` after a `,`
     ['m-[min(100%,_--spacing(6))]', 'm-[min(100%,--spacing(6))]'],
     ['m-[min(100%_,_--spacing(6))]', 'm-[min(100%,--spacing(6))]'],
     ['m-[min(100%,--spacing(6))]', 'm-[min(100%,--spacing(6))]'],


### PR DESCRIPTION
## Summary

Fixes a double word typo in a test comment: 'No need to to wrap' → 'No need to wrap'.

## Test plan

This is a comment-only change in a test file. No functional changes.