### PR TITLE
Don't scan sibling files of a concrete `@source` inside an auto source root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve whitespace in `--default(…)` values in custom functional utilities (e.g. `--default(box alphabetic)` no longer becomes `boxalphabetic`) ([#20392](https://github.com/tailwindlabs/tailwindcss/pull/20392))
 - Don't scan gitignored directories (e.g. `node_modules` and `.git`) when the project uses a safelist-style `.gitignore` (e.g. `/*` followed by `!/…` negations) ([#20397](https://github.com/tailwindlabs/tailwindcss/discussions/20397))
 - Ensure root `theme('…')` namespace lookups in JavaScript plugins and config files return the full namespace object instead of the value of its `DEFAULT` key ([#20399](https://github.com/tailwindlabs/tailwindcss/pull/20399))
-- Don't scan every sibling of a concrete `@source` file when it sits behind an ignored directory inside the project root (e.g. `@source "./node_modules/.generated/ui/button.ts"` no longer scans the whole `ui` folder) ([#TBD](https://github.com/tailwindlabs/tailwindcss/pull/TBD))
+- Don't scan every sibling of a concrete `@source` file when it sits behind an ignored directory inside the project root (e.g. `@source "./node_modules/.generated/ui/button.ts"` no longer scans the whole `ui` folder) ([#20406](https://github.com/tailwindlabs/tailwindcss/pull/20406))
 
 ## [4.3.3] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve whitespace in `--default(…)` values in custom functional utilities (e.g. `--default(box alphabetic)` no longer becomes `boxalphabetic`) ([#20392](https://github.com/tailwindlabs/tailwindcss/pull/20392))
 - Don't scan gitignored directories (e.g. `node_modules` and `.git`) when the project uses a safelist-style `.gitignore` (e.g. `/*` followed by `!/…` negations) ([#20397](https://github.com/tailwindlabs/tailwindcss/discussions/20397))
 - Ensure root `theme('…')` namespace lookups in JavaScript plugins and config files return the full namespace object instead of the value of its `DEFAULT` key ([#20399](https://github.com/tailwindlabs/tailwindcss/pull/20399))
+- Don't scan every sibling of a concrete `@source` file when it sits behind an ignored directory inside the project root (e.g. `@source "./node_modules/.generated/ui/button.ts"` no longer scans the whole `ui` folder) ([#TBD](https://github.com/tailwindlabs/tailwindcss/pull/TBD))
 
 ## [4.3.3] - 2026-07-16
 

--- a/crates/oxide/src/scanner/sources.rs
+++ b/crates/oxide/src/scanner/sources.rs
@@ -323,11 +323,14 @@ fn is_ignored_by_gitignore(
         // itself is not.
         if dir != base {
             if let Some(gitignore) = gitignore {
-                if gitignore
-                    .matched_path_or_any_parents(base, true)
-                    .is_ignore()
-                {
-                    return true;
+                // The nearest `.gitignore` with a definitive answer wins, matching git: patterns
+                // in a deeper `.gitignore` override the directories above it, so a re-included
+                // (`!dir`) directory is not ignored even when an ancestor `.gitignore` ignores
+                // it.
+                match gitignore.matched_path_or_any_parents(base, true) {
+                    ignore::Match::Ignore(_) => return true,
+                    ignore::Match::Whitelist(_) => return false,
+                    ignore::Match::None => {}
                 }
             }
         }

--- a/crates/oxide/src/scanner/sources.rs
+++ b/crates/oxide/src/scanner/sources.rs
@@ -138,12 +138,28 @@ impl Sources {
 /// !/ba*/*.html          ← then ensure we scan the `*.html` files in it as well
 /// ```
 ///
-fn expand_restricted_patterns(sources: Vec<SourceEntry>) -> Vec<SourceEntry> {
-    let unrestricted_roots = sources
+fn expand_restricted_patterns(
+    sources: Vec<SourceEntry>,
+    gitignores: &mut FxHashMap<PathBuf, Option<Gitignore>>,
+    cwd: Option<&Path>,
+) -> Vec<SourceEntry> {
+    // Roots that walk everything under them regardless of ignore rules: explicitly listed
+    // ignored directories (External) and `**` patterns (whitelisted from their own base).
+    let bypassing_roots = sources
         .iter()
         .filter_map(|source| match source {
-            SourceEntry::Auto { base } | SourceEntry::External { base } => Some(base.clone()),
+            SourceEntry::External { base } => Some(base.clone()),
             SourceEntry::Pattern { base, pattern } if pattern.contains("**") => Some(base.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    // Auto roots walk their tree with the default and `.gitignore` rules applied, so they only
+    // cover the paths those rules don't prune.
+    let auto_roots = sources
+        .iter()
+        .filter_map(|source| match source {
+            SourceEntry::Auto { base } => Some(base.clone()),
             _ => None,
         })
         .collect::<Vec<_>>();
@@ -171,7 +187,18 @@ fn expand_restricted_patterns(sources: Vec<SourceEntry>) -> Vec<SourceEntry> {
         // includes the case where `base` is _nested_ inside such a root, because everything under
         // an unrestricted root is walked already. Restricting it would incorrectly hide siblings
         // that the broader source is supposed to pick up.
-        if unrestricted_roots.iter().any(|root| base.starts_with(root)) {
+        //
+        // An auto root only counts when its walk actually reaches `base`. When `base` hides
+        // behind a default-ignored directory (e.g. `node_modules`) or a git-ignored one, the auto
+        // walk prunes it and the pattern's own walk root is the only thing reaching it, so
+        // without the restriction every sibling of the pattern would be scanned as well.
+        let covered = bypassing_roots.iter().any(|root| base.starts_with(root))
+            || (auto_roots
+                .iter()
+                .any(|root| base.starts_with(root) && !crosses_ignored_content_dir(root, base))
+                && !is_ignored_by_gitignore(base, gitignores, cwd));
+
+        if covered {
             expanded.push(source);
             continue;
         }
@@ -182,7 +209,10 @@ fn expand_restricted_patterns(sources: Vec<SourceEntry>) -> Vec<SourceEntry> {
             // When another source root is nested inside this base — an unrestricted root, or the
             // base of another restricted pattern (which is walked from its own root with its own
             // rules) — only ignore direct children so the nested root can still be walked.
-            let has_nested_root = unrestricted_roots.iter().any(|root| root.starts_with(base))
+            let has_nested_root = bypassing_roots
+                .iter()
+                .chain(auto_roots.iter())
+                .any(|root| root.starts_with(base))
                 || pattern_roots
                     .iter()
                     .any(|root| root != base && root.starts_with(base));
@@ -233,6 +263,90 @@ fn expand_restricted_patterns(sources: Vec<SourceEntry>) -> Vec<SourceEntry> {
     }
 
     expanded
+}
+
+/// Whether the relative path from `root` down to `base` crosses a directory that auto source
+/// detection ignores by default (e.g. `node_modules`), meaning a walk from `root` never reaches
+/// `base`.
+fn crosses_ignored_content_dir(root: &Path, base: &Path) -> bool {
+    let Ok(relative) = base.strip_prefix(root) else {
+        return false;
+    };
+
+    relative.components().any(|component| match component {
+        Component::Normal(part) => IGNORED_CONTENT_DIRS
+            .iter()
+            .any(|dir| part.to_string_lossy() == *dir),
+        _ => false,
+    })
+}
+
+/// Whether `base` is ignored by a `.gitignore` file in one of its ancestor directories.
+///
+/// Walk up from the folder, applying each `.gitignore` relative to the directory that contains it
+/// (matching git), and stop at the git repository root so `.gitignore` files outside of the repo
+/// are not considered.
+fn is_ignored_by_gitignore(
+    base: &Path,
+    gitignores: &mut FxHashMap<PathBuf, Option<Gitignore>>,
+    cwd: Option<&Path>,
+) -> bool {
+    let inside_git_repo = base.ancestors().any(|dir| dir.join(".git").exists());
+
+    for dir in base.ancestors() {
+        let gitignore = gitignores.entry(dir.to_path_buf()).or_insert_with(|| {
+            let path = dir.join(".gitignore");
+
+            // `Gitignore::new` roots the matcher at the directory containing the file, so
+            // patterns match relative to it.
+            path.is_file().then(|| Gitignore::new(&path).0)
+        });
+
+        // Only `.gitignore` files in ancestors of `base` can ignore `base` itself. Patterns in
+        // `base`'s own `.gitignore` only match paths _inside_ `base`, never `base` itself (the
+        // file walker still applies them to `base`'s contents).
+        //
+        // Skipping `base`'s own `.gitignore` also prevents a false positive for whitelist style
+        // `.gitignore` files, because relativizing `base` against itself yields the empty path,
+        // which incorrectly matches `/*`.
+        //
+        // E.g.:
+        //
+        // ```gitignore
+        // /*
+        // !/.gitignore
+        // !/app
+        // !/public
+        // ```
+        //
+        // Everything inside `base` except `.gitignore`, `app` and `public` is ignored, but `base`
+        // itself is not.
+        if dir != base {
+            if let Some(gitignore) = gitignore {
+                if gitignore
+                    .matched_path_or_any_parents(base, true)
+                    .is_ignore()
+                {
+                    return true;
+                }
+            }
+        }
+
+        // Stop at the git repository root.
+        if dir.join(".git").exists() {
+            break;
+        }
+
+        // Without a git repository there is no repository root to stop at. Stop once the
+        // directory contains the current working directory instead, so `.gitignore` files outside
+        // of the project (e.g. in the user's home directory) can never apply. Note that the file
+        // walker still applies those `.gitignore` files when deciding which files to scan.
+        if !inside_git_repo && cwd.is_some_and(|cwd| cwd.starts_with(dir)) {
+            break;
+        }
+    }
+
+    false
 }
 
 impl PublicSourceEntry {
@@ -563,6 +677,122 @@ mod tests {
     }
 
     #[test]
+    fn concrete_patterns_in_covered_subdirs_are_not_restricted() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src").join("components")).unwrap();
+        let root = dunce::canonicalize(dir.path()).unwrap();
+        let components = dunce::canonicalize(dir.path().join("src").join("components")).unwrap();
+
+        let sources = public_source_entries_to_private_source_entries(vec![
+            PublicSourceEntry {
+                base: root.to_string_lossy().to_string(),
+                pattern: "**/*".to_string(),
+                negated: false,
+            },
+            PublicSourceEntry {
+                base: root.to_string_lossy().to_string(),
+                pattern: "src/components/foo.html".to_string(),
+                negated: false,
+            },
+        ]);
+
+        // The auto walk reaches `src/components`, so restricting it would hide siblings the
+        // auto source is supposed to pick up.
+        assert_eq!(
+            sources,
+            vec![
+                SourceEntry::Auto { base: root },
+                SourceEntry::Pattern {
+                    base: components,
+                    pattern: "/foo.html".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn concrete_patterns_behind_default_ignored_dirs_are_restricted_inside_an_auto_root() {
+        let dir = tempdir().unwrap();
+        let ui = dir
+            .path()
+            .join("node_modules")
+            .join(".generated")
+            .join("ui");
+        fs::create_dir_all(&ui).unwrap();
+        let root = dunce::canonicalize(dir.path()).unwrap();
+        let ui = dunce::canonicalize(&ui).unwrap();
+
+        let sources = public_source_entries_to_private_source_entries(vec![
+            PublicSourceEntry {
+                base: root.to_string_lossy().to_string(),
+                pattern: "**/*".to_string(),
+                negated: false,
+            },
+            PublicSourceEntry {
+                base: root.to_string_lossy().to_string(),
+                pattern: "node_modules/.generated/ui/button.ts".to_string(),
+                negated: false,
+            },
+        ]);
+
+        // The auto walk prunes `node_modules`, so the pattern's own walk root is the only thing
+        // reaching the file and the base must be restricted to it.
+        assert_eq!(
+            sources,
+            vec![
+                SourceEntry::Auto { base: root },
+                SourceEntry::Ignored {
+                    base: ui.clone(),
+                    pattern: "*".to_string(),
+                },
+                SourceEntry::Pattern {
+                    base: ui,
+                    pattern: "/button.ts".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn concrete_patterns_in_gitignored_dirs_are_restricted_inside_an_auto_root() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".git")).unwrap();
+        fs::write(dir.path().join(".gitignore"), "generated/\n").unwrap();
+        let ui = dir.path().join("generated").join("ui");
+        fs::create_dir_all(&ui).unwrap();
+        let root = dunce::canonicalize(dir.path()).unwrap();
+        let ui = dunce::canonicalize(&ui).unwrap();
+
+        let sources = public_source_entries_to_private_source_entries(vec![
+            PublicSourceEntry {
+                base: root.to_string_lossy().to_string(),
+                pattern: "**/*".to_string(),
+                negated: false,
+            },
+            PublicSourceEntry {
+                base: root.to_string_lossy().to_string(),
+                pattern: "generated/ui/button.ts".to_string(),
+                negated: false,
+            },
+        ]);
+
+        assert_eq!(
+            sources,
+            vec![
+                SourceEntry::Auto { base: root },
+                SourceEntry::Ignored {
+                    base: ui.clone(),
+                    pattern: "*".to_string(),
+                },
+                SourceEntry::Pattern {
+                    base: ui,
+                    pattern: "/button.ts".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn restricted_parent_bases_do_not_open_unrelated_siblings() {
         let dir = tempdir().unwrap();
         let project = dir.path().join("Users").join("robin").join("docus-test");
@@ -780,64 +1010,8 @@ pub fn public_source_entries_to_private_source_entries(
 
             // Promote auto-sources to external sources if they were gitignored
             if let SourceEntry::Auto { ref base } = source {
-                let inside_git_repo = base.ancestors().any(|dir| dir.join(".git").exists());
-
-                // Walk up from the folder, applying each `.gitignore` relative to the directory
-                // that contains it (matching git), and stop at the git repository root so
-                // `.gitignore` files outside of the repo are not considered.
-                for dir in base.ancestors() {
-                    let gitignore = gitignores.entry(dir.to_path_buf()).or_insert_with(|| {
-                        let path = dir.join(".gitignore");
-
-                        // `Gitignore::new` roots the matcher at the directory containing the file,
-                        // so patterns match relative to it.
-                        path.is_file().then(|| Gitignore::new(&path).0)
-                    });
-
-                    // Only `.gitignore` files in ancestors of `base` can ignore `base` itself.
-                    // Patterns in `base`'s own `.gitignore` only match paths _inside_ `base`, never
-                    // `base` itself (the file walker still applies them to `base`'s contents).
-                    //
-                    // Skipping `base`'s own `.gitignore` also prevents a false positive for
-                    // whitelist style `.gitignore` files, because relativizing `base` against
-                    // itself yields the empty path, which incorrectly matches `/*`.
-                    //
-                    // E.g.:
-                    //
-                    // ```gitignore
-                    // /*
-                    // !/.gitignore
-                    // !/app
-                    // !/public
-                    // ```
-                    //
-                    // Everything inside `base` except `.gitignore`, `app` and `public` is ignored,
-                    // but `base` itself is not.
-                    if dir != base {
-                        if let Some(gitignore) = gitignore {
-                            if gitignore
-                                .matched_path_or_any_parents(&base, true)
-                                .is_ignore()
-                            {
-                                source = SourceEntry::External { base: base.into() };
-                                break;
-                            }
-                        }
-                    }
-
-                    // Stop at the git repository root.
-                    if dir.join(".git").exists() {
-                        break;
-                    }
-
-                    // Without a git repository there is no repository root to stop at. Stop once
-                    // the directory contains the current working directory instead, so `.gitignore`
-                    // files outside of the project (e.g. in the user's home directory) can never
-                    // promote a source to an external source. Note that the file walker still
-                    // applies those `.gitignore` files when deciding which files to scan.
-                    if !inside_git_repo && cwd.as_ref().is_some_and(|cwd| cwd.starts_with(dir)) {
-                        break;
-                    }
+                if is_ignored_by_gitignore(base, &mut gitignores, cwd.as_deref()) {
+                    source = SourceEntry::External { base: base.into() };
                 }
             }
 
@@ -845,7 +1019,7 @@ pub fn public_source_entries_to_private_source_entries(
         })
         .collect::<Vec<SourceEntry>>();
 
-    expand_restricted_patterns(sources)
+    expand_restricted_patterns(sources, &mut gitignores, cwd.as_deref())
 }
 
 /// Convert a public source entry to a source entry

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -2148,6 +2148,45 @@ mod scanner {
     }
 
     #[test]
+    fn test_concrete_file_source_in_node_modules_does_not_include_siblings() {
+        let ScanResult { candidates, .. } = scan_with_globs(
+            &[
+                (".gitignore", "node_modules\n"),
+                ("src/index.html", "content-['src/index.html']"),
+                ("node_modules/.generated/ui/button.ts", "content-['button']"),
+                ("node_modules/.generated/ui/table.ts", "content-['table']"),
+            ],
+            vec![
+                "@source './'",
+                "@source './node_modules/.generated/ui/button.ts'",
+            ],
+        );
+
+        assert_eq!(
+            candidates,
+            vec!["content-['button']", "content-['src/index.html']"]
+        );
+    }
+
+    #[test]
+    fn test_concrete_file_source_in_gitignored_dir_does_not_include_siblings() {
+        let ScanResult { candidates, .. } = scan_with_globs(
+            &[
+                (".gitignore", "generated\n"),
+                ("index.html", "content-['index.html']"),
+                ("generated/ui/button.ts", "content-['button']"),
+                ("generated/ui/table.ts", "content-['table']"),
+            ],
+            vec!["@source './'", "@source './generated/ui/button.ts'"],
+        );
+
+        assert_eq!(
+            candidates,
+            vec!["content-['button']", "content-['index.html']"]
+        );
+    }
+
+    #[test]
     fn test_ignore_node_modules_without_gitignore() {
         let ScanResult {
             candidates,

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -2169,6 +2169,31 @@ mod scanner {
     }
 
     #[test]
+    fn test_concrete_file_source_in_reincluded_dir_keeps_siblings() {
+        let ScanResult { candidates, .. } = scan_with_globs(
+            &[
+                (".gitignore", "generated\n"),
+                ("sub/.gitignore", "!generated\n"),
+                ("index.html", "content-['index.html']"),
+                ("sub/generated/ui/button.ts", "content-['button']"),
+                ("sub/generated/ui/table.ts", "content-['table']"),
+            ],
+            vec!["@source './'", "@source './sub/generated/ui/button.ts'"],
+        );
+
+        // `sub/.gitignore` re-includes `generated`, so the auto walk reaches it and its files:
+        // the concrete source must not restrict the directory to just `button.ts`.
+        assert_eq!(
+            candidates,
+            vec![
+                "content-['button']",
+                "content-['index.html']",
+                "content-['table']"
+            ]
+        );
+    }
+
+    #[test]
     fn test_concrete_file_source_in_gitignored_dir_does_not_include_siblings() {
         let ScanResult { candidates, .. } = scan_with_globs(
             &[


### PR DESCRIPTION
## Summary

A concrete file `@source` that sits inside an auto detection root scans the file's entire parent directory:

```css
@source "./node_modules/.generated/ui/button.ts";
```

With the project root as an auto source, every sibling of `button.ts` is scanned and their classes end up in the output. The same directive works correctly when it points outside the root (since #20263).

This is the remaining half of #20255. `expand_restricted_patterns` skips the `*` + `!<pattern>` restriction when the pattern's base is inside an unrestricted root, because everything under that root is walked anyway. But that's not true when the base hides behind a directory the auto walk prunes, like `node_modules` or a git-ignored folder. In that case the pattern's own walk root is the only thing reaching the file, and its ignore rules are just:

```gitignore
!button.ts
```

so all the siblings are walked and included too.

To fix this, an auto root only counts as covering a pattern base when its walk actually reaches it: the path down to the base doesn't cross a default-ignored directory and the base isn't git-ignored. The git-ignored check reuses the ancestor `.gitignore` walk (and cache) that already promotes auto sources to external sources. External roots and `**` patterns still cover everything under them, and patterns in ordinary subdirectories behave like before, restricting those would hide siblings the auto source should pick up.

The `.gitignore` walk now follows git's precedence: the nearest `.gitignore` with a definitive answer wins, so a directory re-included by a deeper `!dir` pattern is not treated as ignored. Because that walk is shared, re-included directory sources also stay auto sources instead of being promoted to external ones.

For context, I ran into this in Nuxt UI: we emit per-component `@source` lines into `node_modules/.nuxt-ui`, and the narrowed list produced byte-identical CSS to sourcing the whole directory (nuxt/ui#6731).

## Test plan

- Three new integration tests: concrete file sources behind `node_modules` and behind a git-ignored directory (both failed before with the sibling's candidates included), and a re-included directory where the siblings must stay.
- Three new unit tests for `expand_restricted_patterns`, including a control for patterns in ordinary covered subdirectories.
- `cargo test --workspace` passes, `cargo fmt --check` clean, no new clippy warnings.
- Verified end to end with `@tailwindcss/vite` on Vite 8 by patching the built oxide binary into a reproduction project: a file `@source` inside the root now only ships that file's classes; whole-directory sources and auto detection are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
