### PR TITLE
Fix: Escape regex special characters in dynamic RegExp construction

### DIFF
--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -1373,7 +1373,8 @@ function allVariablesAreUsed(
   walk(ValueParser.parse(value), (node) => {
     if (node.kind === 'function' && node.value === 'var') {
       let variable = node.nodes[0].value
-      let r = new RegExp(`var\\(${variable}[,)]\\s*`, 'g')
+      const escapedVariable = variable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      let r = new RegExp(`var\\(${escapedVariable}[,)]\\s*`, 'g')
       if (
         // We need to check if the variable is used in the replacement
         !r.test(replacementAsCss) ||


### PR DESCRIPTION
Hi Tailwind team 👋 
While auditing this repo with VibeMass (an AI code auditing tool), i spotted a minor but genuine issue at line 1376 in `packages/tailwindcss/src/canonicalize-candidates.ts`. 

### The Issue
`variable` extracted from arbitrary CSS values like `text-[color:var(--my-color)]` is passed directly into a RegExp constructor without escaping:

```typescript
// Current
let r = new RegExp(`var\\(${variable}[,)]\\s*`, 'g')
