### PR TITLE
Update integration tests: PostCSS re-emits the UTF-8 BOM character

### DIFF
--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -2817,7 +2817,7 @@ test(
       ﻿<div class="ring-3"></div>
 
       --- ./src/input.css ---
-      @import 'tailwindcss';
+      ﻿@import 'tailwindcss';
 
       /*
         The default border color has changed to \`currentcolor\` in Tailwind CSS v4,


### PR DESCRIPTION
This PR updates the integration tests that started failing because of a recent PostCSS update.

PostCSS v8.5.24 started re-emitting the BOM character in the output, see: https://github.com/postcss/postcss/releases/tag/8.5.24 therefore the tests started failing.

This PR just re-adds that back.

It might not be clear from the diff on GitHub, but this is the change: 
<img width="878" height="84" alt="image" src="https://github.com/user-attachments/assets/5e2fbb6e-2ee4-46c5-9a2c-9c3a1a806bb0" />


## Test plan

1. All tests pass again [ci-all]

