### PR TITLE
Don't stop scanning Slim and Haml files at an unterminated percent literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `@tailwindcss/oxide` falls back to WASM on platforms without native bindings ([#20383](https://github.com/tailwindlabs/tailwindcss/pull/20383))
 - Detect classes in Ruby percent literals using angle brackets or custom delimiters (e.g. `%w<flex>`, `%w|flex|`), including in Slim and Haml templates ([#20387](https://github.com/tailwindlabs/tailwindcss/pull/20387))
 - Preserve whitespace in `--default(…)` values in custom functional utilities (e.g. `--default(box alphabetic)` no longer becomes `boxalphabetic`) ([#20392](https://github.com/tailwindlabs/tailwindcss/pull/20392))
+- Ensure classes after an unterminated Ruby percent literal are still detected in Slim and Haml templates ([#20393](https://github.com/tailwindlabs/tailwindcss/pull/20393))
 
 ## [4.3.3] - 2026-07-16
 

--- a/crates/oxide/src/extractor/pre_processors/haml.rs
+++ b/crates/oxide/src/extractor/pre_processors/haml.rs
@@ -232,6 +232,8 @@ impl PreProcessor for Haml {
                         }
                     };
 
+                    let start = cursor.pos;
+
                     result[cursor.pos] = b' '; // Replace `%`
                     cursor.advance();
                     result[cursor.pos] = b' '; // Replace `w`
@@ -275,6 +277,15 @@ impl PreProcessor for Haml {
                         }
 
                         cursor.advance();
+                    }
+
+                    // Without a closing delimiter this is not a percent literal, so undo the
+                    // replacements and rescan the input right after the `%`. Otherwise the cursor
+                    // sits at the end of the input and the rest of the file is never processed.
+                    if depth != 0 {
+                        let end = cursor.pos.min(len);
+                        result[start..end].copy_from_slice(&content[start..end]);
+                        cursor.move_to(start);
                     }
                 }
 
@@ -572,6 +583,26 @@ mod tests {
                 "grid",
             ],
         );
+    }
+
+    #[test]
+    fn test_embedded_ruby_percent_w_unterminated() {
+        for (input, expected) in [
+            (
+                "%div{class: %w|flex}\n.p-4.text-center",
+                "%div class: %w|flex \n p-4 text-center",
+            ),
+            (
+                "%div{class: %W!flex}\n.mt-2.underline",
+                "%div class: %W!flex \n mt-2 underline",
+            ),
+        ] {
+            Haml::test(input, expected);
+        }
+
+        let input = "%div{class: %w|flex}\n.p-4.text-center";
+
+        Haml::test_extract_contains(input, vec!["p-4", "text-center"]);
     }
 
     // https://github.com/tailwindlabs/tailwindcss/pull/17051#issuecomment-2711181352

--- a/crates/oxide/src/extractor/pre_processors/slim.rs
+++ b/crates/oxide/src/extractor/pre_processors/slim.rs
@@ -89,6 +89,8 @@ impl PreProcessor for Slim {
                         }
                     };
 
+                    let start = cursor.pos;
+
                     result[cursor.pos] = b' '; // Replace `%`
                     cursor.advance();
                     result[cursor.pos] = b' '; // Replace `w`
@@ -132,6 +134,15 @@ impl PreProcessor for Slim {
                         }
 
                         cursor.advance();
+                    }
+
+                    // Without a closing delimiter this is not a percent literal, so undo the
+                    // replacements and rescan the input right after the `%`. Otherwise the cursor
+                    // sits at the end of the input and the rest of the file is never processed.
+                    if depth != 0 {
+                        let end = cursor.pos.min(len);
+                        result[start..end].copy_from_slice(&content[start..end]);
+                        cursor.move_to(start);
                     }
                 }
 
@@ -445,5 +456,25 @@ mod tests {
                 "flex",
             ],
         );
+    }
+
+    #[test]
+    fn test_embedded_ruby_percent_w_unterminated() {
+        for (input, expected) in [
+            (
+                "- classes = %w|flex\n.p-4.text-center",
+                "- classes = %w|flex\n p-4 text-center",
+            ),
+            (
+                "- classes = %W!flex\n.mt-2.underline",
+                "- classes = %W!flex\n mt-2 underline",
+            ),
+        ] {
+            Slim::test(input, expected);
+        }
+
+        let input = "- classes = %w|flex\n.p-4.text-center";
+
+        Slim::test_extract_contains(input, vec!["p-4", "text-center"]);
     }
 }


### PR DESCRIPTION
## Summary

While looking at review feedback on #20387 I found that the Slim and Haml percent literal scanners never give up. When a custom delimiter is used and the matching closing delimiter is missing, the inner loop walks to the end of the file, so every class after that point is skipped. It happens both on a genuinely unterminated literal and on something that only looked like one, such as `%w|` in prose.

Both scanners now remember where the literal started. If the closing delimiter never shows up, the replaced bytes are restored and scanning resumes right after the `%`, which leaves the rest of the file to be processed as usual.

## Test plan

Added cases to `slim.rs` and `haml.rs` covering an unterminated `%w|…` and `%W!…`, checking that classes on the following lines still get their dots replaced and are extracted. Both fail on `main` and pass here.

`cargo test -p tailwindcss-oxide` is green (122 + 63), `cargo fmt --all -- --check` is clean, and clippy reports only warnings that were already there.