### PR TITLE
Ensure `@tailwindcss/cli` watches the input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `@tailwindcss/cli` in `--watch` mode doesn't crash on Windows when `@source` points to a directory that doesn't exist ([#20242](https://github.com/tailwindlabs/tailwindcss/pull/20242))
 - Ensure `@tailwindcss/vite` doesn't crash in Deno v2.8.x when `context.parentURL` is not a valid URL ([#20245](https://github.com/tailwindlabs/tailwindcss/pull/20245))
+- Ensure `@tailwindcss/cli` in `--watch` mode rebuilds when the input CSS file changes in an ignored directory ([#20246](https://github.com/tailwindlabs/tailwindcss/pull/20246))
 
 ## [4.3.1] - 2026-06-12
 

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -405,6 +405,44 @@ describe.each([
   )
 
   test(
+    'watch mode rebuilds when the input file is in an ignored folder',
+    {
+      fs: {
+        'package.json': json`
+          {
+            "dependencies": {
+              "tailwindcss": "workspace:^",
+              "@tailwindcss/cli": "workspace:^"
+            }
+          }
+        `,
+        'index.html': html`
+          <div class="underline"></div>
+        `,
+        'assets/index.css': css`
+          @import 'tailwindcss';
+        `,
+      },
+    },
+    async ({ fs, spawn }) => {
+      let process = await spawn(`${command} --input assets/index.css --output dist/out.css --watch`)
+      await process.onStderr((m) => m.includes('Done in'))
+
+      await fs.expectFileToContain('dist/out.css', [candidate`underline`])
+
+      await fs.write(
+        'assets/index.css',
+        css`
+          @import 'tailwindcss';
+          @source inline("flex");
+        `,
+      )
+
+      await fs.expectFileToContain('dist/out.css', [candidate`flex`])
+    },
+  )
+
+  test(
     'production build (stdin)',
     {
       fs: {

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -404,6 +404,7 @@ describe.each([
     },
   )
 
+  // https://github.com/tailwindlabs/tailwindcss/issues/17632
   test(
     'watch mode rebuilds when the input file is in an ignored folder',
     {
@@ -416,24 +417,36 @@ describe.each([
             }
           }
         `,
-        'index.html': html`
+        'assets/tailwind.config.js': js`
+          module.exports = {
+            content: {
+              relative: true,
+              files: ['html/*.html'],
+            },
+          }
+        `,
+        'assets/html/index.html': html`
           <div class="underline"></div>
         `,
-        'assets/index.css': css`
-          @import 'tailwindcss';
+        'assets/css/index.css': css`
+          @import 'tailwindcss' source(none);
+          @config '../tailwind.config.js';
         `,
       },
     },
     async ({ fs, spawn }) => {
-      let process = await spawn(`${command} --input assets/index.css --output dist/out.css --watch`)
+      let process = await spawn(
+        `${command} --input assets/css/index.css --output dist/out.css --watch`,
+      )
       await process.onStderr((m) => m.includes('Done in'))
 
       await fs.expectFileToContain('dist/out.css', [candidate`underline`])
 
       await fs.write(
-        'assets/index.css',
+        'assets/css/index.css',
         css`
-          @import 'tailwindcss';
+          @import 'tailwindcss' source(none);
+          @config '../tailwind.config.js';
           @source inline("flex");
         `,
       )

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -260,6 +260,14 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
       negated: true,
     })
 
+    if (inputFilePath !== null) {
+      sources.push({
+        base: path.dirname(inputFilePath),
+        pattern: path.basename(inputFilePath),
+        negated: false,
+      })
+    }
+
     let scanner = new Scanner({ sources })
     DEBUG && I.end('Setup compiler')
 


### PR DESCRIPTION
This PR fixes an issue where if the `--input` file (when using `@tailwindcss/cli`) lives in an ignored folder, then changes to the input file won't trigger a rebuild.

This happened in #17632 where the input file lives in the `assets/` folder which is ignored by default (because of the `source (none)`).

However, if you make a change to the input file, then the CLI doesn't restart which means that you can't update the `@source` directives without quitting the program and re-starting it manually.

This PR solves that by automatically injecting an `@source` with the path to the input file. This way the CLI will see changes, even if the input file is in an ignored directory.

Fixes: #17632

## Test plan

1. Added an integration test
2. Existing tests pass
3. Reproduced it on the 


Before:
<img width="1122" height="1376" alt="file-295ce4696b6b3199a3915c63f8bb50cd" src="https://github.com/user-attachments/assets/09e5e965-38d1-474d-bfc6-3b5e9bca73b6" />

After:
<img width="1122" height="1376" alt="file-301b2f2e06aee045957355014ae5de87" src="https://github.com/user-attachments/assets/2b6d4cba-f456-4138-98bd-2259876fe70a" />
