### PR TITLE
docs: fix 'preceeded' typo in candidate.ts comment

### DIFF
--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -1096,7 +1096,7 @@ const printArbitraryValueCache = new DefaultMap<string, string>((input) => {
       node.value = ','
     }
 
-    // Wrap custom functions starting with `--`, in parentheses if preceeded by
+    // Wrap custom functions starting with `--`, in parentheses if preceded by
     // a symbol. E.g.: `calc(100%---spacing(2))` → `calc(100%-(--spacing(2)))`
     else if (node.kind === 'function' && node.value.startsWith('--')) {
       let idx = ctx.index


### PR DESCRIPTION
## Summary

Fixes a misspelling in a comment: 'preceeded' → 'preceded'.

## Test plan

Comment-only change. No tests needed.