### PR TITLE
Ensure `drop-shadow-*` utilities work with theme values containing multiple shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent `@tailwindcss/upgrade` from rewriting ignored files when run from a subdirectory ([#20328](https://github.com/tailwindlabs/tailwindcss/issues/20328))
 - Ensure earlier `@source` rules pointing to nested files are scanned when later `@source` rules point to files in parent folders ([#20335](https://github.com/tailwindlabs/tailwindcss/pull/20335))
 - Prevent `@tailwindcss/vite` from triggering full page reloads when scanned files are processed by Vite but haven't been loaded as modules yet ([#20336](https://github.com/tailwindlabs/tailwindcss/pull/20336))
+- Ensure `drop-shadow-*` utilities generate valid CSS when a theme value contains multiple shadows by treating it as inline ([#17677](https://github.com/tailwindlabs/tailwindcss/issues/17677))
 
 ## [4.3.2] - 2026-06-26
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -24056,6 +24056,7 @@ test('filter', async () => {
         'drop-shadow/12.5',
         'drop-shadow-xl',
         'drop-shadow-multi',
+        'drop-shadow-double',
         'drop-shadow-[0_0_red]',
         'drop-shadow-red-500',
         'drop-shadow-red-500/50',
@@ -24078,6 +24079,7 @@ test('filter', async () => {
           --drop-shadow: 0 1px 1px rgb(0 0 0 / 0.05);
           --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
           --drop-shadow-calc: 0 0 calc(1 * var(--spacing)) black;
+          --drop-shadow-double: 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1);
         }
         @theme inline {
           --drop-shadow-multi: 0 1px 1px rgb(0 0 0 / 0.05), 0 9px 7px rgb(0 0 0 / 0.1);
@@ -24183,7 +24185,7 @@ test('filter', async () => {
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
     }
 
-    .drop-shadow-multi {
+    .drop-shadow-double, .drop-shadow-multi {
       --tw-drop-shadow-size: drop-shadow(0 1px 1px var(--tw-drop-shadow-color, #0000000d)) drop-shadow(0 9px 7px var(--tw-drop-shadow-color, #0000001a));
       --tw-drop-shadow: drop-shadow(0 1px 1px #0000000d) drop-shadow(0 9px 7px #0000001a);
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -4629,6 +4629,12 @@ export function createUtilities(theme: Theme) {
         let resolved = theme.resolve(null, ['--drop-shadow'])
         if (value === null || resolved === null) return
 
+        // Multiple shadows can not be represented with a single `var(…)`
+        // reference because every shadow needs to be wrapped in its own
+        // `drop-shadow(…)` function, so behave as if the theme value was
+        // declared using `@theme inline`.
+        if (segment(value, ',').length > 1) resolved = value
+
         return [
           filterProperties(),
           decl('--tw-drop-shadow-alpha', alpha),
@@ -4687,6 +4693,12 @@ export function createUtilities(theme: Theme) {
         let resolved = theme.resolve(candidate.value.value, ['--drop-shadow'])
         if (value && resolved) {
           if (candidate.modifier && !alpha) return
+
+          // Multiple shadows can not be represented with a single `var(…)`
+          // reference because every shadow needs to be wrapped in its own
+          // `drop-shadow(…)` function, so behave as if the theme value was
+          // declared using `@theme inline`.
+          if (segment(value, ',').length > 1) resolved = value
 
           if (alpha) {
             return [


### PR DESCRIPTION
Fixes #17677

## Summary

Theme values for `drop-shadow-*` that contain multiple shadows currently produce broken CSS unless the user remembers to declare them with `@theme inline`. Given:

```css
@theme {
  --drop-shadow-multi: 0 0 20px rgb(0 0 0 / 0.2), 0 1px 2px rgb(0 0 0 / 0.25);
}
```

`drop-shadow-multi` generates:

```css
--tw-drop-shadow: drop-shadow(var(--drop-shadow-multi));
```

which is invalid because the comma-separated list ends up inside a single `drop-shadow(…)` function — each shadow needs its own `drop-shadow(…)` wrapper (the sibling `--tw-drop-shadow-size` declaration already does this correctly).

This PR implements the approach suggested in the issue discussion: when a `--drop-shadow-*` theme value contains multiple shadows, treat it as if it were declared with `@theme inline`, since a single `var(…)` reference can never represent it correctly. The output for the theme value above becomes:

```css
--tw-drop-shadow: drop-shadow(0 0 20px rgb(0 0 0 / 0.2)) drop-shadow(0 1px 2px rgb(0 0 0 / 0.25));
```

Single-shadow theme values are unaffected and keep referencing the variable, so overriding them via the cascade continues to work.

## Test plan

- Added a non-inline multi-shadow theme value (`--drop-shadow-double`) to the existing `filter` test in `utilities.test.ts`. It now compiles to the same (valid) output as the `@theme inline` variant — previously it produced the broken single-`drop-shadow(…)` output described above.
- `pnpm vitest run --project tailwindcss` — all 4871 tests pass.
- Verified the reproduction from #17677 produces valid CSS after the change.
