### PR TITLE
Fix slow Vite rebuilds in projects with large gitignored directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve whitespace in `--default(…)` values in custom functional utilities (e.g. `--default(box alphabetic)` no longer becomes `boxalphabetic`) ([#20392](https://github.com/tailwindlabs/tailwindcss/pull/20392))
 - Don't scan gitignored directories (e.g. `node_modules` and `.git`) when the project uses a safelist-style `.gitignore` (e.g. `/*` followed by `!/…` negations) ([#20397](https://github.com/tailwindlabs/tailwindcss/discussions/20397))
 - Ensure root `theme('…')` namespace lookups in JavaScript plugins and config files return the full namespace object instead of the value of its `DEFAULT` key ([#20399](https://github.com/tailwindlabs/tailwindcss/pull/20399))
-- Skip ignored directories entirely when computing watch globs (`scanner.globs`), instead of walking their full contents on every rebuild ([#TBD](https://github.com/tailwindlabs/tailwindcss/pulls))
+- Skip ignored directories entirely when computing watch globs (`scanner.globs`), instead of walking their full contents on every rebuild ([#20408](https://github.com/tailwindlabs/tailwindcss/pull/20408))
 
 ## [4.3.3] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve whitespace in `--default(…)` values in custom functional utilities (e.g. `--default(box alphabetic)` no longer becomes `boxalphabetic`) ([#20392](https://github.com/tailwindlabs/tailwindcss/pull/20392))
 - Don't scan gitignored directories (e.g. `node_modules` and `.git`) when the project uses a safelist-style `.gitignore` (e.g. `/*` followed by `!/…` negations) ([#20397](https://github.com/tailwindlabs/tailwindcss/discussions/20397))
 - Ensure root `theme('…')` namespace lookups in JavaScript plugins and config files return the full namespace object instead of the value of its `DEFAULT` key ([#20399](https://github.com/tailwindlabs/tailwindcss/pull/20399))
+- Skip ignored directories entirely when computing watch globs (`scanner.globs`), instead of walking their full contents on every rebuild ([#TBD](https://github.com/tailwindlabs/tailwindcss/pulls))
 
 ## [4.3.3] - 2026-07-16
 

--- a/crates/oxide/src/scanner/detect_sources.rs
+++ b/crates/oxide/src/scanner/detect_sources.rs
@@ -112,6 +112,7 @@ pub fn resolve_globs(
         }
 
         if !dirs.contains(path) {
+            it.skip_current_dir();
             continue;
         }
 

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -2641,6 +2641,31 @@ mod scanner {
         assert_eq!(candidates, vec!["content-['b']"]);
     }
 
+    // https://github.com/tailwindlabs/tailwindcss/pull/20408
+    #[test]
+    fn test_resolving_globs_does_not_traverse_gitignored_directories() {
+        let ScanResult { files, globs, .. } = scan_with_globs(
+            &[
+                (".gitignore", "/vendor\n"),
+                ("vendor/pkg/canary/index.html", ""),
+                ("src/index.html", ""),
+            ],
+            vec!["@source '**/*'", "@source './vendor/pkg/canary'"],
+        );
+
+        assert_eq!(
+            files,
+            vec!["src/index.html", "vendor/pkg/canary/index.html"]
+        );
+        assert_eq!(globs, vec![
+            "*",
+            "src/**/*.{aspx,astro,cjs,cts,eex,erb,gjs,gts,haml,handlebars,hbs,heex,html,jade,js,jsx,liquid,md,mdx,mjs,mts,mustache,njk,nunjucks,php,pug,py,razor,rb,rhtml,rs,slim,svelte,tpl,ts,tsx,twig,vue}",
+
+            // This should not include `**` or `**.*.{aspx,...}` otherwise this might be scanned recursively.
+            "vendor/pkg/canary/*",
+        ]);
+    }
+
     #[test]
     fn test_extract_used_css_variables_from_css() {
         let dir = tempdir().unwrap().into_path();


### PR DESCRIPTION
Preface: For full transparency, I used AI (Claude) to help dig into this issue we're having and write some of the explanation below.

Our local Laravel application (with Docker) takes between 2-6s seconds (re)building `app.css` after each Blade file update. After checking with Claude, there seems to be some potential unnecessary traversing of big (gitignored) directories, specifically `vendor` and `storage`.

As far as I understand it, two scans happen in tailwindcss:

- a first scan, the content scan. This one reads the project files (auto-detect). It respects .gitignore, so it correctly skips vendor/ and storage/.

- a second scan, the glob resolution (resolve_globs() in the oxide crate). It builds watch patterns that the Vite plugin registers, so a file save can trigger a CSS rebuild. It walks the project again, but this walk does not respect .gitignore. It only skips a hardcoded list of directory names from `ignored-content-dirs.txt` (node_modules, .git, venv, ...). vendor/ and storage/ are not on that list, so it descends into them and stats every file. These directories can never produce a watch pattern, because the content scan never visited them. That work is perhaps wasted?

Maybe why this went unnoticed: on a native filesystem a stat takes about 1µs, so 57k of them is around 0.06s. A Docker bind mount multiplies that by roughly 100. And the big directory in a typical JS project is `node_modules`, which the name list already catches; `vendor/` is the PHP ecosystem's `node_modules`, and it is not on that list. (#19616 / #19632 fixed the same problem for `scanner.files`; the CLI never reads `scanner.globs`, so it was never affected.)

The fix: the second walk now skips any directory the scan never visited, the same pruning the first walk (line 73) already does.

Measured on our local project: `get_globs()` after `scan()` went from 9.9s to somewhere between 0.2 and 1.0s across runs, with identical output (35 globs). A template save now reloads in about 0.3s instead of 4.

## Test plan

- `cargo test` in `crates/oxide`: 66 tests pass, including the glob assertions for nested and gitignored directories in `tests/scanner.rs`.
- Compared the sorted `get_globs()` output before and after on the project above: identical.

I've also set up a repo that reproduces the issue in a fresh Laravel app:

https://github.com/marickvantuil/tailwind-scan-reproduce

The results:

| Environment | vendor/ | scan | get_globs | syscalls under vendor/ |
| --- | --- | --- | --- | --- |
| GitHub Actions (native FS) | present | 5.0 ms | 48.8 ms | 11,410 |
| GitHub Actions (native FS) | absent | 4.5 ms | 0.9 ms | n/a |
| macOS, Docker bind mount | present | 15.8 ms | 599.4 ms | 11,410 |
| macOS, Docker bind mount | absent | 16.5 ms | 6.5 ms | n/a |