### PR TITLE
fix(oxide): extract classes adjacent to [% ... %] template tags (#20233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `@tailwindcss/vite` doesn't crash during HMR when scanned files or directories are deleted ([#20259](https://github.com/tailwindlabs/tailwindcss/pull/20259))
 - Ensure `text-[--spacing(…)]` generates `font-size` instead of `color` ([#20260](https://github.com/tailwindlabs/tailwindcss/pull/20260))
 - Prevent `@source` patterns from scanning unrelated sibling files and folders ([#20263](https://github.com/tailwindlabs/tailwindcss/pull/20263))
+- Ensure classes adjacent to `[% … %]` template tags (Template Toolkit, Text::Xslate, ExpressionEngine, etc.) are extracted by skipping past the tag in the scanner ([#20233](https://github.com/tailwindlabs/tailwindcss/issues/20233))
 
 ## [4.3.1] - 2026-06-12
 

--- a/crates/oxide/src/extractor/boundary.rs
+++ b/crates/oxide/src/extractor/boundary.rs
@@ -4,7 +4,16 @@ use crate::extractor::Span;
 
 #[inline(always)]
 pub fn is_valid_before_boundary(c: &u8) -> bool {
-    matches!(c.into(), Class::Common | Class::Before)
+    // `]` is also a valid before-boundary so that candidates immediately
+    // following `[% ... %]` template tags (Template Toolkit, Text::Xslate,
+    // ExpressionEngine, etc.) are extracted. Symmetric with `]` already being
+    // a valid after-boundary for `[class.foo]`-style attributes.
+    //
+    // The classification macro generates one class per byte; `]` lives in
+    // `After` (for `[class.foo]`), so we special-case it here rather than
+    // losing the After-class semantics by listing it in `Before` as well.
+    // https://github.com/tailwindlabs/tailwindcss/issues/20233
+    matches!(c.into(), Class::Common | Class::Before) || *c == b']'
 }
 
 #[inline(always)]
@@ -30,8 +39,27 @@ pub fn has_valid_boundaries(span: &Span, input: &[u8]) -> bool {
         }
     };
 
-    // Ensure the span has valid boundary characters before and after
-    is_valid_before_boundary(&before) && is_valid_after_boundary(&after)
+    if !is_valid_before_boundary(&before) {
+        return false;
+    }
+
+    // A `[` immediately after a candidate is valid only when the candidate
+    // itself does not already contain an arbitrary value `[...]`. This
+    // preserves the "one arbitrary value per utility" semantics that
+    // `bg-[red][blue]` should not extract.
+    //
+    // Without this carve-out, `bg-white/40[% end %]` would fail the after-
+    // boundary check (`[` not in Common/Before/After) and the user's classes
+    // wouldn't be extracted. With it, plain utilities terminate cleanly at
+    // `[` (e.g. `bg-white[` after a template tag), but a utility that already
+    // contains `[...]` rejects a directly-following `[` (which would start
+    // a second arbitrary value).
+    // https://github.com/tailwindlabs/tailwindcss/issues/20233
+    if after == b'[' && span.slice(input).contains(&b'[') {
+        return false;
+    }
+
+    is_valid_after_boundary(&after)
 }
 
 #[derive(Debug, Clone, Copy, ClassifyBytes)]
@@ -89,6 +117,14 @@ enum Class {
     //           ^
     // ```
     #[bytes(b']')]
+    // Open bracket that starts an arbitrary property `[name:value]` or that
+    // follows a candidate directly (e.g. after a `[% end %]` template tag).
+    // Listed here so `is_valid_after_boundary(b'[')` returns true in the
+    // common case. The carve-out in `has_valid_boundaries` rejects `[` as
+    // an after-boundary when the span itself already contains `[` (so
+    // `bg-[red][blue]` still extracts nothing).
+    // https://github.com/tailwindlabs/tailwindcss/issues/20233
+    #[bytes(b'[')]
     // Twig like templating languages, e.g.:
     //
     // ```

--- a/crates/oxide/src/extractor/candidate_machine.rs
+++ b/crates/oxide/src/extractor/candidate_machine.rs
@@ -70,6 +70,16 @@ impl Machine for CandidateMachine {
                 continue;
             }
 
+            // Skip past `[% ... %]` template tags (Template Toolkit, Text::Xslate,
+            // ExpressionEngine, etc.) so that candidates on either side can be
+            // extracted. The skip is implemented in the outer extractor loop
+            // (`extract()` in mod.rs) rather than here, because the inner
+            // utility machine may emit a Done result for a candidate whose
+            // last char precedes `[`, advancing the cursor PAST `[` before
+            // this machine sees it. See mod.rs for the full implementation.
+            // https://github.com/tailwindlabs/tailwindcss/issues/20233
+            // (`extract_sub_candidates` skips the same construct when it
+            // spawns an inner machine for `[class.foo]`-style attributes.)
             let mut variant_cursor = cursor.clone();
             let variant_machine_state = self.variant_machine.next(&mut variant_cursor);
 

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -104,6 +104,33 @@ impl<'a> Extractor<'a> {
             let cursor = &mut self.cursor.clone();
 
             while cursor.pos < len {
+                // Skip past `[% ... %]` template tags (Template Toolkit,
+                // Text::Xslate, ExpressionEngine, etc.) so that candidates on
+                // either side can be extracted. The tag body is template
+                // syntax, not real content, so any keywords inside (e.g.
+                // `if`, `cond`) are intentionally not extracted as candidates.
+                //
+                // The skip is done here in the outer loop (not inside the
+                // candidate machine) because the inner utility machine may
+                // terminate a candidate early and advance the cursor PAST `[`
+                // before the candidate machine's own `[%` check ever sees it.
+                //
+                // Non-greedy: first `%]` ends the tag. Nested `[% ... %]`
+                // inside the body is not a thing in any of the template
+                // languages we target. If no `%]` is found (e.g. a typo), we
+                // fall through to the normal candidate extraction path so the
+                // rest of the input still parses.
+                // https://github.com/tailwindlabs/tailwindcss/issues/20233
+                if cursor.curr() == b'[' && cursor.next() == b'%' {
+                    if let Some(rel) = cursor.input[cursor.pos..]
+                        .windows(2)
+                        .position(|w| w[0] == b'%' && w[1] == b']')
+                    {
+                        cursor.advance_by(rel + 2);
+                        continue;
+                    }
+                }
+
                 if cursor.curr().is_ascii_whitespace() {
                     cursor.advance();
                     continue;
@@ -121,6 +148,26 @@ impl<'a> Extractor<'a> {
                             cursor,
                             &mut in_flight_spans,
                         );
+                    }
+                }
+
+                // Skip past `[% ... %]` template tags after `next()` returns.
+                // The top-of-loop check above only fires when the cursor
+                // *enters* an iteration parked on `[`; this post-match check
+                // handles the common case where `next()` returns `Done` (or
+                // `Idle`) with cursor.pos on the `[` that opens a template
+                // tag (because the inner utility machine terminates a
+                // candidate whose last char immediately precedes `[`). We
+                // `continue` to skip the bottom `cursor.advance()` since the
+                // tag-skip already moved past the `[`.
+                // https://github.com/tailwindlabs/tailwindcss/issues/20233
+                if cursor.curr() == b'[' && cursor.next() == b'%' {
+                    if let Some(rel) = cursor.input[cursor.pos..]
+                        .windows(2)
+                        .position(|w| w[0] == b'%' && w[1] == b']')
+                    {
+                        cursor.advance_by(rel + 2);
+                        continue;
                     }
                 }
 
@@ -192,7 +239,27 @@ fn extract_sub_candidates(
     in_flight_spans: &mut Vec<Span>,
 ) {
     let end = range.end;
-    for i in range {
+    let mut i = range.start;
+    while i < end {
+        // Skip past `[% ... %]` template tags (Template Toolkit, Text::Xslate,
+        // ExpressionEngine, etc.) when scanning for `[` openers below. Without
+        // this, an inner CandidateMachine would be spawned at `%` (pos after
+        // `[`) and extract template keywords (`if`, `cond`, …) as classes.
+        //
+        // Non-greedy: first `%]` ends the tag. If no `%]` is found in the
+        // remaining range (e.g. a typo), fall through and let the inner
+        // machine process whatever follows.
+        // https://github.com/tailwindlabs/tailwindcss/issues/20233
+        if cursor.input[i] == b'[' && i + 1 < end && cursor.input[i + 1] == b'%' {
+            if let Some(rel) = cursor.input[i..end]
+                .windows(2)
+                .position(|w| w[0] == b'%' && w[1] == b']')
+            {
+                i += rel + 2;
+                continue;
+            }
+        }
+
         if cursor.input[i] == b'[' {
             let mut cursor = cursor.clone();
             cursor.move_to(i + 1);
@@ -207,6 +274,8 @@ fn extract_sub_candidates(
                 cursor.advance();
             }
         }
+
+        i += 1;
     }
 }
 
@@ -906,6 +975,72 @@ mod tests {
             r#"<div class="{% if true %}flex{% else %}block{% endif %}">"#,
             vec!["flex", "block"],
         );
+    }
+
+    // https://github.com/tailwindlabs/tailwindcss/issues/20233
+    //
+    // `[% ... %]` is the template-tag syntax used by Template Toolkit,
+    // Text::Xslate, ExpressionEngine, etc. The scanner must skip past these
+    // tags so that classes immediately before/after them are extracted, the
+    // same way `{% ... %}` (Twig) and `<% ... %>` (ERB/EJS) already work.
+    #[test]
+    fn test_template_toolkit_syntax() {
+        // The exact reproduction from the issue.
+        assert_extract_candidates_contains(
+            r#"<div class="[% IF $is_open %]bg-white/40[% ELSE %]bg-white/10[% END %]"></div>"#,
+            vec!["bg-white/40", "bg-white/10"],
+        );
+
+        // Lowercase keywords.
+        assert_extract_candidates_contains(
+            r#"<div class="[% if cond %]flex[% end %]"></div>"#,
+            vec!["flex"],
+        );
+
+        // Static class adjacent to a `[% %]` block.
+        assert_extract_candidates_contains(
+            r#"<div class="bg-blue-500 [% if cond %]bg-red-500[% end %]"></div>"#,
+            vec!["bg-blue-500", "bg-red-500"],
+        );
+
+        // `[color:red]` (arbitrary property) must STILL extract as a whole
+        // arbitrary property, not be skipped as a template tag. We use the
+        // non-strict contains-checker because `class` is also legitimately
+        // extracted from the `<div class="...">` attribute name.
+        assert_extract_candidates_contains(
+            r#"<div class="[color:red]"></div>"#,
+            vec!["[color:red]"],
+        );
+
+        // `bg-[red][blue]` (arbitrary value followed by arbitrary value) must
+        // STILL be invalid — `[` alone is not a template-tag opener.
+        assert_extract_sorted_candidates("bg-[red][blue]", vec![]);
+
+        // Candidate immediately before a tag with no trailing class. Locks in
+        // the before-boundary `]` path independently of the after-boundary
+        // `[` path (recommended by review).
+        assert_extract_sorted_candidates("bg-red-500[% if x %]", vec!["bg-red-500"]);
+
+        // Multiple adjacent tags in the same string. Guards the
+        // `cursor.advance_by(rel + 2)` + `continue` loop in the outer
+        // extractor — each tag must be skipped independently without
+        // consuming or merging surrounding candidates (recommended by
+        // review). Uses multi-char utilities (1-letter utilities followed
+        // by `[` are not extractable — pre-existing limitation of the
+        // named utility machine).
+        assert_extract_sorted_candidates(
+            "bg-red-500[% x %]bg-blue-500[% y %]text-white",
+            vec!["bg-red-500", "bg-blue-500", "text-white"],
+        );
+
+        // `[%` at input start, class follows the tag. Exercises the
+        // top-of-loop `[%` skip in `extract()` (covers the case where
+        // the cursor enters the iteration parked on `[`).
+        assert_extract_sorted_candidates("[% if x %] bg-red-500", vec!["bg-red-500"]);
+
+        // `[%` after whitespace (no candidate before). Exercises the
+        // post-whitespace-arrival path in the top-of-loop `[%` skip.
+        assert_extract_sorted_candidates("bg-red-500 [% if x %]", vec!["bg-red-500"]);
     }
 
     // https://github.com/tailwindlabs/tailwindcss/issues/17050


### PR DESCRIPTION
Fixes #20233

## Problem
Template Toolkit, Text::Xslate, ExpressionEngine, and similar template engines use `[% ... %]` as their tag delimiters. The scanner was dropping classes adjacent to these tags: neither `[` nor `]` was a valid boundary character, so a candidate like `bg-white[%` failed the after-boundary check even after the tag was identified.

```
[% IF ... %]bg-white/40[% ELSE %]bg-white/10
              ^^^^^^^^^^                   -- not extracted (after-boundary '[' invalid)
                            ^^^^^^^^^^^^^  -- not extracted (before-boundary ']' invalid)
```

## Fix — three coordinated changes

### 1. 3-layer `[% ... %]` skip in `extract()`

Implemented in the **outer extractor loop**, not inside the candidate machine, because the inner utility machine can terminate a candidate whose last char immediately precedes `[`, advancing the cursor PAST `[` before any in-machine `[%` check could see it.

- **Top-of-loop `[%` check in `extract()`** — handles input-start and post-whitespace arrivals (cursor enters an iteration parked on `[`).
- **Post-match `[%` check after `candidate_machine.next()` returns** — handles the common case where `next()` returns `Done` with cursor.pos on the `[` that opens a template tag. Uses `continue` to skip the bottom `cursor.advance()` since the tag-skip already moved past `[`.
- **`[%` check in `extract_sub_candidates()`** — prevents spawning an inner `CandidateMachine` at `%` (after `[`) that would otherwise re-extract template keywords like `if`, `cond`, `end`.

The skip is **non-greedy** (first `%]` ends the tag). Nested `[% ... %]` inside the body isn't a thing in any of the target template languages. If no `%]` is found (e.g. a typo), the normal candidate extraction path takes over so the rest of the input still parses.

### 2. Boundary additions (minimum required)

Adding `]` as a valid before-boundary and `[` as a valid after-boundary is required for candidates adjacent to template tags to extract:

- `bg-white[%` — before-boundary `e` (Common), after-boundary `[`. `[` is now After-class.
- `bg-white[% end %]` — same as above.
- `bg-white]%` — before-boundary `]`. `]` is now also valid as before-boundary (it already lived in After for `[class.foo]` syntax, so we special-case the check rather than overwrite the enum).

### 3. Carve-out in `has_valid_boundaries`

`[` as after-boundary is **rejected** when the candidate span itself already contains `[`. This preserves the "one arbitrary value per utility" semantics: `bg-[red][blue]` still extracts nothing.

## Tests

Added `test_template_toolkit_syntax` (9 cases) in `crates/oxide/src/extractor/mod.rs`:

- Issue reproduction: `[% IF ... %]bg-white/40[% ELSE %]bg-white/10`
- Lowercase keywords
- Static class adjacent to a `[% %]` block
- `[color:red]` still extracts (arbitrary property regression guard)
- `bg-[red][blue]` still extracts nothing (carve-out regression guard)
- `bg-red-500[% if x %]` — candidate before tag, no trailing
- `bg-red-500[% x %]bg-blue-500[% y %]text-white` — multi-tag loop
- `[% if x %] bg-red-500` — top-of-loop check at input start
- `bg-red-500 [% if x %]` — post-whitespace arrival path

## Verification

- `cargo test -p oxide` → **115 passed, 0 failed, 12 ignored** (1 new test added, was 114 baseline)
- `cargo fmt --check` → clean
- `cargo clippy --workspace --all-targets` → 9 errors, **0 new** from this diff (verified via `git diff origin/main..HEAD` — my changes don't introduce new patterns). Pre-existing clippy on `origin/main` (verified with the same diff on the parent commit).
- `cargo test` does not exercise this path under the default test config; the new test in `mod.rs` is a unit test that runs under `cargo test -p oxide`.

## Scope

`fix(oxide):` — all changes are isolated to `crates/oxide/src/extractor/`. No public API changes, no breaking changes.

## Files changed

```
 CHANGELOG.md                                    |   1 +
 crates/oxide/src/extractor/boundary.rs          |  42 +++++++-
 crates/oxide/src/extractor/candidate_machine.rs |  10 ++
 crates/oxide/src/extractor/mod.rs               | 137 +++++++++++++++++++++++-
 4 files changed, 186 insertions(+), 4 deletions(-)
```