### PR TITLE
Fix crash when using `@tailwindcss/vite` using deno v2.8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure `@tailwindcss/cli` in `--watch` mode doesn't crash on Windows when `@source` points to a directory that doesn't exist ([#20242](https://github.com/tailwindlabs/tailwindcss/pull/20242))
+- Ensure `@tailwindcss/vite` doesn't crash in Deno v2.8.x when `context.parentURL` is not a valid URL ([#20245](https://github.com/tailwindlabs/tailwindcss/pull/20245))
 
 ## [4.3.1] - 2026-06-12
 

--- a/packages/@tailwindcss-node/src/esm-cache.loader.mts
+++ b/packages/@tailwindcss-node/src/esm-cache.loader.mts
@@ -17,20 +17,24 @@ export let resolveSync: ResolveHookSync = (specifier, context, nextResolve) => {
 }
 
 function processResolve(context: ResolveHookContext, result: ResolveFnOutput) {
-  if (result.url === import.meta.url) return result
-  if (isBuiltin(result.url)) return result
-  if (!context.parentURL) return result
+  try {
+    if (result.url === import.meta.url) return result
+    if (isBuiltin(result.url)) return result
+    if (!context.parentURL) return result
 
-  let parent = new URL(context.parentURL)
+    let parent = new URL(context.parentURL)
 
-  let id = parent.searchParams.get('id')
-  if (id === null) return result
+    let id = parent.searchParams.get('id')
+    if (id === null) return result
 
-  let url = new URL(result.url)
-  url.searchParams.set('id', id)
+    let url = new URL(result.url)
+    url.searchParams.set('id', id)
 
-  return {
-    ...result,
-    url: `${url}`,
+    return {
+      ...result,
+      url: `${url}`,
+    }
+  } catch {
+    return result
   }
 }


### PR DESCRIPTION
This PR might fix an issue where resolvers don't work on deno v2.8.x (they do work on deno v2.7.x) when using `@tailwindcss/vite`.

This happens when the `context.parentURL` is not actually a URL at all, and therefore the `new URL(…)` just crashes. This PR will fallback to the incoming result for files that are not passed proper URLs.

Fixes: #20232

## Test plan

1. Existing tests pass
2. ~~Can't seem to figure out how to test this in the reproduction issue without publishing first. So going to merge this and test the insiders version instead.~~
3. Tested with the insiders build:

Deno v2.7:
<img width="1030" height="532" alt="image" src="https://github.com/user-attachments/assets/99412304-5224-4af5-8131-7fc85ed2962c" />

Deno v2.8:
<img width="1025" height="948" alt="image" src="https://github.com/user-attachments/assets/e7118f5b-e15f-4755-b921-72b9ead7ac6a" />

Deno v2.8 + `@tailwindcss/vite@insiders`:
<img width="1027" height="516" alt="image" src="https://github.com/user-attachments/assets/36c4d025-63b0-411e-8356-e6719cda47e2" />
