### PR TITLE
Fix: Escape regex special characters in dynamic RegExp construction

### DIFF
--- a/packages/tailwindcss/src/canonicalize-candidates.test.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.test.ts
@@ -316,6 +316,11 @@ describe.each([['default'], ['with-variant'], ['important'], ['prefix']])('%s', 
       ['[color:var(--color-red-500)]', 'text-red-500'],
       ['[background-color:var(--color-red-500)]', 'bg-red-500'],
 
+      // Arbitrary property to functional utility when CSS variable contains regex special chars
+      ['[color:var(--my-[color])]', 'text-(--my-[color])'],
+
+
+
       // Arbitrary property to named utility (case insensitive)
       ['[color:#fff]', 'text-white'],
       ['[color:#FFF]', 'text-white'],

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -1373,7 +1373,8 @@ function allVariablesAreUsed(
   walk(ValueParser.parse(value), (node) => {
     if (node.kind === 'function' && node.value === 'var') {
       let variable = node.nodes[0].value
-      let r = new RegExp(`var\\(${variable}[,)]\\s*`, 'g')
+      const escapedVariable = variable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      let r = new RegExp(`var\\(${escapedVariable}[,)]\\s*`, 'g')
       if (
         // We need to check if the variable is used in the replacement
         !r.test(replacementAsCss) ||


### PR DESCRIPTION
Hello, thanks for the review on #20313.
I am creating a new pr after Code Reviewer's request. 
CSS variable names can legally contain regex special characters. 
For example --my-[color] is a valid CSS custom property name. When passed to new RegExp without escaping it becomes: var\(--my-[color][,)]\s*

Here [color] is interpreted as a character class by the regex engine rather than a literal string, causing isSafeMigration to incorrectly return false and aborting canonicalization for valid CSS. I've added a test case using [color:var(--my-[color])] which fails without the fix and passes with it, proving this is a realistic edge case worth guarding against.

Let me know if you'd like any adjustments.

Cheers