### PR TITLE
Ignore unknown at-rule warnings for `@position-try`

### DIFF
--- a/packages/@tailwindcss-node/src/optimize.ts
+++ b/packages/@tailwindcss-node/src/optimize.ts
@@ -68,6 +68,13 @@ export function optimize(
       return false
     }
 
+    // Ignore warnings about unknown at-rules.
+    //
+    // TODO: drop `@position-try` once https://github.com/parcel-bundler/lightningcss/pull/1238 lands
+    if (/Unknown at rule: @position-try/.test(warning.message)) {
+      return false
+    }
+
     return true
   })
 


### PR DESCRIPTION
This PR ignores Lightning CSS warnings for the unknow at-rule `@position-try`.

This is a temporary fix/workaround until support for `@position-try` lands in Lightning CSS: https://github.com/parcel-bundler/lightningcss/pull/1238

Fixes: #20275

## Test plan

Ran a test based on the issue:

Before:
```shellsession
❯ tw -i x.css -o out.css --optimize
≈ tailwindcss v4.3.1

Found 1 warning while optimizing generated CSS:

│   position-try-fallbacks: --flip-above;
│ }
│ @position-try --flip-above {
┆              ^-- Unknown at rule: @position-try
┆
│   top: auto;
│   bottom: 0;

Done in 29ms
```

After:
```shellsession
❯ tw -i x.css -o out.css --optimize
≈ tailwindcss v4.3.1

Done in 14ms
```
