### PR TITLE
Fix: Escape regex special characters in dynamic RegExp construction

### DIFF
--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -766,7 +766,8 @@ function spacingCalcToSpacingFunction(input: string, designSystem: DesignSystem)
 
     return WalkAction.Replace(
       ValueParser.parse(
-        `--spacing(${ValueParser.toCss([node.nodes[4]]) // Value node
+        `--spacing(${
+          ValueParser.toCss([node.nodes[4]]) // Value node
         })`,
       ),
     )
@@ -2135,9 +2136,9 @@ function modernizeArbitraryValuesVariant(
               attributeSelector.value === null
                 ? { kind: 'named', value: name }
                 : {
-                  kind: 'arbitrary',
-                  value: `${name}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
-                },
+                    kind: 'arbitrary',
+                    value: `${name}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
+                  },
           } satisfies Variant)
         }
 
@@ -2152,13 +2153,13 @@ function modernizeArbitraryValuesVariant(
               attributeSelector.value === null
                 ? { kind: 'arbitrary', value: name } // aria-[foo]
                 : attributeSelector.operator === '=' &&
-                  attributeSelector.value === 'true' &&
-                  attributeSelector.sensitivity === null
+                    attributeSelector.value === 'true' &&
+                    attributeSelector.sensitivity === null
                   ? { kind: 'named', value: name } // aria-[foo="true"] or aria-[foo='true'] or aria-[foo=true]
                   : {
-                    kind: 'arbitrary',
-                    value: `${attributeSelector.attribute}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
-                  }, // aria-[foo~="true"], aria-[foo|="true"], …
+                      kind: 'arbitrary',
+                      value: `${attributeSelector.attribute}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
+                    }, // aria-[foo~="true"], aria-[foo|="true"], …
           } satisfies Variant)
         }
 

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -766,8 +766,7 @@ function spacingCalcToSpacingFunction(input: string, designSystem: DesignSystem)
 
     return WalkAction.Replace(
       ValueParser.parse(
-        `--spacing(${
-          ValueParser.toCss([node.nodes[4]]) // Value node
+        `--spacing(${ValueParser.toCss([node.nodes[4]]) // Value node
         })`,
       ),
     )
@@ -1373,7 +1372,8 @@ function allVariablesAreUsed(
   walk(ValueParser.parse(value), (node) => {
     if (node.kind === 'function' && node.value === 'var') {
       let variable = node.nodes[0].value
-      let r = new RegExp(`var\\(${variable}[,)]\\s*`, 'g')
+      const escapedVariable = variable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      let r = new RegExp(`var\\(${escapedVariable}[,)]\\s*`, 'g')
       if (
         // We need to check if the variable is used in the replacement
         !r.test(replacementAsCss) ||
@@ -2135,9 +2135,9 @@ function modernizeArbitraryValuesVariant(
               attributeSelector.value === null
                 ? { kind: 'named', value: name }
                 : {
-                    kind: 'arbitrary',
-                    value: `${name}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
-                  },
+                  kind: 'arbitrary',
+                  value: `${name}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
+                },
           } satisfies Variant)
         }
 
@@ -2152,13 +2152,13 @@ function modernizeArbitraryValuesVariant(
               attributeSelector.value === null
                 ? { kind: 'arbitrary', value: name } // aria-[foo]
                 : attributeSelector.operator === '=' &&
-                    attributeSelector.value === 'true' &&
-                    attributeSelector.sensitivity === null
+                  attributeSelector.value === 'true' &&
+                  attributeSelector.sensitivity === null
                   ? { kind: 'named', value: name } // aria-[foo="true"] or aria-[foo='true'] or aria-[foo=true]
                   : {
-                      kind: 'arbitrary',
-                      value: `${attributeSelector.attribute}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
-                    }, // aria-[foo~="true"], aria-[foo|="true"], …
+                    kind: 'arbitrary',
+                    value: `${attributeSelector.attribute}${attributeSelector.operator}${attributeSelector.quote ?? ''}${attributeSelector.value}${attributeSelector.quote ?? ''}${attributeSelector.sensitivity ? ` ${attributeSelector.sensitivity}` : ''}`,
+                  }, // aria-[foo~="true"], aria-[foo|="true"], …
           } satisfies Variant)
         }
 


### PR DESCRIPTION
This PR fixes an issue where CSS variables containing regex special characters were not being escaped properly when constructing dynamic RegExps.