### PR TITLE
Fix not-* producing no output when applied twice to a mixed style-rule/at-rule variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalization: match arbitrary hex colors against theme colors case-insensitively (e.g. `bg-[#fff]` and `bg-[#FFF]` → `bg-white`) ([#20298](https://github.com/tailwindlabs/tailwindcss/pull/20298))
 - Prevent Preflight from overriding Firefox's native `iframe:focus-visible` outline styles ([#20292](https://github.com/tailwindlabs/tailwindcss/pull/20292))
 - Prevent `theme('colors.foo')` in JS plugins from returning an internal disambiguation object when a CSS theme key shares a prefix with a sibling key like `--color-foo-bar` ([#20299](https://github.com/tailwindlabs/tailwindcss/pull/20299))
+- Fix `not-*` producing no output when applied twice to a variant that mixes a style rule with an at-rule (e.g. `not-not-hover:flex`)
 
 ## [4.3.2] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalization: match arbitrary hex colors against theme colors case-insensitively (e.g. `bg-[#fff]` and `bg-[#FFF]` → `bg-white`) ([#20298](https://github.com/tailwindlabs/tailwindcss/pull/20298))
 - Prevent Preflight from overriding Firefox's native `iframe:focus-visible` outline styles ([#20292](https://github.com/tailwindlabs/tailwindcss/pull/20292))
 - Prevent `theme('colors.foo')` in JS plugins from returning an internal disambiguation object when a CSS theme key shares a prefix with a sibling key like `--color-foo-bar` ([#20299](https://github.com/tailwindlabs/tailwindcss/pull/20299))
-- Fix `not-*` producing no output when applied twice to a variant that mixes a style rule with an at-rule (e.g. `not-not-hover:flex`)
+- Fix `not-*` producing no output when applied twice to a variant that mixes a style rule with an at-rule (e.g. `not-not-hover:flex`) ([#20301](https://github.com/tailwindlabs/tailwindcss/pull/20301))
 
 ## [4.3.2] - 2026-06-26
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1924,6 +1924,41 @@ test('not', async () => {
   ).toEqual('')
 })
 
+test('not-not-* restores the original condition for variants that mix a style rule with an at-rule', async () => {
+  // `hover` compiles to a style rule wrapping an at-rule (`&:hover { @media
+  // (hover: hover) { … } }`), which is an AND of two conditions. Negating it
+  // once produces an OR of the two negated halves as sibling rules (De
+  // Morgan's law). Negating that result again must AND the halves back
+  // together instead of negating each independently, otherwise `not-not-*`
+  // silently produces nothing (the sibling `&` wrapper looks like an
+  // unsupported nested style rule) or, if naively "fixed", a condition
+  // broader than the original (an OR instead of an AND).
+  expect(
+    await run(
+      ['not-not-hover:flex', 'not-not-device-hocus:flex'],
+      css`
+        @custom-variant device-hocus {
+          @media (hover: hover) {
+            &:hover,
+            &:focus {
+              @slot;
+            }
+          }
+        }
+        @tailwind utilities;
+      `,
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    @media (hover: hover) {
+      .not-not-hover\\:flex:not(:not(:hover)), .not-not-device-hocus\\:flex:not(:not(:hover, :focus)) {
+        display: flex;
+      }
+    }
+    "
+  `)
+})
+
 test('in', async () => {
   expect(
     await run([

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -496,9 +496,75 @@ export function createVariants(theme: Theme): Variants {
     if (variant.modifier) return null
 
     let didApply = false
+    let failed = false
+
+    // Collect the negated rules from every leaf (or leaf-group, see below)
+    // across the whole tree before mutating `ruleNode`, then assign once at
+    // the end. Assigning to `ruleNode` after each individual leaf would
+    // discard the leaves visited before it.
+    let rules: Rule[] = []
 
     walk([ruleNode], (node, ctx) => {
       if (node.kind !== 'rule' && node.kind !== 'at-rule') return WalkAction.Continue
+
+      // A previous `not-*` application negates a single style-rule+at-rule
+      // chain (an AND, e.g. `hover` = "&:hover" AND "@media (hover: hover)")
+      // into a synthetic `&` wrapper holding both negated halves as siblings
+      // (an OR, per De Morgan's law). Negating that OR again must AND the
+      // two halves back together into a single nested rule — treating them
+      // as independent leaves would produce an OR of negations instead,
+      // which is a different (broader) condition than the intended result.
+      if (
+        node.kind === 'rule' &&
+        node.selector === '&' &&
+        node.nodes.length > 1 &&
+        node.nodes.every(
+          (child) =>
+            (child.kind === 'rule' || child.kind === 'at-rule') && child.nodes.length === 0,
+        )
+      ) {
+        let atRules: AtRule[] = []
+        let styleRules: StyleRule[] = []
+
+        for (let child of node.nodes as (StyleRule | AtRule)[]) {
+          if (child.kind === 'at-rule') atRules.push(child)
+          else styleRules.push(child)
+        }
+
+        if (atRules.length > 1 || styleRules.length > 1) {
+          failed = true
+          return WalkAction.Stop
+        }
+
+        let negatedSelector: string | null = null
+        for (let styleRuleNode of styleRules) {
+          negatedSelector = negateSelector(styleRuleNode.selector)
+          if (!negatedSelector) {
+            failed = true
+            return WalkAction.Stop
+          }
+        }
+
+        let negatedAtRule: AtRule | null = null
+        for (let atRuleNode of atRules) {
+          negatedAtRule = negateAtRule(atRuleNode)
+          if (!negatedAtRule) {
+            failed = true
+            return WalkAction.Stop
+          }
+        }
+
+        rules.push(
+          negatedSelector
+            ? styleRule(negatedSelector, negatedAtRule ? [negatedAtRule] : [])
+            : (negatedAtRule as AtRule),
+        )
+
+        didApply = true
+
+        return WalkAction.Skip
+      }
+
       if (node.nodes.length > 0) return WalkAction.Continue
 
       // Throw out any candidates with variants using nested style rules
@@ -511,20 +577,24 @@ export function createVariants(theme: Theme): Variants {
       for (let node of path) {
         if (node.kind === 'at-rule') {
           atRules.push(node)
-        } else if (node.kind === 'rule') {
+        } else if (node.kind === 'rule' && node.selector !== '&') {
+          // A bare `&` selector carries no meaning of its own — it's the
+          // synthetic wrapper `not` itself introduces to hold sibling
+          // branches, not a real nested style rule, so it shouldn't count
+          // towards the "no nested style rules" check below.
           styleRules.push(node)
         }
       }
 
-      if (atRules.length > 1) return WalkAction.Stop
-      if (styleRules.length > 1) return WalkAction.Stop
-
-      let rules: Rule[] = []
+      if (atRules.length > 1 || styleRules.length > 1) {
+        failed = true
+        return WalkAction.Stop
+      }
 
       for (let node of styleRules) {
         let selector = negateSelector(node.selector)
         if (!selector) {
-          didApply = false
+          failed = true
           return WalkAction.Stop
         }
 
@@ -534,14 +604,12 @@ export function createVariants(theme: Theme): Variants {
       for (let node of atRules) {
         let negatedAtRule = negateAtRule(node)
         if (!negatedAtRule) {
-          didApply = false
+          failed = true
           return WalkAction.Stop
         }
 
         rules.push(negatedAtRule)
       }
-
-      Object.assign(ruleNode, styleRule('&', rules))
 
       // Track that the variant was actually applied
       didApply = true
@@ -549,14 +617,14 @@ export function createVariants(theme: Theme): Variants {
       return WalkAction.Skip
     })
 
+    if (failed || !didApply) return null
+
+    Object.assign(ruleNode, styleRule('&', rules))
+
     // TODO: Tweak group, peer, has to ignore intermediate `&` selectors (maybe?)
     if (ruleNode.kind === 'rule' && ruleNode.selector === '&' && ruleNode.nodes.length === 1) {
       Object.assign(ruleNode, ruleNode.nodes[0])
     }
-
-    // If the node wasn't modified, this variant is not compatible with
-    // `not-*` so discard the candidate.
-    if (!didApply) return null
   })
 
   variants.suggest('not', () => {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -514,6 +514,13 @@ export function createVariants(theme: Theme): Variants {
       // two halves back together into a single nested rule — treating them
       // as independent leaves would produce an OR of negations instead,
       // which is a different (broader) condition than the intended result.
+      //
+      // This branch can only ever see a wrapper `not` itself produced: a
+      // genuinely parallel/authored variant (e.g. two top-level `&:hover {}`
+      // / `&:focus {}` blocks from a custom variant) is already rejected in
+      // `applyVariant` (compile.ts) before `not`'s `applyFn` is invoked at
+      // all, since applying it in isolation yields more than one top-level
+      // node there.
       if (
         node.kind === 'rule' &&
         node.selector === '&' &&


### PR DESCRIPTION
## Summary

`not-*` produces no CSS at all when applied twice to a variant whose implementation mixes a style rule with an at-rule — e.g. `hover`, which compiles to `&:hover { @media (hover: hover) { … } }` (an AND of a selector condition and a media condition). `not-not-hover:flex` and `not-not-device-hocus:flex` (a custom variant with the same shape) both compile to an empty string, silently, with no warning.

### Root cause

`not` applied once to `hover` negates the AND into an OR via De Morgan's law, producing a synthetic `&` wrapper rule containing two sibling leaves — a negated selector rule and a negated at-rule. This is the correct, working representation of "not hover" (`&:not(*:hover)` **or** `@media not (hover: hover)`).

Applying `not` a *second* time walks into that synthetic wrapper. Its leaf-collection logic (`variants.ts`, in the `not` compound variant) counts every `rule`-kind ancestor towards a "no nested style rules allowed" guard — including the synthetic `&` wrapper itself, which isn't a real nested selector, just an implementation detail. That pushes the count to 2 and the whole candidate is discarded (`styleRules.length > 1` → bail with `didApply` never set).

My first attempt just excluded bare `&` rules from that count. That "fixed" the empty output, but produced a *worse* bug: negating each sibling independently gives `NOT(NOT A) OR NOT(NOT B)` = `A OR B`, which is a **broader** condition than the original `A AND B` (e.g. it would apply on any device with `hover: hover` support regardless of whether the element is actually hovered). This PR instead detects that specific synthetic-wrapper shape (a bare `&` rule whose direct children are all already-resolved leaves) and negates it as a single AND'd unit — reconstructing a rule isomorphic to the original `hover` structure, so `not-not-hover:flex` is equivalent to `hover:flex` again, and a third `not` correctly cascades back to the OR form of a single negation.

Genuinely user-authored parallel/OR variants (e.g. a custom variant with two independent top-level blocks) are unaffected — they're rejected earlier in the pipeline and this change doesn't touch that path (verified via the existing `not-parallel-style-rules` / `not-parallel-at-rules` / `not-parallel-mixed-rules` tests, which still pass).

## Test plan

- Added a regression test in `packages/tailwindcss/src/variants.test.ts` ("`not-not-*` restores the original condition for variants that mix a style rule with an at-rule") covering both the built-in `hover` variant and a custom variant with the same shape.
- Verified via `pnpm --filter tailwindcss exec vitest run` that this test fails with empty output on the unfixed code (confirmed by reverting the fix and re-running), and passes with the fix applied, producing output structurally identical to un-negated `hover:flex`/`device-hocus:flex` (just with a double-negated condition).
- Also manually verified (via scratch tests, not committed) that triple negation (`not-not-not-hover:flex`) correctly cascades back to the same OR-shaped output as a single `not-hover:flex`, and that the pre-existing `not-parallel-*` rejection tests still produce empty output as before.
- Ran the full `tailwindcss` package test suite (`pnpm --filter tailwindcss exec vitest run`) — 4685 tests passing, no regressions.
- Verified formatting on the changed files with `npx prettier --check`.