### PR TITLE
Use version range for PostCSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extract class candidates from conditional Maud syntax like `p.text-black[condition]` ([#20269](https://github.com/tailwindlabs/tailwindcss/pull/20269))
 - Prevent `@position-try` rules from triggering unknown at-rule warnings when optimizing CSS ([#20277](https://github.com/tailwindlabs/tailwindcss/pull/20277))
 - Support class suggestions for named opacity modifiers from `--opacity` theme values ([#20287](https://github.com/tailwindlabs/tailwindcss/pull/20287))
+- Prevent type errors in `@tailwindcss/postcss` when used with newer PostCSS patch releases ([#20289](https://github.com/tailwindlabs/tailwindcss/pull/20289))
 
 ## [4.3.1] - 2026-06-12
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ catalogs:
       specifier: 1.32.0
       version: 1.32.0
     postcss:
-      specifier: 8.5.15
+      specifier: ^8.5.15
       version: 8.5.15
     prettier:
       specifier: 3.8.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   lightningcss-linux-x64-musl: 1.32.0
   lightningcss-win32-x64-msvc: 1.32.0
   lightningcss: 1.32.0
-  postcss: 8.5.15
+  postcss: ^8.5.15
   prettier: 3.8.3
   vite: 8.0.14
   webpack: 5.107.0


### PR DESCRIPTION
This PR fixes an issue where new PostCSS release could lead to type related issues if newer versions change the types. 

Right now `@tailwindcss/postcss` uses a hardcoded PostCSS version. Let's loosen this up and use a semver range instead.

Fixes: #20288

## Test plan

1. All tests still pass
