### PR TITLE
Don't scan ignored folders using `.gitignore` safelist setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `@tailwindcss/oxide` falls back to WASM on platforms without native bindings ([#20383](https://github.com/tailwindlabs/tailwindcss/pull/20383))
 - Detect classes in Ruby percent literals using angle brackets or custom delimiters (e.g. `%w<flex>`, `%w|flex|`), including in Slim and Haml templates ([#20387](https://github.com/tailwindlabs/tailwindcss/pull/20387))
 - Preserve whitespace in `--default(…)` values in custom functional utilities (e.g. `--default(box alphabetic)` no longer becomes `boxalphabetic`) ([#20392](https://github.com/tailwindlabs/tailwindcss/pull/20392))
+- Don't scan gitignored directories (e.g. `node_modules` and `.git`) when the project uses a safelist-style `.gitignore` (e.g. `/*` followed by `!/…` negations) ([#20397](https://github.com/tailwindlabs/tailwindcss/discussions/20397))
 
 ## [4.3.3] - 2026-07-16
 

--- a/crates/oxide/src/scanner/sources.rs
+++ b/crates/oxide/src/scanner/sources.rs
@@ -763,12 +763,11 @@ pub fn public_source_entries_to_private_source_entries(
         .collect::<Vec<_>>();
 
     // Compiled `.gitignore` matchers are cached per directory so we read and parse each
-    // `.gitignore` file at most once, even though entries commonly share ancestor directories
-    // (e.g. the repository root). A cached `None` means the directory has no `.gitignore` file.
+    // `.gitignore` file at most once, even though entries commonly share ancestor directories (e.g.
+    // the repository root). A cached `None` means the directory has no `.gitignore` file.
     let mut gitignores: FxHashMap<PathBuf, Option<Gitignore>> = FxHashMap::default();
 
-    // Boundary for the `.gitignore` walk when a source is not inside a git repository (see
-    // below).
+    // Boundary for the `.gitignore` walk when a source is not inside a git repository (see below).
     let cwd = std::env::current_dir()
         .map(|cwd| dunce::canonicalize(&cwd).unwrap_or(cwd))
         .ok();
@@ -790,8 +789,8 @@ pub fn public_source_entries_to_private_source_entries(
                     let gitignore = gitignores.entry(dir.to_path_buf()).or_insert_with(|| {
                         let path = dir.join(".gitignore");
 
-                        // `Gitignore::new` roots the matcher at the directory
-                        // containing the file, so patterns match relative to it.
+                        // `Gitignore::new` roots the matcher at the directory containing the file,
+                        // so patterns match relative to it.
                         path.is_file().then(|| Gitignore::new(&path).0)
                     });
 
@@ -831,12 +830,11 @@ pub fn public_source_entries_to_private_source_entries(
                         break;
                     }
 
-                    // Without a git repository there is no repository root to stop at. Stop
-                    // once the directory contains the current working directory instead, so
-                    // `.gitignore` files outside of the project (e.g. in the user's home
-                    // directory) can never promote a source to an external source. Note that
-                    // the file walker still applies those `.gitignore` files when deciding
-                    // which files to scan.
+                    // Without a git repository there is no repository root to stop at. Stop once
+                    // the directory contains the current working directory instead, so `.gitignore`
+                    // files outside of the project (e.g. in the user's home directory) can never
+                    // promote a source to an external source. Note that the file walker still
+                    // applies those `.gitignore` files when deciding which files to scan.
                     if !inside_git_repo && cwd.as_ref().is_some_and(|cwd| cwd.starts_with(dir)) {
                         break;
                     }

--- a/crates/oxide/src/scanner/sources.rs
+++ b/crates/oxide/src/scanner/sources.rs
@@ -795,13 +795,34 @@ pub fn public_source_entries_to_private_source_entries(
                         path.is_file().then(|| Gitignore::new(&path).0)
                     });
 
-                    if let Some(gitignore) = gitignore {
-                        if gitignore
-                            .matched_path_or_any_parents(&base, true)
-                            .is_ignore()
-                        {
-                            source = SourceEntry::External { base: base.into() };
-                            break;
+                    // Only `.gitignore` files in ancestors of `base` can ignore `base` itself.
+                    // Patterns in `base`'s own `.gitignore` only match paths _inside_ `base`, never
+                    // `base` itself (the file walker still applies them to `base`'s contents).
+                    //
+                    // Skipping `base`'s own `.gitignore` also prevents a false positive for
+                    // whitelist style `.gitignore` files, because relativizing `base` against
+                    // itself yields the empty path, which incorrectly matches `/*`.
+                    //
+                    // E.g.:
+                    //
+                    // ```gitignore
+                    // /*
+                    // !/.gitignore
+                    // !/app
+                    // !/public
+                    // ```
+                    //
+                    // Everything inside `base` except `.gitignore`, `app` and `public` is ignored,
+                    // but `base` itself is not.
+                    if dir != base {
+                        if let Some(gitignore) = gitignore {
+                            if gitignore
+                                .matched_path_or_any_parents(&base, true)
+                                .is_ignore()
+                            {
+                                source = SourceEntry::External { base: base.into() };
+                                break;
+                            }
                         }
                     }
 

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1685,6 +1685,27 @@ mod scanner {
     }
 
     #[test]
+    fn explicit_source_directories_respect_their_own_gitignore() {
+        // A directory referenced via `@source` behaves like an auto source detection
+        // root. The `.gitignore` file _inside_ that directory still applies to its
+        // contents. Only when the directory itself is ignored (by an ancestor
+        // `.gitignore`, see the tests above) do we bypass the ignore rules.
+        let ScanResult {
+            files, candidates, ..
+        } = scan_with_globs(
+            &[
+                ("vendor/.gitignore", "ignored.html"),
+                ("vendor/index.html", "content-['vendor/index.html']"),
+                ("vendor/ignored.html", "content-['vendor/ignored.html']"),
+            ],
+            vec!["@source 'vendor'"],
+        );
+
+        assert_eq!(files, vec!["vendor/index.html"]);
+        assert_eq!(candidates, vec!["content-['vendor/index.html']"]);
+    }
+
+    #[test]
     fn explicit_sources_can_include_files_inside_gitignored_parent_directories() {
         let ScanResult {
             candidates,

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1605,6 +1605,86 @@ mod scanner {
     }
 
     #[test]
+    fn it_respects_gitignore_files_with_whitelist_patterns() {
+        // https://github.com/tailwindlabs/tailwindcss/discussions/20382
+        //
+        // A `.gitignore` that ignores everything (`/*`) and then whitelists specific
+        // directories and files using negated patterns.
+        let ScanResult {
+            files, candidates, ..
+        } = scan(&[
+            (
+                ".gitignore",
+                "/*\n!/app\n!/public\n!/package.json\n!/.gitignore\n",
+            ),
+            ("app/index.html", "content-['app/index.html']"),
+            ("public/index.html", "content-['public/index.html']"),
+            ("package.json", ""),
+            // These are all ignored by the `/*` rule because they are not whitelisted
+            ("build/generated.html", "content-['build/generated.html']"),
+            ("logs/dev.log", "content-['logs/dev.log']"),
+            (
+                "node_modules/my-ui-lib/index.html",
+                "content-['node_modules/my-ui-lib/index.html']",
+            ),
+        ]);
+
+        assert_eq!(
+            files,
+            vec!["app/index.html", "package.json", "public/index.html"]
+        );
+        assert_eq!(
+            candidates,
+            vec![
+                "content-['app/index.html']",
+                "content-['public/index.html']"
+            ]
+        );
+    }
+
+    #[test]
+    fn it_respects_gitignore_files_with_nested_whitelist_patterns() {
+        // Example from the official `.gitignore` documentation:
+        //
+        // ```gitignore
+        // # exclude everything except directory foo/bar
+        // /*
+        // !/foo
+        // /foo/*
+        // !/foo/bar
+        // ```
+        let ScanResult {
+            files, candidates, ..
+        } = scan(&[
+            (
+                ".gitignore",
+                "# exclude everything except directory foo/bar\n/*\n!/foo\n/foo/*\n!/foo/bar\n",
+            ),
+            ("foo/bar/index.html", "content-['foo/bar/index.html']"),
+            (
+                "foo/bar/nested/index.html",
+                "content-['foo/bar/nested/index.html']",
+            ),
+            // These are all ignored because they are not inside `foo/bar`
+            ("index.html", "content-['index.html']"),
+            ("foo/index.html", "content-['foo/index.html']"),
+            ("foo/baz/index.html", "content-['foo/baz/index.html']"),
+        ]);
+
+        assert_eq!(
+            files,
+            vec!["foo/bar/index.html", "foo/bar/nested/index.html"]
+        );
+        assert_eq!(
+            candidates,
+            vec![
+                "content-['foo/bar/index.html']",
+                "content-['foo/bar/nested/index.html']"
+            ]
+        );
+    }
+
+    #[test]
     fn explicit_sources_can_include_files_inside_gitignored_parent_directories() {
         let ScanResult {
             candidates,

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2276,6 +2276,70 @@ test(
   },
 )
 
+// https://github.com/tailwindlabs/tailwindcss/discussions/20382
+test(
+  'auto source detection respects allow-list .gitignore files',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "tailwindcss": "workspace:^",
+            "@tailwindcss/cli": "workspace:^"
+          }
+        }
+      `,
+      '.gitignore': txt`
+        /*
+        !/.gitignore
+        !/app
+        !/public
+        !/package.json
+      `,
+      'app/root.css': css` @import 'tailwindcss/utilities'; `,
+      // Included by the `!/app` pattern in `.gitignore`
+      //
+      // → Should be included
+      'app/index.html': html`
+        <div class="content-['app/index.html']"></div>
+      `,
+      // Included by the `!/public` pattern in `.gitignore`
+      //
+      // → Should be included
+      'public/index.html': html`
+        <div class="content-['public/index.html']"></div>
+      `,
+      // Ignored by the `/*` in `.gitignore`
+      //
+      // → Should be ignored
+      'build/index.html': html`
+        <div class="content-['build/index.html']"></div>
+      `,
+      // Ignored by the `/*` in `.gitignore` and the default `node_modules` rules
+      //
+      // → Should be ignored
+      'node_modules/my-ui-lib/index.html': html`
+        <div
+          class="content-['node_modules/my-ui-lib/index.html']"
+        ></div>
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('pnpm tailwindcss --input app/root.css --output dist/out.css')
+
+    await fs.expectFileToContain('dist/out.css', [
+      candidate`content-['app/index.html']`,
+      candidate`content-['public/index.html']`,
+    ])
+
+    await fs.expectFileNotToContain('dist/out.css', [
+      candidate`content-['build/index.html']`,
+      candidate`content-['node_modules/my-ui-lib/index.html']`,
+    ])
+  },
+)
+
 test(
   '@source works with symlinks (referencing folder in current folder)',
   {


### PR DESCRIPTION
This PR fixes an issue where a folder containing a `.gitignore` that uses a whitelist setup results in too many folders being scanned:

```gitignore
# .gitignore
/*
!/app
```

We want to make sure that we respect the `.gitignore` file, but we also need to make sure that `@source` directives 'win' from `.gitignore` files. For example:

```css
@import 'tailwindcss';
@source "./node_modules/my-package/*.js";
```

In this case, `node_modules` is likely ignored via `.gitignore`, but you _do_ want to include the files from the `my-package` folder, essentially overriding the `.gitignore` rules.

To do this, we internally mark this folder as an `External` folder such that it gets read, because that's what we want.

The current bug has a pattern like `/*` and then safelist/whitelist patterns to include certain folders. The problem with the `/*` pattern is that this convert the _current_ folder to an `External` folder. This is wrong. The current folder cannot be ignored by the current `.gitignore` file itself. You can ignore files and folders _inside_ the current folder, but not the folder itself. The current folder can only be ignored by parent `.gitignore` rules.

Originally discussed in: https://github.com/tailwindlabs/tailwindcss/discussions/20382
Fixes: #20385

## Test plan

1. Added regression tests
2. Added integration tests

Manually tested, and logging the scanned files does result in some interesting results:


<details>

<summary>Before</summary>

```
Reading ".git/COMMIT_EDITMSG"
Reading ".git/HEAD"
Reading ".git/MERGE_RR"
Reading ".git/config"
Reading ".git/description"
Reading ".git/hooks/applypatch-msg.sample"
Reading ".git/hooks/commit-msg.sample"
Reading ".git/hooks/fsmonitor-watchman.sample"
Reading ".git/hooks/post-update.sample"
Reading ".git/hooks/pre-applypatch.sample"
Reading ".git/hooks/pre-commit.sample"
Reading ".git/hooks/pre-merge-commit.sample"
Reading ".git/hooks/pre-push.sample"
Reading ".git/hooks/pre-rebase.sample"
Reading ".git/hooks/pre-receive.sample"
Reading ".git/hooks/prepare-commit-msg.sample"
Reading ".git/hooks/push-to-checkout.sample"
Reading ".git/hooks/sendemail-validate.sample"
Reading ".git/hooks/update.sample"
Reading ".git/index"
Reading ".git/info/exclude"
Reading ".git/logs/HEAD"
Reading ".git/logs/refs/heads/main"
Reading ".git/objects/02/2fe3aa1b28300c0146acdff4eb3240cd2a861b"
Reading ".git/objects/17/45509b3ec34de9d8ddd6708c9d73f191c63c48"
Reading ".git/objects/1e/d83f044a80cfec0843a0d68fa859c101e4e02f"
Reading ".git/objects/60/76888f3ae7ecd2712c236933314e1c420e52f2"
Reading ".git/objects/76/e5d55dc7d51e47bff78b27e39a13110e17c072"
Reading ".git/objects/89/7b4529b9a3db489cc00e2cff4bbd1a2f09fb50"
Reading ".git/objects/8c/781ce3374b53455c284bef51bffbee5ca88969"
Reading ".git/objects/b2/ceaa157eef0b2a8d0231a1396b17684da71de7"
Reading ".git/objects/da/7ef6439d0779bae07668b42d77dcbce2f84111"
Reading ".git/refs/heads/main"
Reading ".gitattributes"
Reading ".gitignore"
Reading "app/index.html"
Reading "build/index.html"
Reading "node_modules/.modules.yaml"
Reading "node_modules/.package-map.json"
Reading "node_modules/.pnpm-workspace-state-v1.json"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/README.md"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/package.json"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/src/scopes.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/src/sourcemap-codec.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/src/strings.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/src/vlq.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/README.md"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.mjs"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.umd.js"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/package.json"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/binary-search.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/by-source.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/flatten-map.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/resolve.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/sort.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/sourcemap-segment.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/strip-filename.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/trace-mapping.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/src/types.ts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/binary-search.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/binary-search.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/binary-search.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/binary-search.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/by-source.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/by-source.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/by-source.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/by-source.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/resolve.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/resolve.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/resolve.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/resolve.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sort.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sort.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sort.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sort.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/types.d.cts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/types.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/types.d.mts"
Reading "node_modules/.pnpm/@jridgewell+gen-mapping@0.3.13/node_modules/@jridgewell/trace-mapping/types/types.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/README.md"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.mjs"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.umd.js"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/types/gen-mapping.d.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/types/set-array.d.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/types/sourcemap-segment.d.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/dist/types/types.d.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/package.json"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/src/gen-mapping.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/src/set-array.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/src/sourcemap-segment.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/src/types.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/set-array.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/set-array.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/set-array.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/set-array.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/types.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/types.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/types.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/gen-mapping/types/types.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/README.md"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/dist/remapping.mjs"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/dist/remapping.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/dist/remapping.umd.js"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/dist/remapping.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/package.json"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/src/build-source-map-tree.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/src/remapping.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/src/source-map-tree.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/src/source-map.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/src/types.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/remapping.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/remapping.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/remapping.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/remapping.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map-tree.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map-tree.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map-tree.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map-tree.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/source-map.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/types.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/types.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/types.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/remapping/types/types.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/README.md"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.mjs"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.umd.js"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/package.json"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/binary-search.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/by-source.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/flatten-map.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/resolve.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/sort.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/sourcemap-segment.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/strip-filename.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/trace-mapping.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/src/types.ts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/binary-search.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/binary-search.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/binary-search.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/binary-search.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/by-source.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/by-source.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/by-source.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/by-source.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/resolve.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/resolve.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/resolve.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/resolve.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sort.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sort.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sort.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sort.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/types.d.cts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/types.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/types.d.mts"
Reading "node_modules/.pnpm/@jridgewell+remapping@2.3.5/node_modules/@jridgewell/trace-mapping/types/types.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/README.md"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.mjs"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/dist/types/resolve-uri.d.ts"
Reading "node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri/package.json"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/README.md"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.mjs"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/dist/types/resolve-uri.d.ts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/resolve-uri/package.json"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/LICENSE"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/README.md"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/package.json"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/src/scopes.ts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/src/sourcemap-codec.ts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/src/strings.ts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/src/vlq.ts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts.map"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts"
Reading "node_modules/.pnpm/@jridgewell+trace-mapping@0.3.31/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts.map"
Reading "node_modules/.pnpm/@parcel+watcher-darwin-arm64@2.6.0/node_modules/@parcel/watcher-darwin-arm64/LICENSE"
Reading "node_modules/.pnpm/@parcel+watcher-darwin-arm64@2.6.0/node_modules/@parcel/watcher-darwin-arm64/README.md"
Reading "node_modules/.pnpm/@parcel+watcher-darwin-arm64@2.6.0/node_modules/@parcel/watcher-darwin-arm64/package.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher-darwin-arm64/LICENSE"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher-darwin-arm64/README.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher-darwin-arm64/package.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/LICENSE"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/README.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/binding.gyp"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/index.d.ts"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/index.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/index.js.flow"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/package.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/scripts/build-from-source.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Backend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Backend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Debounce.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Debounce.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/DirTree.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/DirTree.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Event.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Glob.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Glob.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/PromiseRunner.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Signal.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Watcher.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/Watcher.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/binding.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/kqueue/KqueueBackend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/kqueue/KqueueBackend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/linux/InotifyBackend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/linux/InotifyBackend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/macos/FSEventsBackend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/macos/FSEventsBackend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/shared/BruteForceBackend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/shared/BruteForceBackend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/unix/fts.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/unix/legacy.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/wasm/WasmBackend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/wasm/WasmBackend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/wasm/include.h"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/watchman/BSER.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/watchman/BSER.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/watchman/IPC.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/watchman/WatchmanBackend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/watchman/WatchmanBackend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/windows/WindowsBackend.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/windows/WindowsBackend.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/windows/win_utils.cc"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/src/windows/win_utils.hh"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/@parcel/watcher/wrapper.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/LICENSE"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/README.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/index.d.ts"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/lib/detect-libc.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/lib/elf.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/lib/filesystem.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/lib/process.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/detect-libc/package.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/is-glob/LICENSE"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/is-glob/README.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/is-glob/index.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/is-glob/package.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/LICENSE.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/README.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/common.gypi"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/except.gypi"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/index.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/napi-inl.deprecated.h"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/napi-inl.h"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/napi.h"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/node_addon_api.gyp"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/node_api.gyp"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/noexcept.gypi"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/nothing.c"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/package-support.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/package.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/tools/README.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/tools/check-napi.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/tools/clang-format.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/tools/conversion.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/node-addon-api/tools/eslint-format.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/LICENSE"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/README.md"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/index.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/lib/constants.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/lib/parse.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/lib/picomatch.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/lib/scan.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/lib/utils.js"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/package.json"
Reading "node_modules/.pnpm/@parcel+watcher@2.6.0/node_modules/picomatch/posix.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/graceful-fs/LICENSE"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/graceful-fs/README.md"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/graceful-fs/clone.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/graceful-fs/graceful-fs.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/graceful-fs/legacy-streams.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/graceful-fs/package.json"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/graceful-fs/polyfills.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/LICENSE"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/README.md"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/AsyncParallelBailHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/AsyncParallelHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/AsyncSeriesBailHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/AsyncSeriesHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/AsyncSeriesLoopHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/AsyncSeriesWaterfallHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/Hook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/HookCodeFactory.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/HookMap.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/MultiHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/SyncBailHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/SyncHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/SyncLoopHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/SyncWaterfallHook.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/index.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/lib/util-browser.js"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/package.json"
Reading "node_modules/.pnpm/enhanced-resolve@5.24.5/node_modules/tapable/tapable.d.ts"
Reading "node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/LICENSE"
Reading "node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/README.md"
Reading "node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/clone.js"
Reading "node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/graceful-fs.js"
Reading "node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/legacy-streams.js"
Reading "node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/package.json"
Reading "node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs/polyfills.js"
Reading "node_modules/.pnpm/is-extglob@2.1.1/node_modules/is-extglob/LICENSE"
Reading "node_modules/.pnpm/is-extglob@2.1.1/node_modules/is-extglob/README.md"
Reading "node_modules/.pnpm/is-extglob@2.1.1/node_modules/is-extglob/index.js"
Reading "node_modules/.pnpm/is-extglob@2.1.1/node_modules/is-extglob/package.json"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-extglob/LICENSE"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-extglob/README.md"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-extglob/index.js"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-extglob/package.json"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-glob/LICENSE"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-glob/README.md"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-glob/index.js"
Reading "node_modules/.pnpm/is-glob@4.0.3/node_modules/is-glob/package.json"
Reading "node_modules/.pnpm/lightningcss-darwin-arm64@1.33.0/node_modules/lightningcss-darwin-arm64/LICENSE"
Reading "node_modules/.pnpm/lightningcss-darwin-arm64@1.33.0/node_modules/lightningcss-darwin-arm64/README.md"
Reading "node_modules/.pnpm/lightningcss-darwin-arm64@1.33.0/node_modules/lightningcss-darwin-arm64/package.json"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/LICENSE"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/README.md"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/index.d.ts"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/lib/detect-libc.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/lib/elf.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/lib/filesystem.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/lib/process.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/detect-libc/package.json"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss-darwin-arm64/LICENSE"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss-darwin-arm64/README.md"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss-darwin-arm64/package.json"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/LICENSE"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/README.md"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/ast.d.ts"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/ast.js.flow"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/browserslistToTargets.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/composeVisitors.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/flags.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/index.d.ts"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/index.js"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/index.js.flow"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/index.mjs"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/targets.d.ts"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/node/targets.js.flow"
Reading "node_modules/.pnpm/lightningcss@1.33.0/node_modules/lightningcss/package.json"
Reading "node_modules/.pnpm/lock.yaml"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/LICENSE"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/README.md"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/package.json"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/src/scopes.ts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/src/sourcemap-codec.ts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/src/strings.ts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/src/vlq.ts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts.map"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/magic-string/LICENSE"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/magic-string/README.md"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/magic-string/dist/index.d.mts"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/magic-string/dist/index.mjs"
Reading "node_modules/.pnpm/magic-string@1.1.0/node_modules/magic-string/package.json"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/LICENSE"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/README.md"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.mjs"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.mjs.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.umd.js"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/gen-mapping.umd.js.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/types/gen-mapping.d.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/types/set-array.d.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/types/sourcemap-segment.d.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/dist/types/types.d.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/package.json"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/src/gen-mapping.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/src/set-array.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/src/sourcemap-segment.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/src/types.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/gen-mapping.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/set-array.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/set-array.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/set-array.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/set-array.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/sourcemap-segment.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/types.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/types.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/types.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/gen-mapping/types/types.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/LICENSE"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/README.md"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/dist/remapping.mjs"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/dist/remapping.mjs.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/dist/remapping.umd.js"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/dist/remapping.umd.js.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/package.json"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/src/build-source-map-tree.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/src/remapping.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/src/source-map-tree.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/src/source-map.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/src/types.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/build-source-map-tree.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/remapping.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/remapping.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/remapping.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/remapping.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map-tree.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map-tree.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map-tree.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map-tree.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/source-map.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/types.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/types.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/types.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/remapping/types/types.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/LICENSE"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/README.md"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.mjs"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.mjs.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/dist/resolve-uri.umd.js.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/dist/types/resolve-uri.d.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/resolve-uri/package.json"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/LICENSE"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/README.md"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.mjs.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/dist/sourcemap-codec.umd.js.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/package.json"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/src/scopes.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/src/sourcemap-codec.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/src/strings.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/src/vlq.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/scopes.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/sourcemap-codec.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/strings.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/strings.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/sourcemap-codec/types/vlq.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/LICENSE"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/README.md"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.mjs"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.mjs.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.umd.js"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/dist/trace-mapping.umd.js.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/package.json"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/binary-search.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/by-source.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/flatten-map.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/resolve.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/sort.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/sourcemap-segment.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/strip-filename.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/trace-mapping.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/src/types.ts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/binary-search.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/binary-search.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/binary-search.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/binary-search.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/by-source.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/by-source.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/by-source.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/by-source.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/flatten-map.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/resolve.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/resolve.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/resolve.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/resolve.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sort.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sort.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sort.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sort.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/sourcemap-segment.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/strip-filename.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/trace-mapping.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/types.d.cts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/types.d.cts.map"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/types.d.mts"
Reading "node_modules/.pnpm/node_modules/@jridgewell/trace-mapping/types/types.d.mts.map"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher-darwin-arm64/LICENSE"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher-darwin-arm64/README.md"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher-darwin-arm64/package.json"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/LICENSE"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/README.md"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/binding.gyp"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/index.d.ts"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/index.js"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/index.js.flow"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/package.json"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/scripts/build-from-source.js"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Backend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Backend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Debounce.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Debounce.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/DirTree.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/DirTree.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Event.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Glob.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Glob.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/PromiseRunner.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Signal.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Watcher.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/Watcher.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/binding.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/kqueue/KqueueBackend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/kqueue/KqueueBackend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/linux/InotifyBackend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/linux/InotifyBackend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/macos/FSEventsBackend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/macos/FSEventsBackend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/shared/BruteForceBackend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/shared/BruteForceBackend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/unix/fts.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/unix/legacy.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/wasm/WasmBackend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/wasm/WasmBackend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/wasm/include.h"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/watchman/BSER.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/watchman/BSER.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/watchman/IPC.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/watchman/WatchmanBackend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/watchman/WatchmanBackend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/windows/WindowsBackend.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/windows/WindowsBackend.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/windows/win_utils.cc"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/src/windows/win_utils.hh"
Reading "node_modules/.pnpm/node_modules/@parcel/watcher/wrapper.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/LICENSE"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/esm-cache.loader.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/esm-cache.loader.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/index.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/index.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/index.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/require-cache.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/dist/require-cache.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/node/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-darwin-arm64/LICENSE"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-darwin-arm64/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-darwin-arm64/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/LICENSE"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.cjs.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.cjs.min.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.cjs.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.esm-bundler.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.min.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.min.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/dist/emnapi-core.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/LICENSE"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.cjs.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.cjs.min.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.cjs.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.esm-bundler.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.iife.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.iife.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.min.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.min.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/dist/emnapi.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/LICENSE"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.cjs.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.cjs.min.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.cjs.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.esm-bundler.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.min.d.mts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.min.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/dist/wasi-threads.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/dist/emnapi-plugins.cjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/dist/emnapi-plugins.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/dist/fs-proxy.cjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/dist/fs.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/fs-proxy.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/runtime.cjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime/runtime.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/dist/tsdoc-metadata.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/dist/wasm-util.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/dist/wasm-util.esm-bundler.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/dist/wasm-util.esm.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/dist/wasm-util.esm.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/dist/wasm-util.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/dist/wasm-util.min.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/asyncify.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/jspi.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/load.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/memory.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/error.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/fd.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/fs.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/path.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/preview1.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/rights.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/types.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/wasi/util.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/cjs/webassembly.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/asyncify.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/index.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/jspi.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/load.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/memory.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/error.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/fd.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/fs.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/index.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/path.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/preview1.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/rights.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/types.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/wasi/util.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/lib/mjs/webassembly.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/CopyrightNotice.txt"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/LICENSE.txt"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/README.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/SECURITY.md"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/modules/index.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/modules/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/modules/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/tslib.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/tslib.es6.html"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/tslib.es6.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/tslib.es6.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/tslib.html"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib/tslib.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/package.json"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/tailwindcss-oxide.wasi-browser.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/tailwindcss-oxide.wasi.cjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/wasi-worker-browser.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide-wasm32-wasi/wasi-worker.mjs"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide/LICENSE"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide/index.d.ts"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide/index.js"
Reading "node_modules/.pnpm/node_modules/@tailwindcss/oxide/package.json"
Reading "node_modules/.pnpm/node_modules/detect-libc/LICENSE"
Reading "node_modules/.pnpm/node_modules/detect-libc/README.md"
Reading "node_modules/.pnpm/node_modules/detect-libc/index.d.ts"
Reading "node_modules/.pnpm/node_modules/detect-libc/lib/detect-libc.js"
Reading "node_modules/.pnpm/node_modules/detect-libc/lib/elf.js"
Reading "node_modules/.pnpm/node_modules/detect-libc/lib/filesystem.js"
Reading "node_modules/.pnpm/node_modules/detect-libc/lib/process.js"
Reading "node_modules/.pnpm/node_modules/detect-libc/package.json"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/LICENSE"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/README.md"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/AliasFieldPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/AliasPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/AliasUtils.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/AppendPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/CloneBasenamePlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ConditionalPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/DescriptionFilePlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/DescriptionFileUtils.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/DirectoryExistsPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ExportsFieldPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ExtensionAliasPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/FileExistsPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ImportsFieldPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/JoinRequestPartPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/JoinRequestPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/LogInfoPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/MainFieldPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ModulesInHierachicDirectoriesPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ModulesInHierarchicalDirectoriesPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ModulesInRootPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ModulesUtils.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/NextPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ParsePlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/PnpPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/Resolver.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ResolverFactory.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/RestrictionsPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/ResultPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/RootsPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/SelfReferencePlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/SymlinkPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/SyncAsyncFileSystemDecorator.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/TryNextPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/TsconfigPathsPlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/UnsafeCachePlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/UseFilePlugin.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/createInnerContext.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/forEachBail.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/getInnerRequest.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/getPaths.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/index.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/entrypoints.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/fileURLToPath.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/fs.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/graceful-fs-browser.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/identifier.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/memoize.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/module-browser.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/path-browser.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/path.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/process-browser.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/strip-json-comments.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/lib/util/url-browser.js"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/package.json"
Reading "node_modules/.pnpm/node_modules/enhanced-resolve/types.d.ts"
Reading "node_modules/.pnpm/node_modules/graceful-fs/LICENSE"
Reading "node_modules/.pnpm/node_modules/graceful-fs/README.md"
Reading "node_modules/.pnpm/node_modules/graceful-fs/clone.js"
Reading "node_modules/.pnpm/node_modules/graceful-fs/graceful-fs.js"
Reading "node_modules/.pnpm/node_modules/graceful-fs/legacy-streams.js"
Reading "node_modules/.pnpm/node_modules/graceful-fs/package.json"
Reading "node_modules/.pnpm/node_modules/graceful-fs/polyfills.js"
Reading "node_modules/.pnpm/node_modules/is-extglob/LICENSE"
Reading "node_modules/.pnpm/node_modules/is-extglob/README.md"
Reading "node_modules/.pnpm/node_modules/is-extglob/index.js"
Reading "node_modules/.pnpm/node_modules/is-extglob/package.json"
Reading "node_modules/.pnpm/node_modules/is-glob/LICENSE"
Reading "node_modules/.pnpm/node_modules/is-glob/README.md"
Reading "node_modules/.pnpm/node_modules/is-glob/index.js"
Reading "node_modules/.pnpm/node_modules/is-glob/package.json"
Reading "node_modules/.pnpm/node_modules/jiti/LICENSE"
Reading "node_modules/.pnpm/node_modules/jiti/README.md"
Reading "node_modules/.pnpm/node_modules/jiti/dist/babel.cjs"
Reading "node_modules/.pnpm/node_modules/jiti/dist/jiti.cjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti-cli.mjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti-hooks.mjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti-native.mjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti-register.d.mts"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti-register.mjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti-static.mjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti.cjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti.d.cts"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti.d.mts"
Reading "node_modules/.pnpm/node_modules/jiti/lib/jiti.mjs"
Reading "node_modules/.pnpm/node_modules/jiti/lib/types.d.ts"
Reading "node_modules/.pnpm/node_modules/jiti/package.json"
Reading "node_modules/.pnpm/node_modules/lightningcss-darwin-arm64/LICENSE"
Reading "node_modules/.pnpm/node_modules/lightningcss-darwin-arm64/README.md"
Reading "node_modules/.pnpm/node_modules/lightningcss-darwin-arm64/package.json"
Reading "node_modules/.pnpm/node_modules/lightningcss/LICENSE"
Reading "node_modules/.pnpm/node_modules/lightningcss/README.md"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/ast.d.ts"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/ast.js.flow"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/browserslistToTargets.js"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/composeVisitors.js"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/flags.js"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/index.d.ts"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/index.js"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/index.js.flow"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/index.mjs"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/targets.d.ts"
Reading "node_modules/.pnpm/node_modules/lightningcss/node/targets.js.flow"
Reading "node_modules/.pnpm/node_modules/lightningcss/package.json"
Reading "node_modules/.pnpm/node_modules/magic-string/LICENSE"
Reading "node_modules/.pnpm/node_modules/magic-string/README.md"
Reading "node_modules/.pnpm/node_modules/magic-string/dist/index.d.mts"
Reading "node_modules/.pnpm/node_modules/magic-string/dist/index.mjs"
Reading "node_modules/.pnpm/node_modules/magic-string/package.json"
Reading "node_modules/.pnpm/node_modules/mri/index.d.ts"
Reading "node_modules/.pnpm/node_modules/mri/lib/index.js"
Reading "node_modules/.pnpm/node_modules/mri/lib/index.mjs"
Reading "node_modules/.pnpm/node_modules/mri/license.md"
Reading "node_modules/.pnpm/node_modules/mri/package.json"
Reading "node_modules/.pnpm/node_modules/mri/readme.md"
Reading "node_modules/.pnpm/node_modules/node-addon-api/LICENSE.md"
Reading "node_modules/.pnpm/node_modules/node-addon-api/README.md"
Reading "node_modules/.pnpm/node_modules/node-addon-api/common.gypi"
Reading "node_modules/.pnpm/node_modules/node-addon-api/except.gypi"
Reading "node_modules/.pnpm/node_modules/node-addon-api/index.js"
Reading "node_modules/.pnpm/node_modules/node-addon-api/napi-inl.deprecated.h"
Reading "node_modules/.pnpm/node_modules/node-addon-api/napi-inl.h"
Reading "node_modules/.pnpm/node_modules/node-addon-api/napi.h"
Reading "node_modules/.pnpm/node_modules/node-addon-api/node_addon_api.gyp"
Reading "node_modules/.pnpm/node_modules/node-addon-api/node_api.gyp"
Reading "node_modules/.pnpm/node_modules/node-addon-api/noexcept.gypi"
Reading "node_modules/.pnpm/node_modules/node-addon-api/nothing.c"
Reading "node_modules/.pnpm/node_modules/node-addon-api/package-support.json"
Reading "node_modules/.pnpm/node_modules/node-addon-api/package.json"
Reading "node_modules/.pnpm/node_modules/node-addon-api/tools/README.md"
Reading "node_modules/.pnpm/node_modules/node-addon-api/tools/check-napi.js"
Reading "node_modules/.pnpm/node_modules/node-addon-api/tools/clang-format.js"
Reading "node_modules/.pnpm/node_modules/node-addon-api/tools/conversion.js"
Reading "node_modules/.pnpm/node_modules/node-addon-api/tools/eslint-format.js"
Reading "node_modules/.pnpm/node_modules/picocolors/LICENSE"
Reading "node_modules/.pnpm/node_modules/picocolors/README.md"
Reading "node_modules/.pnpm/node_modules/picocolors/package.json"
Reading "node_modules/.pnpm/node_modules/picocolors/picocolors.browser.js"
Reading "node_modules/.pnpm/node_modules/picocolors/picocolors.d.ts"
Reading "node_modules/.pnpm/node_modules/picocolors/picocolors.js"
Reading "node_modules/.pnpm/node_modules/picocolors/types.d.ts"
Reading "node_modules/.pnpm/node_modules/picomatch/LICENSE"
Reading "node_modules/.pnpm/node_modules/picomatch/README.md"
Reading "node_modules/.pnpm/node_modules/picomatch/index.js"
Reading "node_modules/.pnpm/node_modules/picomatch/lib/constants.js"
Reading "node_modules/.pnpm/node_modules/picomatch/lib/parse.js"
Reading "node_modules/.pnpm/node_modules/picomatch/lib/picomatch.js"
Reading "node_modules/.pnpm/node_modules/picomatch/lib/scan.js"
Reading "node_modules/.pnpm/node_modules/picomatch/lib/utils.js"
Reading "node_modules/.pnpm/node_modules/picomatch/package.json"
Reading "node_modules/.pnpm/node_modules/picomatch/posix.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/LICENSE"
Reading "node_modules/.pnpm/node_modules/source-map-js/README.md"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/array-set.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/base64-vlq.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/base64.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/binary-search.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/mapping-list.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/quick-sort.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/source-map-consumer.d.ts"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/source-map-consumer.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/source-map-generator.d.ts"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/source-map-generator.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/source-node.d.ts"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/source-node.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/lib/util.js"
Reading "node_modules/.pnpm/node_modules/source-map-js/package.json"
Reading "node_modules/.pnpm/node_modules/source-map-js/source-map.d.ts"
Reading "node_modules/.pnpm/node_modules/source-map-js/source-map.js"
Reading "node_modules/.pnpm/node_modules/tapable/LICENSE"
Reading "node_modules/.pnpm/node_modules/tapable/README.md"
Reading "node_modules/.pnpm/node_modules/tapable/lib/AsyncParallelBailHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/AsyncParallelHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/AsyncSeriesBailHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/AsyncSeriesHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/AsyncSeriesLoopHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/AsyncSeriesWaterfallHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/Hook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/HookCodeFactory.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/HookMap.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/MultiHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/SyncBailHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/SyncHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/SyncLoopHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/SyncWaterfallHook.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/index.js"
Reading "node_modules/.pnpm/node_modules/tapable/lib/util-browser.js"
Reading "node_modules/.pnpm/node_modules/tapable/package.json"
Reading "node_modules/.pnpm/node_modules/tapable/tapable.d.ts"
Reading "node_modules/@tailwindcss/cli/LICENSE"
Reading "node_modules/@tailwindcss/cli/README.md"
Reading "node_modules/@tailwindcss/cli/dist/index.mjs"
Reading "node_modules/@tailwindcss/cli/package.json"
Reading "node_modules/my-ui-lib/index.html"
Reading "node_modules/tailwindcss/LICENSE"
Reading "node_modules/tailwindcss/README.md"
Reading "node_modules/tailwindcss/dist/chunk-5JIJA4QV.mjs"
Reading "node_modules/tailwindcss/dist/chunk-C2OYBFIH.mjs"
Reading "node_modules/tailwindcss/dist/chunk-DCG7AFIE.mjs"
Reading "node_modules/tailwindcss/dist/colors-C__qRT83.d.ts"
Reading "node_modules/tailwindcss/dist/colors.d.mts"
Reading "node_modules/tailwindcss/dist/colors.d.ts"
Reading "node_modules/tailwindcss/dist/colors.js"
Reading "node_modules/tailwindcss/dist/colors.mjs"
Reading "node_modules/tailwindcss/dist/default-theme.d.mts"
Reading "node_modules/tailwindcss/dist/default-theme.d.ts"
Reading "node_modules/tailwindcss/dist/default-theme.js"
Reading "node_modules/tailwindcss/dist/default-theme.mjs"
Reading "node_modules/tailwindcss/dist/flatten-color-palette.d.mts"
Reading "node_modules/tailwindcss/dist/flatten-color-palette.d.ts"
Reading "node_modules/tailwindcss/dist/flatten-color-palette.js"
Reading "node_modules/tailwindcss/dist/flatten-color-palette.mjs"
Reading "node_modules/tailwindcss/dist/lib.d.mts"
Reading "node_modules/tailwindcss/dist/lib.d.ts"
Reading "node_modules/tailwindcss/dist/lib.js"
Reading "node_modules/tailwindcss/dist/lib.mjs"
Reading "node_modules/tailwindcss/dist/plugin.d.mts"
Reading "node_modules/tailwindcss/dist/plugin.d.ts"
Reading "node_modules/tailwindcss/dist/plugin.js"
Reading "node_modules/tailwindcss/dist/plugin.mjs"
Reading "node_modules/tailwindcss/dist/resolve-config-B4yBzhca.d.ts"
Reading "node_modules/tailwindcss/dist/resolve-config-QUZ9b-Gn.d.mts"
Reading "node_modules/tailwindcss/dist/types-DWdTiksJ.d.mts"
Reading "node_modules/tailwindcss/package.json"
Reading "package.json"
Reading "pnpm-lock.yaml"
Reading "pnpm-workspace.yaml"
Reading "public/index.html"
Reading "tailwindcss-10742.log"
```

</details>

<details>

<summary>After</summary>

```
Reading "./app/index.html"
Reading "./package.json"
Reading "./public/index.html"
```

</details>

