### PR TITLE
chore: bump enhanced-resolve from 5.21.6 to 5.22.1

### DIFF
--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -170,7 +170,7 @@ table {
   Use the modern Firefox focus style for all focusable elements.
 */
 
-:-moz-focusring {
+:-moz-focusring:where(:not(iframe)) {
   outline: auto;
 }
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
 catalog:
   '@types/node': 22.19.19
   dedent: 1.7.2
-  enhanced-resolve: 5.21.6
+  enhanced-resolve: 5.22.1
   lightningcss-darwin-arm64: 1.32.0
   lightningcss-darwin-x64: 1.32.0
   lightningcss-linux-arm64-gnu: 1.32.0


### PR DESCRIPTION
## Description

Bumps `enhanced-resolve` from `5.21.6` to `5.22.1` in the workspace catalog to address security advisory AIKIDO-2026-11084.

The affected versions below 5.22.1 have a security vulnerability. Bumping to 5.22.1 resolves it.

The pnpm-lock.yaml will need to be regenerated after merging (via `pnpm install`).

Closes #20291
