### PR TITLE
Fix typo in css-parser.test.ts: 'with with' → 'with'

### DIFF
--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -203,7 +203,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ])
     })
 
-    it('should parse declarations with with strings and escaped string endings', () => {
+    it('should parse declarations with strings and escaped string endings', () => {
       expect(
         parse(css`
           content: 'These are not the end "\' of the string';


### PR DESCRIPTION
Fixes a duplicate word typo in `packages/tailwindcss/src/css-parser.test.ts`.