### PR TITLE
Scan git-ignored directories inside explicit glob sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect classes in Ruby percent literals using angle brackets or custom delimiters (e.g. `%w<flex>`, `%w|flex|`), including in Slim and Haml templates ([#20387](https://github.com/tailwindlabs/tailwindcss/pull/20387))
 - Preserve whitespace in `--default(…)` values in custom functional utilities (e.g. `--default(box alphabetic)` no longer becomes `boxalphabetic`) ([#20392](https://github.com/tailwindlabs/tailwindcss/pull/20392))
 - Don't scan gitignored directories (e.g. `node_modules` and `.git`) when the project uses a safelist-style `.gitignore` (e.g. `/*` followed by `!/…` negations) ([#20397](https://github.com/tailwindlabs/tailwindcss/discussions/20397))
+- Ensure explicit glob `@source` patterns scan through git-ignored directories (e.g. Laravel `storage/` directories that ignore themselves with `*`) ([#20405](https://github.com/tailwindlabs/tailwindcss/pull/20405))
 
 ## [4.3.3] - 2026-07-16
 

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -725,6 +725,12 @@ fn create_walker(sources: &Sources) -> Option<WalkBuilder> {
         }
     };
 
+    // Bases of glob sources whose directories must stay walkable even when a
+    // `.gitignore` ignores them, otherwise the pattern rules emitted below can
+    // never reach the files they whitelist (e.g. a directory that ignores
+    // itself with `*`, like Laravel's `storage/` directories).
+    let mut reopened_bases: Vec<&PathBuf> = Vec::new();
+
     for source in sources.iter() {
         match source {
             SourceEntry::Auto { base } => {
@@ -752,6 +758,14 @@ fn create_walker(sources: &Sources) -> Option<WalkBuilder> {
                     if let Some(extension) = Path::new(&pattern).extension() {
                         // Extend auto source detection to include the extension
                         emit(base, format!("!*.{}", extension.to_string_lossy()));
+
+                        // The extension rule above whitelists matching files even
+                        // when they are git-ignored, but it cannot stop the walker
+                        // from pruning git-ignored directories on the way to those
+                        // files. Keep directories under this base walkable as well.
+                        if !reopened_bases.contains(&base) {
+                            reopened_bases.push(base);
+                        }
                     }
                 }
             }
@@ -829,6 +843,17 @@ fn create_walker(sources: &Sources) -> Option<WalkBuilder> {
 
     for root in other_roots {
         builder.add(root);
+    }
+
+    // Re-open directories under glob sources. These rules are registered before
+    // the auto source detection rules and the `@source` rules so both still take
+    // precedence, e.g. `node_modules` inside a glob source stays pruned unless
+    // targeted explicitly.
+    for base in reopened_bases {
+        let mut ignore_builder = GitignoreBuilder::new(base);
+        ignore_builder.add_line(None, "!*/").unwrap();
+        let ignore = ignore_builder.build().unwrap();
+        builder.add_gitignore(ignore);
     }
 
     // Setup auto source detection rules

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1605,6 +1605,131 @@ mod scanner {
     }
 
     #[test]
+    fn it_scans_gitignored_files_matched_by_explicit_glob_sources() {
+        let ScanResult {
+            candidates, files, ..
+        } = scan_with_globs(
+            &[
+                (".gitignore", "/web/ignored.html"),
+                ("web/index.html", "content-['web/index.html']"),
+                ("web/ignored.html", "content-['web/ignored.html']"),
+            ],
+            vec!["@source './web/**/*.html'"],
+        );
+
+        assert_eq!(
+            candidates,
+            vec!["content-['web/ignored.html']", "content-['web/index.html']",]
+        );
+        assert_eq!(files, vec!["web/ignored.html", "web/index.html"]);
+    }
+
+    #[test]
+    fn it_scans_explicit_glob_sources_through_gitignored_directories() {
+        // https://github.com/tailwindlabs/tailwindcss/issues/18870
+        let ScanResult {
+            candidates, files, ..
+        } = scan_with_globs(
+            &[
+                (".gitignore", "/web/pages"),
+                ("web/index.html", "content-['web/index.html']"),
+                (
+                    "web/pages/nested/page.html",
+                    "content-['web/pages/nested/page.html']",
+                ),
+            ],
+            vec!["@source './web/**/*.html'"],
+        );
+
+        assert_eq!(
+            candidates,
+            vec![
+                "content-['web/index.html']",
+                "content-['web/pages/nested/page.html']",
+            ]
+        );
+        assert_eq!(files, vec!["web/index.html", "web/pages/nested/page.html"]);
+    }
+
+    #[test]
+    fn it_scans_explicit_glob_sources_through_self_ignoring_directories() {
+        // Directories that ignore themselves with `*` + `!.gitignore`, like
+        // Laravel's `storage/` directories.
+        //
+        // https://github.com/tailwindlabs/tailwindcss/issues/18870
+        let ScanResult {
+            candidates, files, ..
+        } = scan_with_globs(
+            &[
+                ("src/index.html", "content-['src/index.html']"),
+                ("storage/cms/.gitignore", "*\n!.gitignore\n"),
+                (
+                    "storage/cms/collection/en/page.html",
+                    "content-['storage/cms/collection/en/page.html']",
+                ),
+            ],
+            vec!["@source './src'", "@source './storage/cms/**/*.html'"],
+        );
+
+        assert_eq!(
+            candidates,
+            vec![
+                "content-['src/index.html']",
+                "content-['storage/cms/collection/en/page.html']",
+            ]
+        );
+        assert_eq!(
+            files,
+            vec!["src/index.html", "storage/cms/collection/en/page.html"]
+        );
+    }
+
+    #[test]
+    fn it_keeps_auto_ignored_directories_pruned_inside_explicit_glob_sources() {
+        // Re-opening gitignored directories for an explicit glob source must not
+        // re-open directories that are always ignored, like `node_modules`.
+        let ScanResult {
+            candidates, files, ..
+        } = scan_with_globs(
+            &[
+                ("web/.gitignore", "*\n!.gitignore\n"),
+                ("web/pages/index.html", "content-['web/pages/index.html']"),
+                (
+                    "web/node_modules/dep/ui.html",
+                    "content-['web/node_modules/dep/ui.html']",
+                ),
+            ],
+            vec!["@source './web/**/*.html'"],
+        );
+
+        assert_eq!(candidates, vec!["content-['web/pages/index.html']"]);
+        assert_eq!(files, vec!["web/pages/index.html"]);
+    }
+
+    #[test]
+    fn it_respects_source_not_inside_glob_sources_through_gitignored_directories() {
+        let ScanResult {
+            candidates, files, ..
+        } = scan_with_globs(
+            &[
+                ("web/.gitignore", "*\n!.gitignore\n"),
+                ("web/pages/index.html", "content-['web/pages/index.html']"),
+                (
+                    "web/pages/secret/hidden.html",
+                    "content-['web/pages/secret/hidden.html']",
+                ),
+            ],
+            vec![
+                "@source './web/**/*.html'",
+                "@source not './web/pages/secret'",
+            ],
+        );
+
+        assert_eq!(candidates, vec!["content-['web/pages/index.html']"]);
+        assert_eq!(files, vec!["web/pages/index.html"]);
+    }
+
+    #[test]
     fn it_respects_gitignore_files_with_whitelist_patterns() {
         // https://github.com/tailwindlabs/tailwindcss/discussions/20382
         //


### PR DESCRIPTION
Fixes #18870

## Summary

`@source "../storage/app/private/cms_content/**/*.html"` finds nothing when the target directory is ignored from the inside, i.e. a `.gitignore` containing `*` + `!.gitignore`, the way Laravel ships every `storage/` directory. The reporter's testcase also shows the two shapes that already work: pointing `@source` at the exact file, and the same glob once the nested `.gitignore` is deleted.

The asymmetry is in how the walker treats files vs. directories. Glob sources emit an `!*.html` rule, and manually registered rules rank above on-disk `.gitignore` files, so a git-ignored *file* matched by an explicit glob is scanned today (this PR adds a test pinning that). That rule can't save anything inside a git-ignored *directory* though: `*` matches the child directories themselves, the walker prunes them, and no file rule ever runs. An ignore in an ancestor `.gitignore` (say `/storage` in the project root) doesn't trigger the bug, because the normalized source base starts the walk inside the ignored tree. That's what makes the failure look random unless you know where the ignore line lives.

Glob sources now also register a directory re-include (`!*/`) for their base, ordered so that everything that should still win, does:

- registered before the auto source detection rules, so `node_modules` etc. inside a glob source stay pruned unless targeted explicitly (the concern raised in the issue about accidentally walking huge trees)
- registered before the `@source` rules, so `@source not` still excludes directories inside a re-opened source
- on-disk `.gitignore` files rank below manually registered rules, which is what lets the walker descend

Bare directory sources (`@source "../storage/app/private/cms_content"`) are unchanged: they emit no file rules, so `.gitignore` semantics inside them still apply, as pinned by `it_respects_gitignore_in_workspace_root`.

## Test plan

- Five new tests in `crates/oxide/tests/scanner.rs`: the issue's Laravel shape, a glob through an ancestor-ignored directory, git-ignored files matched by a glob (pins existing behavior), `node_modules` staying pruned inside a re-opened source, and `@source not` inside one.
- `cargo test --workspace` passes.
- Reproduced against the reporter's testcase layout (CSS entry in `src/`, relative `../storage/...` sources, `source(none)`): before this change the scanner returns no files from `cms_content`; with it, the pre-rendered HTML is scanned and its candidates extracted.

[ci-all]
