### PR TITLE
Fix failing upgrade test in CI

### DIFF
--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -2557,7 +2557,7 @@ test(
         @import './utilities.css';
         @import './generated/ignore-me.css';
       `,
-      'src/generated/.gitignore': `
+      'src/generated/.gitignore': txt`
         *
         !.gitignore
       `,


### PR DESCRIPTION
The last CI run on `main` was on July 16, and the last `globby` release (16.2.2) was released on July 15 (~21 hours earlier). Due to the default `minimumReleaseAge` in pnpm of 24 hours, it meant that we were receiving the previous globby version.

In the new version, they slightly changed some of the `.gitignore` parsing, but in one of our upgrade tests we wrote an invalid `.gitignore` file (which had indented lines). 

This PR fixes that by using the `txt` tagged template literal, which behind the scenes uses `dedent` which in turn makes sure that we ship a proper `.gitignore` file.


## Test plan

All tests should pass [ci-all]
