### PR TITLE
Preserve zero spacing as a length in custom properties

### DIFF
--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -128,6 +128,28 @@ describe('--spacing(…)', () => {
       `)
     })
 
+    test('--spacing(…) preserves a length when zero is assigned to a custom property', async () => {
+      expect(
+        await compileCss(css`
+          @theme {
+            --spacing: 0.25rem;
+          }
+
+          .foo {
+            --offset: --spacing(0);
+            width: calc(100% + var(--offset));
+          }
+        `),
+      ).toMatchInlineSnapshot(`
+        "
+        .foo {
+          --offset: 0px;
+          width: calc(100% + var(--offset));
+        }
+        "
+      `)
+    })
+
     test('--spacing(…) optimizes the output when the input is `0` (with an inlined theme value)', async () => {
       expect(
         await compileCss(css`

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -42,7 +42,7 @@ function alpha(
 
 function spacing(
   designSystem: DesignSystem,
-  _source: AstNode,
+  source: AstNode,
   value: string,
   ...rest: string[]
 ): string {
@@ -74,7 +74,9 @@ function spacing(
   // - That means that a value of `1` can be replaced by `multiplier`
   let valueDimension = dimensions.get(value)
   if (valueDimension) {
-    if (valueDimension[0] === 0) return '0'
+    if (valueDimension[0] === 0) {
+      return source.kind === 'declaration' && source.property.startsWith('--') ? '0px' : '0'
+    }
     if (valueDimension[0] === 1) return multiplier
   }
 


### PR DESCRIPTION
## Summary

Fixes #20315.

`--spacing(0)` was optimized to unitless `0` even when assigned to a custom property. That changes the value type from a length to a number when the variable is later used in `calc()`, so this keeps direct declarations compact while emitting `0px` for custom-property assignments.

## Test plan

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/tailwindcss/src/css-functions.test.ts --hideSkippedTests`
- `pnpm exec prettier --check packages/tailwindcss/src/css-functions.ts packages/tailwindcss/src/css-functions.test.ts`

I also ran the same Vitest command after adding the regression test but before the fix, and confirmed it failed with `--offset: 0` instead of `--offset: 0px`.
