### PR TITLE
migrate to pnpm v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,7 +15,7 @@ on:
 env:
   APP_NAME: tailwindcss-oxide
   NODE_VERSION: 24
-  PNPM_VERSION: '9.6.0'
+  PNPM_VERSION: '11.9.0'
   OXIDE_LOCATION: ./crates/node
 
 permissions:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 
@@ -220,7 +220,7 @@ jobs:
         run: |
           echo "TAG_NAME=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
 env:
   APP_NAME: tailwindcss-oxide
   NODE_VERSION: 24
-  PNPM_VERSION: '9.6.0'
+  PNPM_VERSION: '11.9.0'
   OXIDE_LOCATION: ./crates/node
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 
@@ -219,7 +219,7 @@ jobs:
           fetch-depth: 20
           persist-credentials: false
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
 

--- a/crates/node/npm/wasm32-wasi/.npmrc
+++ b/crates/node/npm/wasm32-wasi/.npmrc
@@ -1,1 +1,0 @@
-node-linker=hoisted

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -639,6 +639,15 @@ describe.each([
     'git ignore files outside of a repo are not considered',
     {
       fs: {
+        // Make the test root a pnpm workspace that includes `home/project` so
+        // the install below resolves the transitive dependency overrides that
+        // the test harness injects into this `pnpm-workspace.yaml`.
+        'pnpm-workspace.yaml': yaml`
+          #
+          packages:
+            - home/project
+        `,
+
         // Ignore everything in the "home" directory
         'home/.gitignore': '*',
 
@@ -676,7 +685,7 @@ describe.each([
       installDependencies: false,
     },
     async ({ fs, root, exec }) => {
-      await exec(`pnpm install --ignore-workspace`, {
+      await exec(`pnpm install`, {
         cwd: path.join(root, 'home/project'),
       })
 

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "dedent": "catalog:",
     "fast-glob": "^3.3.3",
-    "source-map-js": "^1.2.1"
+    "source-map-js": "^1.2.1",
+    "yaml": "^2.9.0"
   }
 }

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -202,6 +202,7 @@ test(
       `,
       'notes/unrelated.txt': `order-[0] bg-[--my-red]`,
     },
+    retry: 0,
   },
   async ({ exec, fs, expect }) => {
     await exec('npx @tailwindcss/upgrade')
@@ -1168,6 +1169,7 @@ test(
         }
       `,
     },
+    retry: 0,
   },
   async ({ exec, fs, expect }) => {
     await exec('npx @tailwindcss/upgrade --force')
@@ -1279,6 +1281,7 @@ test(
         }
       `,
     },
+    retry: 0,
   },
   async ({ exec, fs, expect }) => {
     await exec('npx @tailwindcss/upgrade --force')
@@ -2253,6 +2256,7 @@ test(
         }
       `,
     },
+    retry: 0,
   },
   async ({ exec, fs, expect }) => {
     await exec('npx @tailwindcss/upgrade --force')

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -28,7 +28,7 @@ test(
     },
   },
   async ({ fs, exec, expect }) => {
-    let output = await exec('npx @tailwindcss/upgrade')
+    let output = await exec('pnpm exec upgrade')
     expect(output).toContain('Cannot find any CSS files that reference Tailwind CSS.')
 
     // Files should not be modified
@@ -100,7 +100,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
       "
@@ -158,7 +158,7 @@ test(
     })
 
     // Ensure the v4 project compiles correctly
-    await exec('npx tailwindcss --input src/input.css --output dist/out.css')
+    await exec('pnpm exec tailwindcss --input src/input.css --output dist/out.css')
 
     await fs.expectFileToContain('dist/out.css', [
       candidate`flex!`,
@@ -205,7 +205,7 @@ test(
     retry: 0,
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./**/*.{html,php,txt}')).toMatchInlineSnapshot(`
       "
@@ -263,7 +263,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
       "
@@ -335,7 +335,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -407,7 +407,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -484,7 +484,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -587,7 +587,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -695,7 +695,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     await fs.expectFileToContain(
       'postcss.config.js',
@@ -766,7 +766,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     let packageJsonContent = await fs.read('package.json')
     let packageJson = JSON.parse(packageJsonContent)
@@ -813,7 +813,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     let packageJsonContent = await fs.read('package.json')
     let packageJson = JSON.parse(packageJsonContent)
@@ -865,7 +865,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     await fs.expectFileToContain('src/index.css', css`@import 'tailwindcss';`)
     await fs.expectFileToContain(
@@ -941,7 +941,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     await fs.expectFileToContain('src/index.css', css`@import 'tailwindcss';`)
     await fs.expectFileToContain(
@@ -1008,7 +1008,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.html')).toMatchInlineSnapshot(`
       "
@@ -1055,7 +1055,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.html')).toMatchInlineSnapshot(`
       "
@@ -1099,7 +1099,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -1172,7 +1172,7 @@ test(
     retry: 0,
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -1284,7 +1284,7 @@ test(
     retry: 0,
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -1417,7 +1417,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    let output = await exec('npx @tailwindcss/upgrade --force')
+    let output = await exec('pnpm exec upgrade --force')
 
     expect(output).toMatch(
       /You have one or more stylesheets that are imported into a utility layer and non-utility layer./,
@@ -1541,7 +1541,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
@@ -1766,7 +1766,7 @@ test(
     },
   },
   async ({ exec, expect }) => {
-    let output = await exec('npx @tailwindcss/upgrade --force', {}, { ignoreStdErr: true }).catch(
+    let output = await exec('pnpm exec upgrade --force', {}, { ignoreStdErr: true }).catch(
       (e) => e.toString(),
     )
 
@@ -1838,7 +1838,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
@@ -1974,7 +1974,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
@@ -2094,7 +2094,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
@@ -2174,7 +2174,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -2259,7 +2259,7 @@ test(
     retry: 0,
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -2313,7 +2313,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     let pkg = JSON.parse(await fs.read('package.json'))
 
@@ -2392,7 +2392,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     // Files should not be modified
     expect(await fs.dumpFiles('./*.{js,css,html}')).toMatchInlineSnapshot(`
@@ -2490,7 +2490,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade --force')
+    await exec('pnpm exec upgrade --force')
 
     // Files should not be modified
     expect(await fs.dumpFiles('./*.{js,css,html,tsx}')).toMatchInlineSnapshot(`
@@ -2597,7 +2597,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade ./src/index.css')
+    await exec('pnpm exec upgrade ./src/index.css')
 
     expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
       "
@@ -2723,7 +2723,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
       "
@@ -2809,7 +2809,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
       "
@@ -2877,7 +2877,7 @@ test(
     },
   },
   async ({ exec, root, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     let before = await fs.dumpFiles('./src/**/*.{css,html}')
     expect(before).toMatchInlineSnapshot(`
@@ -2919,7 +2919,7 @@ test(
     }
 
     // Run the upgrade again
-    let output = await exec('npx @tailwindcss/upgrade')
+    let output = await exec('pnpm exec upgrade')
     expect(output).toContain('No changes were made to your repository')
 
     let after = await fs.dumpFiles('./src/**/*.{css,html}')
@@ -2998,7 +2998,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
       "
@@ -3047,7 +3047,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/{*,.env,.env.*}')).toMatchInlineSnapshot(`
       "
@@ -3118,7 +3118,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./{src,templates}/**/*')).toMatchInlineSnapshot(`
       "
@@ -3194,6 +3194,10 @@ test(
     let originalKeepFile = await fs.read('src/keep.php')
     let originalTemplate = await fs.read('src/templates/template-0.php')
 
+    // NOTE: This test intentionally keeps `npx` instead of `pnpm exec`. It uses
+    // a `NODE_OPTIONS` hook that overrides `fs.writeFile` to simulate a bad
+    // write, and `pnpm exec` may write a bin shim on startup which would trip
+    // that hook before template migration begins.
     let process = await spawn('npx @tailwindcss/upgrade --force', {
       env: {
         NODE_OPTIONS: '--require=./hook.cjs',
@@ -3261,7 +3265,7 @@ test(
     },
   },
   async ({ root, exec, fs, expect }) => {
-    let stdout = await exec('npx @tailwindcss/upgrade', {
+    let stdout = await exec('pnpm exec upgrade', {
       cwd: path.join(root, 'project-a'),
     })
 
@@ -3335,7 +3339,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    let stdout = await exec('npx @tailwindcss/upgrade')
+    let stdout = await exec('pnpm exec upgrade')
 
     expect(stdout).not.toContain(
       'Running this command will add the dependency to the workspace root',
@@ -3411,7 +3415,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('./src/**/*.{css,vue}')).toMatchInlineSnapshot(`
       "

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -164,7 +164,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.{css,js,html}')).toMatchInlineSnapshot(`
       "
@@ -370,7 +370,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(
       await fs.dumpFiles(
@@ -484,7 +484,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -586,7 +586,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.{css,ts}')).toMatchInlineSnapshot(`
       "
@@ -672,7 +672,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -750,7 +750,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -824,7 +824,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -934,7 +934,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('project-{a,b}/**/*.{css,ts}')).toMatchInlineSnapshot(`
       "
@@ -1032,7 +1032,7 @@ test(
     },
   },
   async ({ root, exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade', {
+    await exec('pnpm exec upgrade', {
       cwd: path.join(root, 'frontend'),
     })
 
@@ -1119,7 +1119,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/*.css')).toMatchInlineSnapshot(`
       "
@@ -1194,7 +1194,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/*.css')).toMatchInlineSnapshot(`
       "
@@ -1270,7 +1270,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/*.css')).toMatchInlineSnapshot(`
       "
@@ -1346,7 +1346,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
         "
@@ -1408,7 +1408,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
         "
@@ -1470,7 +1470,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
         "
@@ -1509,7 +1509,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
         "
@@ -1580,7 +1580,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
         "
@@ -1683,7 +1683,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.{css,html}')).toMatchInlineSnapshot(`
         "
@@ -1793,7 +1793,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.{css,html}')).toMatchInlineSnapshot(`
         "
@@ -1895,7 +1895,7 @@ describe('border compatibility', () => {
       },
     },
     async ({ exec, fs, expect }) => {
-      await exec('npx @tailwindcss/upgrade')
+      await exec('pnpm exec upgrade')
 
       expect(await fs.dumpFiles('src/**/*.{css,html}')).toMatchInlineSnapshot(`
         "
@@ -1993,7 +1993,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -2064,7 +2064,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
       "
@@ -2141,7 +2141,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
       "

--- a/integrations/upgrade/upgrade-errors.test.ts
+++ b/integrations/upgrade/upgrade-errors.test.ts
@@ -31,6 +31,7 @@ test(
         @tailwind utilities;
       `,
     },
+    retry: 0,
   },
   async ({ exec, expect }) => {
     // Ensure we are in a git repo
@@ -105,6 +106,7 @@ test(
         @tailwind utilities;
       `,
     },
+    retry: 0,
   },
   async ({ exec, expect }) => {
     // Use `bun` to install dependencies
@@ -192,6 +194,7 @@ test(
         @tailwind utilities;
       `,
     },
+    retry: 0,
   },
   async ({ exec, expect }) => {
     // Use `npm` to install dependencies

--- a/integrations/upgrade/upgrade-errors.test.ts
+++ b/integrations/upgrade/upgrade-errors.test.ts
@@ -40,7 +40,7 @@ test(
     await exec('git commit -m "before migration"')
 
     // Fully upgrade to v4
-    await exec('npx @tailwindcss/upgrade')
+    await exec('pnpm exec upgrade')
 
     // Undo all changes to the current repo. This will bring the repo back to a
     // v3 state, but the `node_modules` will now have v4 installed.
@@ -48,7 +48,7 @@ test(
 
     // Re-running the upgrade should result in an error
     return expect(() => {
-      return exec('npx @tailwindcss/upgrade', {}, { ignoreStdErr: true }).catch((e) => {
+      return exec('pnpm exec upgrade', {}, { ignoreStdErr: true }).catch((e) => {
         // Replacing the current version with a hardcoded `v4` to make it stable
         // when we release new minor/patch versions.
         return Promise.reject(
@@ -56,7 +56,7 @@ test(
         )
       })
     }).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Command failed: npx @tailwindcss/upgrade
+      "Command failed: pnpm exec upgrade
       ≈ tailwindcss v4.0.0
 
       │ ↳ Upgrading from Tailwind CSS \`v4.0.0\` 

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -431,6 +431,15 @@ export function test(
         node_modules/
       `
 
+      // Disable Git's automatic line ending conversion in these throwaway test
+      // repositories. Tools like pnpm write files (e.g. `pnpm-lock.yaml`) with
+      // LF endings, which on Windows (where `core.autocrlf=true` is common)
+      // makes Git emit noisy "LF will be replaced by CRLF" warnings when it
+      // touches those files.
+      config.fs['.gitattributes'] ??= txt`
+        * -text
+      `
+
       // Ensure there is always a root `pnpm-workspace.yaml` so that transitive
       // dependency overrides (and the build allow list) are injected into it.
       // As of pnpm v10, these can no longer live in the `pnpm.overrides` field

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -126,6 +126,39 @@ export function test(
           execOptions: ExecOptions = {},
         ) {
           let cwd = childProcessOptions.cwd ?? root
+          let originalCommand = command
+
+          // Avoid `pnpm exec upgrade` on Windows because the upgrader runs
+          // `pnpm add`, which rewrites Windows `.cmd` shims while the current
+          // shim is still executing.
+          //
+          // Pretty sure this is a pnpm v11 bug on Windows.
+          if (IS_WINDOWS && command.includes('pnpm exec upgrade')) {
+            for (let base = cwd; ; base = path.dirname(base)) {
+              let upgradeBin = path.join(
+                base,
+                'node_modules',
+                '@tailwindcss',
+                'upgrade',
+                'dist',
+                'index.mjs',
+              )
+
+              try {
+                await fs.access(upgradeBin)
+                command = command.replace('pnpm exec upgrade', `node "${upgradeBin}"`)
+                break
+              } catch (error: any) {
+                if (error?.code !== 'ENOENT') throw error
+              }
+
+              let parent = path.dirname(base)
+              if (parent === base) {
+                throw new Error(`Unable to resolve @tailwindcss/upgrade from ${cwd}`)
+              }
+            }
+          }
+
           if (debug && cwd !== root) {
             let relative = path.relative(root, cwd)
             if (relative[0] !== '.') relative = `./${relative}`
@@ -145,6 +178,11 @@ export function test(
               },
               (error, stdout, stderr) => {
                 if (error) {
+                  if (command !== originalCommand) {
+                    error.message = error.message.replace(command, originalCommand)
+                    let mappedError = error as any
+                    mappedError.cmd = originalCommand
+                  }
                   if (execOptions.ignoreStdErr !== true) console.error(stderr)
                   if (only || debug) {
                     console.error(stdout)

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -44,6 +44,7 @@ interface TestConfig {
 
   timeout?: number
   installDependencies?: boolean
+  retry?: number
 }
 interface TestContext {
   root: string
@@ -98,7 +99,7 @@ export function test(
     name,
     {
       timeout: config.timeout ?? TEST_TIMEOUT,
-      retry: process.env.CI ? 2 : 0,
+      retry: config.retry ?? (process.env.CI ? 2 : 0),
       only: only || (!process.env.CI && debug),
       skip,
       concurrent,

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -8,10 +8,14 @@ import path from 'node:path'
 import { promisify, stripVTControlCharacters } from 'node:util'
 import { RawSourceMap, SourceMapConsumer } from 'source-map-js'
 import { test as defaultTest, type ExpectStatic } from 'vitest'
+import * as Yaml from 'yaml'
 import { createLineTable } from '../packages/tailwindcss/src/source-maps/line-table'
 import { escape } from '../packages/tailwindcss/src/utils/escape'
 
 const REPO_ROOT = path.join(__dirname, '..')
+const ROOT_PNPM_WORKSPACE = Yaml.parse(
+  await fs.readFile(path.join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8'),
+)
 const PUBLIC_PACKAGES = (await fs.readdir(path.join(REPO_ROOT, 'dist'))).map((name) =>
   name.replace('tailwindcss-', '@tailwindcss/').replace('.tgz', ''),
 )
@@ -306,6 +310,8 @@ export function test(
 
             if (filename.endsWith('package.json')) {
               content = await overwriteVersionsInPackageJson(content)
+            } else if (filename.endsWith('pnpm-workspace.yaml')) {
+              content = overwriteVersionsInPnpmWorkspace(content)
             }
 
             // Ensure that files written on Windows use \r\n line ending
@@ -424,6 +430,12 @@ export function test(
         node_modules/
       `
 
+      // Ensure there is always a root `pnpm-workspace.yaml` so that transitive
+      // dependency overrides (and the build allow list) are injected into it.
+      // As of pnpm v10, these can no longer live in the `pnpm.overrides` field
+      // of `package.json`.
+      config.fs['pnpm-workspace.yaml'] ??= ''
+
       for (let [filename, content] of Object.entries(config.fs)) {
         if (content.toString().startsWith('symlink:')) {
           // The symlink path is relative to the target destination's path
@@ -441,14 +453,12 @@ export function test(
       let shouldInstallDependencies = config.installDependencies ?? true
 
       try {
-        // In debug mode, the directory is going to be inside the pnpm workspace
-        // of the tailwindcss package. This means that `pnpm install` will run
-        // pnpm install on the workspace instead (expect if the root dir defines
-        // a separate workspace). We work around this by using the
-        // `--ignore-workspace` flag.
+        // Every test project gets its own root `pnpm-workspace.yaml` (see
+        // above). This makes the test directory its own workspace root, so even
+        // in debug mode — where the directory lives inside this repository's
+        // pnpm workspace — `pnpm install` won't attach to the parent workspace.
         if (shouldInstallDependencies) {
-          let ignoreWorkspace = debug && !config.fs['pnpm-workspace.yaml']
-          await context.exec(`pnpm install${ignoreWorkspace ? ' --ignore-workspace' : ''}`)
+          await context.exec(`pnpm install`)
         }
       } catch (error: any) {
         console.error(error)
@@ -526,28 +536,42 @@ async function overwriteVersionsInPackageJson(content: string): Promise<string> 
     }
   }
 
+  return JSON.stringify(json, null, 2)
+}
+
+function overwriteVersionsInPnpmWorkspace(content: string): string {
+  let workspace = content.trim() === '' ? {} : Yaml.parse(content)
+
+  // Inherit information from the root workspace
+  workspace.allowBuilds = {
+    ...ROOT_PNPM_WORKSPACE.allowBuilds,
+    ...workspace.allowBuilds,
+  }
+
   // Inject transitive dependency overwrite. This is necessary because
   // @tailwindcss/vite internally depends on a specific version of
   // @tailwindcss/oxide and we instead want to resolve it to the locally built
   // version.
-  json.pnpm ||= {}
-  json.pnpm.overrides ||= {}
+  //
+  // As of pnpm v10, the `pnpm.overrides` field in `package.json` is no longer
+  // read. Overrides have to be defined in `pnpm-workspace.yaml` instead.
+  workspace.overrides ||= {}
   for (let pkg of PUBLIC_PACKAGES) {
     if (pkg === 'tailwindcss') {
       // We want to be explicit about the `tailwindcss` package so our tests can
       // also import v3 without conflicting v4 tarballs.
-      json.pnpm.overrides['@tailwindcss/node>tailwindcss'] = resolveVersion(pkg)
-      json.pnpm.overrides['@tailwindcss/upgrade>tailwindcss'] = resolveVersion(pkg)
-      json.pnpm.overrides['@tailwindcss/cli>tailwindcss'] = resolveVersion(pkg)
-      json.pnpm.overrides['@tailwindcss/postcss>tailwindcss'] = resolveVersion(pkg)
-      json.pnpm.overrides['@tailwindcss/vite>tailwindcss'] = resolveVersion(pkg)
-      json.pnpm.overrides['@tailwindcss/webpack>tailwindcss'] = resolveVersion(pkg)
+      workspace.overrides['@tailwindcss/node>tailwindcss'] = resolveVersion(pkg)
+      workspace.overrides['@tailwindcss/upgrade>tailwindcss'] = resolveVersion(pkg)
+      workspace.overrides['@tailwindcss/cli>tailwindcss'] = resolveVersion(pkg)
+      workspace.overrides['@tailwindcss/postcss>tailwindcss'] = resolveVersion(pkg)
+      workspace.overrides['@tailwindcss/vite>tailwindcss'] = resolveVersion(pkg)
+      workspace.overrides['@tailwindcss/webpack>tailwindcss'] = resolveVersion(pkg)
     } else {
-      json.pnpm.overrides[pkg] = resolveVersion(pkg)
+      workspace.overrides[pkg] = resolveVersion(pkg)
     }
   }
 
-  return JSON.stringify(json, null, 2)
+  return Yaml.stringify(workspace)
 }
 
 function resolveVersion(dependency: string) {

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1090,6 +1090,14 @@ test(
         </head>
       `,
       'src/index.js': js`import Plotly from 'plotly.js/lib/core'`,
+
+      // `plotly.js` pulls in `es5-ext`, which has a build script. As of pnpm
+      // v10, build scripts only run when explicitly allowed.
+      'pnpm-workspace.yaml': yaml`
+        #
+        allowBuilds:
+          es5-ext: true
+      `,
     },
   },
   async ({ exec, expect, fs }) => {

--- a/integrations/vite/nuxt.test.ts
+++ b/integrations/vite/nuxt.test.ts
@@ -8,6 +8,7 @@ import {
   retryAssertion,
   test,
   ts,
+  yaml,
 } from '../utils'
 
 const SETUP = {
@@ -21,13 +22,13 @@ const SETUP = {
           "nitropack": "2.11.0",
           "tailwindcss": "workspace:^",
           "vue": "latest"
-        },
-        "pnpm": {
-          "overrides": {
-            "nuxi": "3.28.0"
-          }
         }
       }
+    `,
+    'pnpm-workspace.yaml': yaml`
+      #
+      overrides:
+        nuxi: 3.28.0
     `,
     'nuxt.config.ts': ts`
       import tailwindcss from '@tailwindcss/vite'

--- a/package.json
+++ b/package.json
@@ -60,11 +60,5 @@
     "typescript": "^5.9.3",
     "vitest": "^4.1.7"
   },
-  "packageManager": "pnpm@9.6.0",
-  "pnpm": {
-    "patchedDependencies": {
-      "@parcel/watcher@2.5.1": "patches/@parcel__watcher@2.5.1.patch",
-      "lightningcss@1.32.0": "patches/lightningcss@1.32.0.patch"
-    }
-  }
+  "packageManager": "pnpm@11.9.0"
 }

--- a/playgrounds/nextjs/package.json
+++ b/playgrounds/nextjs/package.json
@@ -20,11 +20,5 @@
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
     "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.15",
-      "@types/react-dom": "19.2.3"
-    }
   }
 }

--- a/playgrounds/v3/package.json
+++ b/playgrounds/v3/package.json
@@ -20,11 +20,5 @@
     "@types/react-dom": "19.2.3",
     "autoprefixer": "^10.5.0",
     "typescript": "^6.0.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.15",
-      "@types/react-dom": "19.2.3"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,12 +53,8 @@ catalogs:
       version: 5.107.0
 
 patchedDependencies:
-  '@parcel/watcher@2.5.1':
-    hash: p6xahr7zs4c5qsorj3exeppxhm
-    path: patches/@parcel__watcher@2.5.1.patch
-  lightningcss@1.32.0:
-    hash: mz3chiqe2jbihxa25xumd4ogum
-    path: patches/lightningcss@1.32.0.patch
+  '@parcel/watcher@2.5.1': c22241764997c5af4980d3be22550ae47858f14849dca486726653fa127eb69c
+  lightningcss@1.32.0: 1d4a8800d60d13d42887b88b3a86576df4b451670308145fb432ec8abbf40930
 
 importers:
 
@@ -87,7 +83,7 @@ importers:
         version: 4.3.0(prettier@3.8.3)(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0)
       turbo:
         specifier: ^2.9.18
         version: 2.9.18
@@ -96,9 +92,19 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@22.19.19)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0))
+        version: 4.1.7(@types/node@22.19.19)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
   crates/node:
+    devDependencies:
+      '@napi-rs/cli':
+        specifier: 3.7.0
+        version: 3.7.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.1)(node-addon-api@8.7.0)
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.5
+        version: 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      emnapi:
+        specifier: 1.11.1
+        version: 1.11.1(node-addon-api@8.7.0)
     optionalDependencies:
       '@tailwindcss/oxide-android-arm64':
         specifier: workspace:*
@@ -136,16 +142,6 @@ importers:
       '@tailwindcss/oxide-win32-x64-msvc':
         specifier: workspace:*
         version: link:npm/win32-x64-msvc
-    devDependencies:
-      '@napi-rs/cli':
-        specifier: 3.7.0
-        version: 3.7.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.1)(node-addon-api@8.7.0)
-      '@napi-rs/wasm-runtime':
-        specifier: ^1.1.5
-        version: 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      emnapi:
-        specifier: 1.11.1
-        version: 1.11.1(node-addon-api@8.7.0)
 
   crates/node/npm/android-arm-eabi: {}
 
@@ -203,6 +199,9 @@ importers:
       source-map-js:
         specifier: ^1.2.1
         version: 1.2.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   packages/@tailwindcss-browser:
     devDependencies:
@@ -220,7 +219,7 @@ importers:
     dependencies:
       '@parcel/watcher':
         specifier: 2.5.1
-        version: 2.5.1(patch_hash=p6xahr7zs4c5qsorj3exeppxhm)
+        version: 2.5.1(patch_hash=c22241764997c5af4980d3be22550ae47858f14849dca486726653fa127eb69c)
       '@tailwindcss/node':
         specifier: workspace:*
         version: link:../@tailwindcss-node
@@ -253,7 +252,7 @@ importers:
         version: 2.7.0
       lightningcss:
         specifier: 'catalog:'
-        version: 1.32.0(patch_hash=mz3chiqe2jbihxa25xumd4ogum)
+        version: 1.32.0(patch_hash=1d4a8800d60d13d42887b88b3a86576df4b451670308145fb432ec8abbf40930)
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -449,7 +448,7 @@ importers:
         version: 22.19.19
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)
+        version: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
   packages/@tailwindcss-webpack:
     dependencies:
@@ -494,7 +493,7 @@ importers:
         version: 1.7.2
       lightningcss:
         specifier: 'catalog:'
-        version: 1.32.0(patch_hash=mz3chiqe2jbihxa25xumd4ogum)
+        version: 1.32.0(patch_hash=1d4a8800d60d13d42887b88b3a86576df4b451670308145fb432ec8abbf40930)
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -549,7 +548,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       tailwindcss:
         specifier: ^3
-        version: 3.4.19
+        version: 3.4.19(yaml@2.9.0)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -574,7 +573,7 @@ importers:
         version: link:../../packages/@tailwindcss-vite
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0))
+        version: 6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -596,7 +595,7 @@ importers:
         version: 1.3.14
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
 packages:
 
@@ -808,89 +807,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1154,42 +1169,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-arm64-musl@1.4.5':
     resolution: {integrity: sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/lzma-linux-ppc64-gnu@1.4.5':
     resolution: {integrity: sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-riscv64-gnu@1.4.5':
     resolution: {integrity: sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-s390x-gnu@1.4.5':
     resolution: {integrity: sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-gnu@1.4.5':
     resolution: {integrity: sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     resolution: {integrity: sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/lzma-wasm32-wasi@1.4.5':
     resolution: {integrity: sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA==}
@@ -1259,36 +1281,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-arm64-musl@1.1.0':
     resolution: {integrity: sha512-L/y1/26q9L/uBqiW/JdOb/Dc94egFvNALUZV2WCGKQXc6UByPBMgdiEyW2dtoYxYYYYc+AKD+jr+wQPcvX2vrQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/tar-linux-ppc64-gnu@1.1.0':
     resolution: {integrity: sha512-EPE1K/80RQvPbLRJDJs1QmCIcH+7WRi0F73+oTe1582y9RtfGRuzAkzeBuAGRXAQEjRQw/RjtNqr6UTJ+8UuWQ==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-s390x-gnu@1.1.0':
     resolution: {integrity: sha512-B2jhWiB1ffw1nQBqLUP1h4+J1ovAxBOoe5N2IqDMOc63fsPZKNqF1PvO/dIem8z7LL4U4bsfmhy3gBfu547oNQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-x64-gnu@1.1.0':
     resolution: {integrity: sha512-tbZDHnb9617lTnsDMGo/eAMZxnsQFnaRe+MszRqHguKfMwkisc9CCJnks/r1o84u5fECI+J/HOrKXgczq/3Oww==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/tar-linux-x64-musl@1.1.0':
     resolution: {integrity: sha512-dV6cODlzbO8u6Anmv2N/ilQHq/AWz0xyltuXoLU3yUyXbZcnWYZuB2rL8OBGPmqNcD+x9NdScBNXh7vWN0naSQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/tar-wasm32-wasi@1.1.0':
     resolution: {integrity: sha512-jIa9nb2HzOrfH0F8QQ9g3WE4aMH5vSI5/1NYVNm9ysCmNjCCtMXCAhlI3WKCdm/DwHf0zLqdrrtDFXODcNaqMw==}
@@ -1364,24 +1392,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/wasm-tools-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-jAasbIvjZXCgX0TCuEFQr+4D6Lla/3AAVx2LmDuMjgG4xoIXzjKWl7c4chuaD+TI+prWT0X6LJcdzFT+ROKGHQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/wasm-tools-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-Plgk5rPqqK2nocBGajkMVbGm010Z7dnUgq0wtnYRZbzWWxwWcXfZMPa8EYxrK4eE8SzpI7VlZP1tdVsdjgGwMw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/wasm-tools-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-GW7AzGuWxtQkyHknHWYFdR0CHmW6is8rG2Rf4V6GNmMpmwtXt/ItWYWtBe4zqJWycMNazpfZKSw/BpT7/MVCXQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/wasm-tools-wasm32-wasi@1.0.1':
     resolution: {integrity: sha512-/nQVSTrqSsn7YdAc2R7Ips/tnw5SPUcl3D7QrXCNGPqjbatIspnaexvaOYNyKMU6xPu+pc0BTnKVmqhlJJCPLA==}
@@ -1430,24 +1462,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.7':
     resolution: {integrity: sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.7':
     resolution: {integrity: sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.7':
     resolution: {integrity: sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.7':
     resolution: {integrity: sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==}
@@ -1661,30 +1697,35 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-glibc@2.5.6':
     resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
@@ -1697,6 +1738,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
@@ -1709,6 +1751,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
@@ -1721,6 +1764,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
@@ -1818,36 +1862,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -1909,66 +1959,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -2014,21 +2077,25 @@ packages:
     resolution: {integrity: sha512-1ZD4YFhG1rmgqj+W8hfwHyKV8xDxGsc/3KgU0FwmiVEX7JfzhCkgBO/xlCG79kRKSrzuVzt4icO/G3cCKn0pag==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@2.0.2':
     resolution: {integrity: sha512-/PtTkM/DsDLjeuXTmeJeRfbjCDbcL9jvoVgZrgxYFZ28y2cdLvbChbW9uigOzs5dQEs1CIBQXMTTj7KhdBTuQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@2.0.2':
     resolution: {integrity: sha512-bBjsZxMHRaPo6X9SokApm6ucs+UhXtAJFyJJyuk2BH4XJsLeCU9Dz1vMwioeohFbJUUeTASVPm6/BL+RhSaunw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@2.0.2':
     resolution: {integrity: sha512-HjlpInqzabDNkhVsUJpsHPqa9QYVWBViJoyWNjzXCAW0vKMDvwaphyUvokSinX8FGTlZi/sr5UEaHJo6XtQ35g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@2.0.2':
     resolution: {integrity: sha512-YaRYNFLJRpkGfYjSWR7n9f+nQKtrlmrrffpAn/blc2geHcRvXoBc5SCs1idPtsLhj7H9qWWhs7ucjyHy4csWFg==}
@@ -3485,6 +3552,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -4349,7 +4421,7 @@ snapshots:
 
   '@parcel/watcher-win32-x64@2.5.6': {}
 
-  '@parcel/watcher@2.5.1(patch_hash=p6xahr7zs4c5qsorj3exeppxhm)':
+  '@parcel/watcher@2.5.1(patch_hash=c22241764997c5af4980d3be22550ae47858f14849dca486726653fa127eb69c)':
     dependencies:
       detect-libc: 1.0.3
       is-glob: 4.0.3
@@ -4657,10 +4729,10 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -4671,13 +4743,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0))':
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -5208,7 +5280,7 @@ snapshots:
 
   lightningcss-win32-x64-msvc@1.32.0: {}
 
-  lightningcss@1.32.0(patch_hash=mz3chiqe2jbihxa25xumd4ogum):
+  lightningcss@1.32.0(patch_hash=1d4a8800d60d13d42887b88b3a86576df4b451670308145fb432ec8abbf40930):
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
@@ -5398,19 +5470,21 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.15
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.15
+      yaml: 2.9.0
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.15
+      yaml: 2.9.0
 
   postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
@@ -5652,7 +5726,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(yaml@2.9.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -5671,7 +5745,7 @@ snapshots:
       postcss: 8.5.15
       postcss-import: 15.1.0(postcss@8.5.15)
       postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(yaml@2.9.0)
       postcss-nested: 6.2.0(postcss@8.5.15)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -5755,7 +5829,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -5766,7 +5840,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.4
       source-map: 0.7.6
@@ -5830,9 +5904,9 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0):
+  vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
-      lightningcss: 1.32.0(patch_hash=mz3chiqe2jbihxa25xumd4ogum)
+      lightningcss: 1.32.0(patch_hash=1d4a8800d60d13d42887b88b3a86576df4b451670308145fb432ec8abbf40930)
       picomatch: 4.0.4
       postcss: 8.5.15
       rolldown: 1.0.2
@@ -5843,10 +5917,11 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.48.0
+      yaml: 2.9.0
 
-  vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0):
+  vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
-      lightningcss: 1.32.0(patch_hash=mz3chiqe2jbihxa25xumd4ogum)
+      lightningcss: 1.32.0(patch_hash=1d4a8800d60d13d42887b88b3a86576df4b451670308145fb432ec8abbf40930)
       picomatch: 4.0.4
       postcss: 8.5.15
       rolldown: 1.0.2
@@ -5857,11 +5932,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.48.0
+      yaml: 2.9.0
 
-  vitest@4.1.7(@types/node@22.19.19)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)):
+  vitest@4.1.7(@types/node@22.19.19)(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -5878,7 +5954,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)
+      vite: 8.0.14(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19
@@ -5935,3 +6011,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  yaml@2.9.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,10 @@ packages:
   - 'playgrounds/*'
   - 'integrations'
 
+patchedDependencies:
+  '@parcel/watcher@2.5.1': patches/@parcel__watcher@2.5.1.patch
+  lightningcss@1.32.0: patches/lightningcss@1.32.0.patch
+
 catalog:
   '@types/node': 22.19.19
   dedent: 1.7.2
@@ -21,3 +25,21 @@ catalog:
   prettier: 3.8.3
   vite: 8.0.14
   webpack: 5.107.0
+
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - bun
+  - esbuild
+  - sharp
+  - tree-sitter
+  - tree-sitter-javascript
+  - tree-sitter-typescript
+
+allowBuilds:
+  '@parcel/watcher': true
+  bun: true
+  esbuild: true
+  sharp: true
+  tree-sitter: true
+  tree-sitter-javascript: true
+  tree-sitter-typescript: true

--- a/scripts/pack-packages.mjs
+++ b/scripts/pack-packages.mjs
@@ -21,18 +21,25 @@ let workspaces = new Map()
 for (let path of paths) {
   let pkg = await fs.readFile(path, 'utf8').then(JSON.parse)
   if (pkg.private) continue
-  workspaces.set(pkg.name, { version: pkg.version ?? '', dir: dirname(path) })
+  workspaces.set(pkg.name, {
+    version: pkg.version ?? '',
+    dir: dirname(path),
+    hasBundledDependencies: pkg.bundledDependencies?.length > 0 ?? false,
+  })
 }
 
 // Clean dist folder
 await fs.rm(path.join(root, 'dist'), { recursive: true, force: true })
 
 Promise.all(
-  [...workspaces.entries()].map(async ([name, { dir }]) => {
+  [...workspaces.entries()].map(async ([name, { dir, hasBundledDependencies }]) => {
     function pack() {
       return new Promise((resolve) => {
+        // `bundledDependencies` can only be packed with the hoisted node linker
+        // since pnpm v10. We opt into it for those packages only, instead of
+        // changing the node linker for the entire workspace.
         exec(
-          `pnpm pack --pack-gzip-level=0 --pack-destination="${path.join(root, 'dist').replace(/\\/g, '\\\\')}"`,
+          `pnpm pack --pack-gzip-level=0 --pack-destination="${path.join(root, 'dist').replace(/\\/g, '\\\\')}"${hasBundledDependencies ? ' --config.node-linker=hoisted' : ''}`,
           { cwd: dir },
           (err, stdout, stderr) => {
             if (err) {


### PR DESCRIPTION
This PR bumps the repo to pnpm v11 (from v9). 

I kept running into weird Windows specific issues for the integration tests due to some shims but they all pass right now.

Bumping to pnpm v11 also meant that everything is driven by a `pnpm-workspace.yaml` file, and changes applied via the `pnpm` field in the `package.json` don't work anymore.

This also moved the `node-linker` setup that was defined in the `.npmrc` file for the wasm oxide build into the `pnpm-workspace.yaml` file. Ideally this is scoped to just this package, but I couldn't get that to work, so it's applied to all packages right now.

[ci-all]
