### PR TITLE
Add bare value support for `auto-rows-*` and `auto-cols-*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support bare spacing values for `auto-rows-*` and `auto-cols-*` utilities (e.g. `auto-rows-12` and `auto-cols-16`) ([#20229](https://github.com/tailwindlabs/tailwindcss/pull/20229))
+
 ### Fixed
 
 - Ensure `@tailwindcss/cli` in `--watch` mode doesn't crash on Windows when `@source` points to a directory that doesn't exist ([#20242](https://github.com/tailwindlabs/tailwindcss/pull/20242))

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -9012,15 +9012,28 @@ test('break-after', async () => {
 
 test('auto-cols', async () => {
   expect(
-    await run([
-      'auto-cols-auto',
-      'auto-cols-min',
-      'auto-cols-max',
-      'auto-cols-fr',
-      'auto-cols-[2fr]',
-    ]),
+    await run(
+      [
+        'auto-cols-auto',
+        'auto-cols-min',
+        'auto-cols-max',
+        'auto-cols-fr',
+        'auto-cols-[2fr]',
+        'auto-cols-12',
+      ],
+      css`
+        @tailwind utilities;
+        @theme {
+          --spacing: 0.25rem;
+        }
+      `,
+    ),
   ).toMatchInlineSnapshot(`
     "
+    .auto-cols-12 {
+      grid-auto-columns: calc(var(--spacing) * 12);
+    }
+
     .auto-cols-\\[2fr\\] {
       grid-auto-columns: 2fr;
     }
@@ -9039,6 +9052,10 @@ test('auto-cols', async () => {
 
     .auto-cols-min {
       grid-auto-columns: min-content;
+    }
+
+    :root, :host {
+      --spacing: .25rem;
     }
     "
   `)
@@ -9129,15 +9146,28 @@ test('grid-flow', async () => {
 
 test('auto-rows', async () => {
   expect(
-    await run([
-      'auto-rows-auto',
-      'auto-rows-min',
-      'auto-rows-max',
-      'auto-rows-fr',
-      'auto-rows-[2fr]',
-    ]),
+    await run(
+      [
+        'auto-rows-auto',
+        'auto-rows-min',
+        'auto-rows-max',
+        'auto-rows-fr',
+        'auto-rows-[2fr]',
+        'auto-rows-12',
+      ],
+      css`
+        @tailwind utilities;
+        @theme {
+          --spacing: 0.25rem;
+        }
+      `,
+    ),
   ).toMatchInlineSnapshot(`
     "
+    .auto-rows-12 {
+      grid-auto-rows: calc(var(--spacing) * 12);
+    }
+
     .auto-rows-\\[2fr\\] {
       grid-auto-rows: 2fr;
     }
@@ -9156,6 +9186,10 @@ test('auto-rows', async () => {
 
     .auto-rows-min {
       grid-auto-rows: min-content;
+    }
+
+    :root, :host {
+      --spacing: .25rem;
     }
     "
   `)

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1986,7 +1986,8 @@ export function createUtilities(theme: Theme) {
   functionalUtility('auto-cols', {
     themeKeys: ['--grid-auto-columns'],
     handleBareValue: ({ value }) => {
-      if (!isPositiveInteger(value)) return null
+      if (!theme.resolve(null, ['--spacing'])) return null
+      if (!isValidSpacingMultiplier(value)) return null
       return `--spacing(${value})`
     },
     handle: (value) => [decl('grid-auto-columns', value)],
@@ -2001,7 +2002,8 @@ export function createUtilities(theme: Theme) {
   functionalUtility('auto-rows', {
     themeKeys: ['--grid-auto-rows'],
     handleBareValue: ({ value }) => {
-      if (!isPositiveInteger(value)) return null
+      if (!theme.resolve(null, ['--spacing'])) return null
+      if (!isValidSpacingMultiplier(value)) return null
       return `--spacing(${value})`
     },
     handle: (value) => [decl('grid-auto-rows', value)],

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1985,6 +1985,10 @@ export function createUtilities(theme: Theme) {
 
   functionalUtility('auto-cols', {
     themeKeys: ['--grid-auto-columns'],
+    handleBareValue: ({ value }) => {
+      if (!isPositiveInteger(value)) return null
+      return `--spacing(${value})`
+    },
     handle: (value) => [decl('grid-auto-columns', value)],
     staticValues: {
       auto: [decl('grid-auto-columns', 'auto')],
@@ -1996,6 +2000,10 @@ export function createUtilities(theme: Theme) {
 
   functionalUtility('auto-rows', {
     themeKeys: ['--grid-auto-rows'],
+    handleBareValue: ({ value }) => {
+      if (!isPositiveInteger(value)) return null
+      return `--spacing(${value})`
+    },
     handle: (value) => [decl('grid-auto-rows', value)],
     staticValues: {
       auto: [decl('grid-auto-rows', 'auto')],


### PR DESCRIPTION
This PR adds bare value support for `auto-rows-*` and `auto-cols-*`.

We first introduced `auto-rows-auto`, `auto-rows-min`, `auto-rows-max` and `auto-rows-fr` (same for `auto-cols-*`) back in Tailwind CSS v1.9 (https://v1.tailwindcss.com/docs/grid-auto-rows#app) but we haven't touched it since.

This PR now adds support for bare values that use the spacing scale. That means that you can now use `auto-rows-12` or `auto-cols-12` which will result in the following CSS:

```css
.auto-cols-12 {
  grid-auto-columns: calc(var(--spacing) * 12);
}
.auto-rows-12 {
  grid-auto-rows: calc(var(--spacing) * 12);
}
```

We could also add support for percentage based values. The only question is what the syntax should be. This can either be `auto-rows-3/4` or `auto-rows-75%`. 

For the fraction case, we already have `w-3/4` and `aspect-3/4` even though they both have a different value as a result:
```css
.aspect-3\/4 {
  aspect-ratio: 3/4;
}
.w-3\/4 {
  width: calc(3 / 4 * 100%);
}
```

We also have some precedence for the `%` value as well, e.g. `via-10%` for gradient color stops.

I think I would personally towards the `auto-rows-75%` value instead of `auto-rows-3/4`. The fraction syntax works great for aspect ratio because that's literally what it is (`aspect-16/9`). The fraction also works great for widths, because you typically have 2 elements next to each other:
```html
<div>
  <div class="w-1/3"></div>
  <div class="w-2/3"></div>
</div>
```

Since you only use the `auto-rows-*` once on a parent element, I think the `auto-rows-75%` makes a bit more sense than `auto-rows-3/4` since there is no _other_ element (at least not that I can think of).


## TODO

- [ ] Support percentages?
   - [ ] Syntax A: `auto-rows-3/4`
   - [ ] Syntax B: `auto-rows-75%`
   - [ ] Syntax C: support both, but that seems silly

Percentage support isn't a blocker for this PR, since you can always use `auto-rows-[75%]` if you want

## Test plan

1. Added a test to prove that this works
1. Existing tests still pass

Requested by: https://github.com/tailwindlabs/tailwindcss/discussions/20225