### PR TITLE
Avoid full reload in `@tailwindcss/vite` when editing a scanned file that is not a loaded module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure CSS nesting is handled even when Lightning CSS isn't run, like in `@tailwindcss/browser` and Tailwind Play ([#20124](https://github.com/tailwindlabs/tailwindcss/pull/20124))
 - Prevent achromatic theme colors from shifting hue in `color-mix(…)` with polar color spaces like `oklch` ([#19830](https://github.com/tailwindlabs/tailwindcss/issues/19830))
 - Ensure `--spacing(0)` is optimized to `0px` instead of `0` so it remains a `<length>` when used in `calc(…)` ([#20319](https://github.com/tailwindlabs/tailwindcss/pull/20319))
+- Prevent `@tailwindcss/vite` from forcing a full page reload when editing a scanned JS/TS file that is not part of the loaded module graph, like a lazy route or an unvisited chunk ([#20323](https://github.com/tailwindlabs/tailwindcss/pull/20323))
 
 ## [4.3.2] - 2026-06-26
 

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -585,6 +585,128 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
   )
 
   test(
+    'scanned module files that are not loaded do not trigger a full reload',
+    {
+      fs: {
+        'package.json': json`{}`,
+        'pnpm-workspace.yaml': yaml`
+          #
+          packages:
+            - project-a
+        `,
+        'project-a/package.json': json`
+          {
+            "type": "module",
+            "dependencies": {
+              "@tailwindcss/vite": "workspace:^",
+              "tailwindcss": "workspace:^"
+            },
+            "devDependencies": {
+              ${transformer === 'lightningcss' ? `"lightningcss": "^1",` : ''}
+              "vite": "^8"
+            }
+          }
+        `,
+        'project-a/vite.config.ts': ts`
+          import tailwindcss from '@tailwindcss/vite'
+          import { defineConfig } from 'vite'
+
+          export default defineConfig({
+            css: ${transformer === 'postcss' ? '{}' : "{ transformer: 'lightningcss' }"},
+            build: { cssMinify: false },
+            plugins: [
+              tailwindcss(),
+              {
+                // Log every payload sent over the HMR channels so the test
+                // can observe (the absence of) full reloads
+                name: 'hot-send-logger',
+                configureServer(server) {
+                  for (let environment of Object.values(server.environments)) {
+                    let send = environment.hot.send.bind(environment.hot)
+                    environment.hot.send = (...args) => {
+                      console.log('HOT_SEND ' + JSON.stringify(args[0]))
+                      return send(...args)
+                    }
+                  }
+                },
+              },
+            ],
+          })
+        `,
+        'project-a/index.html': html`
+          <html>
+            <head>
+              <link rel="stylesheet" href="./src/index.css" />
+            </head>
+            <body>
+              <div id="app"></div>
+              <script type="module" src="./src/main.ts"></script>
+            </body>
+          </html>
+        `,
+        'project-a/src/main.ts': ts`import { classes } from './app'`,
+        'project-a/src/app.ts': ts`export let classes = "content-['src/app.ts']"`,
+
+        // This file is scanned by Tailwind but never imported, so it is not
+        // part of the loaded module graph (e.g. a lazy route or an unvisited
+        // chunk)
+        'project-a/src/unloaded.ts': ts`export let classes = "content-['src/unloaded.ts']"`,
+        'project-a/src/index.css': css`@import 'tailwindcss';`,
+      },
+    },
+    async ({ root, spawn, fs, expect }) => {
+      let process = await spawn('pnpm vite dev', {
+        cwd: path.join(root, 'project-a'),
+      })
+      await process.onStdout((m) => m.includes('ready in'))
+
+      let url = ''
+      await process.onStdout((m) => {
+        let match = /Local:\s*(http.*)\//.exec(m)
+        if (match) url = match[1]
+        return Boolean(url)
+      })
+
+      await retryAssertion(async () => {
+        let styles = await fetchStyles(url, '/index.html')
+        expect(styles).toContain(candidate`content-['src/unloaded.ts']`)
+      })
+
+      // Flush all messages so that we can be sure the next messages are from
+      // the file change we're about to make
+      process.flush()
+
+      // Changing a scanned but not loaded module file should regenerate the
+      // CSS through a regular CSS update instead of a full reload
+      {
+        await fs.write(
+          'project-a/src/unloaded.ts',
+          ts`export let classes = "content-['updated:src/unloaded.ts']"`,
+        )
+
+        let payload = ''
+        await process.onStdout((m) => {
+          if (!m.includes('HOT_SEND')) return false
+          if (m.includes('full-reload')) {
+            payload = 'full-reload'
+            return true
+          }
+          if (m.includes('"type":"update"')) {
+            payload = 'update'
+            return true
+          }
+          return false
+        })
+        expect(payload).toBe('update')
+
+        // Ensure the styles were regenerated with the new content
+        let styles = await fetchStyles(url, '/index.html')
+        expect(styles).toContain(candidate`content-['updated:src/unloaded.ts']`)
+      }
+    },
+  )
+
+  test(
     `source(none) disables looking at the module graph`,
     {
       fs: {

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -25,6 +25,7 @@ const DEBUG = env.DEBUG
 const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/
 const COMMON_JS_PROXY_RE = /\?commonjs-proxy/
 const INLINE_STYLE_ID_RE = /[?&]index=\d+\.css$/
+const JS_MODULE_RE = /\.[cm]?[jt]sx?$/
 
 export type PluginOptions = {
   /**
@@ -276,6 +277,14 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
             modules.length > 0 &&
             modules.every((mod) => mod.type === 'asset' || mod.id === undefined)
           if (!isExternalFile) return
+
+          // JS and TS source files are handled by Vite itself whenever they
+          // are loaded. If one only shows up as an external file here, it
+          // means it is scanned by Tailwind but not currently loaded as a
+          // module (e.g. a lazy route or an unvisited chunk). New candidates
+          // in the file are picked up through the regular CSS update, so a
+          // full reload is not needed and would only throw away client state.
+          if (JS_MODULE_RE.test(file)) return
 
           // Skip if the module exists in other environments. SSR framework has
           // its own server side hmr/reload mechanism when handling server


### PR DESCRIPTION
## Summary

Fixes #20320

In dev mode, `@tailwindcss/vite`'s `hotUpdate` hook has a fallback that sends a `full-reload` for files that Tailwind scans but that aren't handled by Vite or any plugin (e.g. `.php` or `.html` templates). Without it, edits to those files wouldn't refresh the page at all.

However, the check ("every module for this file is an `asset` and/or has no id") also matches JS/TS source files that Tailwind has scanned but that Vite hasn't loaded as a module yet — lazy routes, unvisited chunks, and so on. The scanner's `addWatchFile` call creates an asset-type module-graph node with `id === undefined` for every scanned file, and for a not-yet-loaded `.tsx` there is no real JS node next to it, so the fallback fires and the whole page reloads, throwing away all client state. In apps with route-level code splitting this happens on almost every edit to a not-currently-loaded component.

This change exempts JS/TS module files (`.js`, `.jsx`, `.ts`, `.tsx`, `.mjs`, `.cjs`, `.mts`, `.cts`) from the fallback. Vite handles these files itself whenever they are actually loaded, and for scanned-but-unloaded files any new candidates still flow through the regular CSS update, so nothing is lost by skipping the reload:

- Editing a scanned-but-unloaded `.ts` file now results in a targeted `{"type":"update"}` for the Tailwind stylesheet instead of `{"type":"full-reload"}`, and the generated CSS includes the new candidates.
- Editing a scanned external `.php` file still triggers a full reload as before.

## Test plan

- Added an integration test that boots a Vite 8 dev server with a `src/unloaded.ts` file that is scanned but never imported. A small fixture plugin wraps `environment.hot.send` to log every HMR payload. The test edits `unloaded.ts` and asserts that an `update` payload is sent (not a `full-reload`) and that the stylesheet regenerates with the new candidate.
- Verified both directions manually against a minimal reproduction (Vite 8.1.4): before the change, editing the unloaded file logs `HOT_SEND {"type":"full-reload"}`; after the change it logs `HOT_SEND {"type":"update", ...}` for `/src/index.css` and the CSS contains the new candidate. Editing a scanned `.php` file still logs `HOT_SEND {"type":"full-reload"}`.

```
pnpm exec vitest run --root=./integrations vite/index.test.ts -t "scanned module files that are not loaded do not trigger a full reload"
```
