### PR TITLE
Ensure `@source` files behind symlinks trigger rebuilds in `@tailwindcss/vite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure `@tailwindcss/vite` rebuilds when a `@source` file behind a symlink changes, such as a file in a linked package in a pnpm workspace ([#20347](https://github.com/tailwindlabs/tailwindcss/pull/20347))
 
 ## [4.3.3] - 2026-07-16
 

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1609,3 +1609,96 @@ test(
     })
   },
 )
+
+test(
+  '`@source` files behind a workspace symlink trigger rebuilds when the real file changes',
+  {
+    fs: {
+      'package.json': json`{}`,
+      'pnpm-workspace.yaml': yaml`
+        #
+        packages:
+          - project-a
+          - project-b
+      `,
+      'project-a/package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "project-b": "workspace:*",
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^7"
+          }
+        }
+      `,
+      'project-a/vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
+
+        export default defineConfig({
+          build: { cssMinify: false },
+          plugins: [tailwindcss()],
+        })
+      `,
+      'project-a/index.html': html`
+        <head>
+          <link rel="stylesheet" href="./src/index.css" />
+        </head>
+        <body>
+          <div>Hello, world!</div>
+        </body>
+      `,
+      'project-a/src/index.css': css`
+        @import 'tailwindcss' source(none);
+        @source '../node_modules/project-b/index.js';
+      `,
+      'project-b/package.json': json`
+        {
+          "name": "project-b",
+          "version": "1.0.0",
+          "exports": "./index.js"
+        }
+      `,
+      'project-b/index.js': js`
+        const className = "content-['project-b/index.js']"
+        export default { className }
+      `,
+    },
+  },
+  async ({ root, spawn, fs, expect }) => {
+    let process = await spawn('pnpm vite dev', {
+      cwd: path.join(root, 'project-a'),
+    })
+    await process.onStdout((m) => m.includes('ready in'))
+
+    let url = ''
+    await process.onStdout((m) => {
+      let match = /Local:\s*(http.*)\//.exec(m)
+      if (match) url = match[1]
+      return Boolean(url)
+    })
+
+    await retryAssertion(async () => {
+      let styles = await fetchStyles(url)
+      expect(styles).toContain(candidate`content-['project-b/index.js']`)
+    })
+
+    await retryAssertion(async () => {
+      // Write to the real file, not through the `node_modules` symlink that
+      // the `@source` directive goes through.
+      await fs.write(
+        'project-b/index.js',
+        js`
+          const className = "[.changed_&]:content-['project-b/index.js']"
+          export default { className }
+        `,
+      )
+
+      let styles = await fetchStyles(url)
+      expect(styles).toContain(candidate`[.changed_&]:content-['project-b/index.js']`)
+    })
+  },
+)

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1687,8 +1687,7 @@ test(
     })
 
     await retryAssertion(async () => {
-      // Write to the real file, not through the `node_modules` symlink that
-      // the `@source` directive goes through.
+      // Write to the real file, not through the symlink the `@source` goes through
       await fs.write(
         'project-b/index.js',
         js`

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -504,6 +504,12 @@ class Root {
   // assume the file has always changed.
   private buildDependencies = new Map<string, number | null>()
 
+  // Cache of resolved symlinks for scanned paths. Scanned paths preserve
+  // symlinks as written in `@source` directives (e.g. a path through a pnpm
+  // workspace symlink in `node_modules`), but Vite tracks modules and file
+  // change events by their real path.
+  private realpaths = new Map<string, string>()
+
   constructor(
     private id: string,
     private base: string,
@@ -515,6 +521,30 @@ class Root {
 
   get scannedFiles() {
     return this.scanner?.files ?? []
+  }
+
+  private realpath(file: string): string {
+    let real = this.realpaths.get(file)
+    if (real === undefined) {
+      try {
+        real = realpathSync(file)
+      } catch {
+        real = file
+      }
+      this.realpaths.set(file, real)
+    }
+    return real
+  }
+
+  // Whether a changed file is one of the scanned files, accounting for scanned
+  // paths that reach the file through a symlink.
+  isScannedFile(file: string, realpath: string | null): boolean {
+    for (let scanned of this.scannedFiles) {
+      if (scanned === file) return true
+      if (realpath !== null && scanned === realpath) return true
+      if (this.realpath(scanned) === file) return true
+    }
+    return false
   }
 
   // Generate the CSS for the root file. This can return false if the file is
@@ -626,24 +656,35 @@ class Root {
 
     if (this.compiler.features & Features.Utilities) {
       DEBUG && I.start('Register dependency messages')
-      // Watch individual files found via custom `@source` paths
+      // Watch individual files found via custom `@source` paths. Also watch
+      // the resolved path when it differs, otherwise changes to a file behind
+      // a symlink are never noticed (Vite's watcher ignores `node_modules`,
+      // and change events carry the real path).
       for (let file of this.scanner.files) {
         addWatchFile(file)
+
+        let real = this.realpath(file)
+        if (real !== file) {
+          addWatchFile(real)
+        }
       }
 
-      // Watch globs found via custom `@source` paths
+      // Watch globs found via custom `@source` paths, on the resolved base as
+      // well so files created behind a symlink are noticed too.
       for (let glob of this.scanner.globs) {
         if (glob.pattern[0] === '!') continue
 
-        let relative = path.relative(this.base, glob.base)
-        if (relative[0] !== '.') {
-          relative = './' + relative
-        }
-        // Ensure relative is a posix style path since we will merge it with the
-        // glob.
-        relative = normalizePath(relative)
+        for (let base of new Set([glob.base, this.realpath(glob.base)])) {
+          let relative = path.relative(this.base, base)
+          if (relative[0] !== '.') {
+            relative = './' + relative
+          }
+          // Ensure relative is a posix style path since we will merge it with
+          // the glob.
+          relative = normalizePath(relative)
 
-        addWatchFile(path.posix.join(relative, glob.pattern))
+          addWatchFile(path.posix.join(relative, glob.pattern))
+        }
 
         let root = this.compiler.root
 
@@ -736,10 +777,7 @@ function isScannedFile(
         // for sure that it's being watched by any of the Tailwind CSS roots. It
         // doesn't matter which root it is since it's only used to know whether
         // we should trigger a full reload or not.
-        if (
-          root.scannedFiles.includes(checks.file) ||
-          (checks.realpath && root.scannedFiles.includes(checks.realpath))
-        ) {
+        if (root.isScannedFile(checks.file, checks.realpath)) {
           return true
         }
       }

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -504,11 +504,15 @@ class Root {
   // assume the file has always changed.
   private buildDependencies = new Map<string, number | null>()
 
-  // Cache of resolved symlinks for scanned paths. Scanned paths preserve
-  // symlinks as written in `@source` directives (e.g. a path through a pnpm
-  // workspace symlink in `node_modules`), but Vite tracks modules and file
-  // change events by their real path.
-  private realpaths = new Map<string, string>()
+  // Resolved symlinks for scanned paths. Scanned paths preserve symlinks as
+  // written in `@source` directives, but Vite tracks files by their real path.
+  private realpaths = new DefaultMap<string, string>((file) => {
+    try {
+      return realpathSync(file)
+    } catch {
+      return file
+    }
+  })
 
   constructor(
     private id: string,
@@ -523,26 +527,13 @@ class Root {
     return this.scanner?.files ?? []
   }
 
-  private realpath(file: string): string {
-    let real = this.realpaths.get(file)
-    if (real === undefined) {
-      try {
-        real = realpathSync(file)
-      } catch {
-        real = file
-      }
-      this.realpaths.set(file, real)
-    }
-    return real
-  }
-
-  // Whether a changed file is one of the scanned files, accounting for scanned
-  // paths that reach the file through a symlink.
+  // Whether a changed file is one of the scanned files, accounting for
+  // symlinks on either side.
   isScannedFile(file: string, realpath: string | null): boolean {
+    let resolved = realpath ?? file
     for (let scanned of this.scannedFiles) {
-      if (scanned === file) return true
-      if (realpath !== null && scanned === realpath) return true
-      if (this.realpath(scanned) === file) return true
+      if (scanned === file || scanned === resolved) return true
+      if (this.realpaths.get(scanned) === resolved) return true
     }
     return false
   }
@@ -585,6 +576,9 @@ class Root {
     if (!this.compiler || !this.scanner || (await requiresBuildPromise)) {
       clearRequireCache(Array.from(this.buildDependencies.keys()))
       this.buildDependencies.clear()
+
+      // Symlinks may have been retargeted since the last full rebuild
+      this.realpaths.clear()
 
       this.addBuildDependency(idToPath(inputPath))
 
@@ -656,25 +650,21 @@ class Root {
 
     if (this.compiler.features & Features.Utilities) {
       DEBUG && I.start('Register dependency messages')
-      // Watch individual files found via custom `@source` paths. Also watch
-      // the resolved path when it differs, otherwise changes to a file behind
-      // a symlink are never noticed (Vite's watcher ignores `node_modules`,
-      // and change events carry the real path).
+      // Watch individual files found via custom `@source` paths, and their
+      // resolved paths when a symlink is involved
       for (let file of this.scanner.files) {
         addWatchFile(file)
 
-        let real = this.realpath(file)
-        if (real !== file) {
-          addWatchFile(real)
-        }
+        let real = this.realpaths.get(file)
+        if (real !== file) addWatchFile(real)
       }
 
-      // Watch globs found via custom `@source` paths, on the resolved base as
-      // well so files created behind a symlink are noticed too.
+      // Watch globs found via custom `@source` paths, also on the resolved
+      // base when it goes through a symlink
       for (let glob of this.scanner.globs) {
         if (glob.pattern[0] === '!') continue
 
-        for (let base of new Set([glob.base, this.realpath(glob.base)])) {
+        for (let base of new Set([glob.base, this.realpaths.get(glob.base)])) {
           let relative = path.relative(this.base, base)
           if (relative[0] !== '.') {
             relative = './' + relative


### PR DESCRIPTION
Fixes #20346

## Summary

Since #20203 the scanner preserves symlinks in `@source` paths, so `scanner.files` can contain a path like `app/node_modules/pkg/index.js` while Vite tracks the module and its file change events under the real `packages/pkg/index.js`. The plugin registered only the written path via `addWatchFile`, which Vite's watcher ignores inside `node_modules`, so editing the real file behind a workspace symlink never invalidated the CSS module and new candidates only appeared after restarting the dev server.

This registers the resolved path alongside the written one for scanned files and glob bases, cached per root. `isScannedFile` gets the missing direction too: it already resolved the changed file before comparing against scanned paths, now it also resolves scanned paths before comparing against the changed file, so full reloads for non-module `@source` files keep working when the path goes through a symlink.

## Test plan

Added an integration test with a pnpm workspace where `@source` points through the `node_modules` symlink of a linked workspace package. It fails without the change (the new candidate never appears until the dev server restarts) and passes with it. The full `integrations/vite` suite passes. Also verified the reproduction from #20346 directly: with this build, editing the file behind the symlink updates the page without a restart.