### PR TITLE
fix(cli): use case-insensitive path comparison on Windows in watch mode

### DIFF
--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -22,6 +22,7 @@ import {
   relative,
   wordWrap,
 } from '../../utils/renderer'
+import { pathsEqual } from '../../utils/paths-equal'
 import { drainStdin, outputFile } from './utils'
 
 const css = String.raw
@@ -338,7 +339,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
         try {
           // If the only change happened to the output file, then we don't want to
           // trigger a rebuild because that will result in an infinite loop.
-          if (files.length === 1 && files[0] === args['--output']) return
+          if (files.length === 1 && args['--output'] && pathsEqual(files[0], args['--output'])) return
 
           using I = new Instrumentation()
           DEBUG && I.start('[@tailwindcss/cli] (watcher)')
@@ -807,7 +808,7 @@ function getRebuildStrategy(
     // If one of the changed files is related to the input CSS or JS
     // config/plugin files, then we need to do a full rebuild because
     // the theme might have changed.
-    if (fullRebuildPaths.includes(file)) {
+    if (fullRebuildPaths.some((p) => pathsEqual(p, file))) {
       return { kind: 'full' }
     }
 

--- a/packages/@tailwindcss-cli/src/utils/paths-equal.test.ts
+++ b/packages/@tailwindcss-cli/src/utils/paths-equal.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('./paths-equal', async () => {
+  const actual = await vi.importActual<typeof import('./paths-equal')>('./paths-equal')
+  return actual
+})
+
+describe('pathsEqual', () => {
+  it('returns true for identical paths', async () => {
+    const { pathsEqual } = await import('./paths-equal')
+    expect(pathsEqual('/foo/bar/baz.css', '/foo/bar/baz.css')).toBe(true)
+  })
+
+  it('returns false for completely different paths', async () => {
+    const { pathsEqual } = await import('./paths-equal')
+    expect(pathsEqual('/foo/bar.css', '/foo/baz.css')).toBe(false)
+  })
+
+  if (process.platform === 'win32') {
+    it('returns true for paths differing only in case on Windows', async () => {
+      const { pathsEqual } = await import('./paths-equal')
+      expect(pathsEqual('C:\\src\\Input.css', 'C:\\src\\input.css')).toBe(true)
+    })
+  } else {
+    it('returns false for paths differing in case on non-Windows', async () => {
+      const { pathsEqual } = await import('./paths-equal')
+      expect(pathsEqual('/src/Input.css', '/src/input.css')).toBe(false)
+    })
+  }
+})

--- a/packages/@tailwindcss-cli/src/utils/paths-equal.ts
+++ b/packages/@tailwindcss-cli/src/utils/paths-equal.ts
@@ -1,0 +1,8 @@
+const IS_WINDOWS = process.platform === 'win32'
+
+export function pathsEqual(a: string, b: string): boolean {
+  if (IS_WINDOWS) {
+    return a.toLowerCase() === b.toLowerCase()
+  }
+  return a === b
+}


### PR DESCRIPTION
Cherry-pick of PR #19774 with rebased conflict resolution.

Fixes #16784

On Windows (case-insensitive filesystem), the CLI \--watch\ mode doesn't rebuild when the input file path casing differs from what exists on disk.

Adds a \pathsEqual()\ helper that uses case-insensitive comparison on Windows and applies it to output file identity check and full rebuild path matching.