### PR TITLE
Improve release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,3 +321,38 @@ jobs:
               ref: 'main',
               workflow_id: 'upgrade-tailwindcss.yml'
             })
+
+  notify:
+    if: ${{ always() && (needs.build.result == 'failure' || needs.build-freebsd.result == 'failure' || needs.release.result == 'failure') }}
+    needs:
+      - build
+      - build-freebsd
+      - release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve release label
+        id: release
+        env:
+          INPUT_CHANNEL: ${{ github.event.inputs.channel || '' }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            tag_name="${RELEASE_TAG:-${GITHUB_REF_NAME}}"
+            echo "label=release ${tag_name}" >> $GITHUB_OUTPUT
+          elif [[ "$INPUT_CHANNEL" == "release" ]]; then
+            version=$(node -p "require('./packages/tailwindcss/package.json').version")
+            echo "label=release v${version}" >> $GITHUB_OUTPUT
+          else
+            sha_short=$(git rev-parse --short HEAD)
+            echo "label=insiders release 0.0.0-insiders.${sha_short}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify Discord
+        uses: discord-actions/message@5c7149c81a83146e5d01f142be1bf87a61831c4d # v2
+        with:
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          message: 'The [most recent ${{ github.workflow }} workflow](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>) for `${{ steps.release.outputs.label }}` has failed.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,7 +308,7 @@ jobs:
         run: |
           pnpm --recursive --filter="!@tailwindcss/oxide-wasm32-wasi" publish --tag ${RELEASE_CHANNEL} --no-git-checks
           # The wasm package needs a special npm config that isn't read when pnpm --recursive is used
-          pushd crates/node/npm/wasm32-wasi; pnpm publish --tag ${RELEASE_CHANNEL} --no-git-checks; popd;
+          pushd crates/node/npm/wasm32-wasi; pnpm publish --tag ${RELEASE_CHANNEL} --no-git-checks --config.node-linker=hoisted; popd;
 
       - name: Trigger Tailwind Play update
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
This PR improves the release script:

- The `node-linker=hoisted` was missing for the `wasm32-wasi` package (this is because of the pnpm v11 changes where it migrated the noide-linker setup from `.npmrc` to a flag during `pack`)
- Notify discord in case the release fails

## Test plan

1. All tests should pass because we didn't change anything related to code
2. Unfortunately, the only way to properly testing this is to merge it

