### PR TITLE
Visualize scanner related tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +136,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "errno"
@@ -297,6 +314,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "overload"
@@ -603,6 +632,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +682,7 @@ dependencies = [
  "fast-glob",
  "globwalk",
  "ignore 0.4.33",
+ "insta",
  "log",
  "pretty_assertions",
  "rayon",
@@ -830,6 +866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -20,6 +20,7 @@ ignore = { path = "../ignore" }
 regex = "1.11.1"
 
 [dev-dependencies]
+insta = "1.48.0"
 tempfile = "3.13.0"
 pretty_assertions = "1.4.1"
 unicode-width = "0.2.0"

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -118,11 +118,15 @@ mod scanner {
                 }
                 if file_type.is_symlink() {
                     if let Ok(target) = fs::read_link(&path) {
-                        let target = target
+                        let mut target = target
                             .strip_prefix(root)
                             .unwrap_or(&target)
                             .to_string_lossy()
                             .replace('\\', "/");
+                        if target.is_empty() {
+                            // The symlink points to the root itself
+                            target = ".".into();
+                        }
                         display_name = format!("{name} → {target}");
 
                         // The symlink points to a target that doesn't exist
@@ -3512,11 +3516,14 @@ mod scanner {
             ],
         );
 
-        // Create recursive symlinks
-        let _ = symlink(dir.join("a"), dir.join("b"));
-        let _ = symlink(dir.join("b/c"), dir.join("c"));
-        let _ = symlink(dir.join("b/root"), &dir);
-        let _ = symlink(dir.join("c"), dir.join("a"));
+        // Create recursive symlinks:
+        //
+        // - `a → b`, `b/c → c`, `c → a` form a cycle
+        // - `b/root → .` points back at the root directory
+        let _ = symlink(dir.join("b"), dir.join("a"));
+        let _ = symlink(dir.join("c"), dir.join("b/c"));
+        let _ = symlink(&dir, dir.join("b/root"));
+        let _ = symlink(dir.join("a"), dir.join("c"));
 
         let mut scanner = Scanner::new(vec![public_source_entry_from_pattern(
             dir.clone(),
@@ -3526,10 +3533,18 @@ mod scanner {
 
         assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
         .
-        ├── ✗ a → c (broken)
+        ├── ✓ a → b
+        │   ├── ✗ c → c
+        │   ├── ✓ index.html
+        │   └── ✗ root → .
         ├── ✓ b
-        │   └── ✓ index.html
-        ├── ✗ c → b/c (broken)
+        │   ├── ✗ c → c
+        │   ├── ✓ index.html
+        │   └── ✗ root → .
+        ├── ✓ c → a
+        │   ├── ✗ c → c
+        │   ├── ✓ index.html
+        │   └── ✗ root → .
         └── ✓ z
             └── ✓ index.html
         ");

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod scanner {
+    use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
     use std::path::{Path, PathBuf};
     use std::process::Command;
@@ -55,6 +56,126 @@ mod scanner {
         globs: Vec<String>,
         normalized_sources: Vec<String>,
         candidates: Vec<String>,
+        tree: String,
+    }
+
+    /// Renders the directory as a tree, annotating every file and folder with
+    /// an indicator that shows whether the scanner picked it up:
+    ///
+    /// - `✓` — scanned
+    /// - `✗` — ignored / skipped
+    ///
+    /// Symlinks are rendered as `link → target`, and the contents of every
+    /// `.gitignore` file are printed right below the file itself.
+    ///
+    /// Folders that are a git repository root (they contain a `.git` folder)
+    /// are marked with `(git)`, because ignore rules behave differently
+    /// inside and outside of a repository.
+    fn fs_tree(root: &Path, scanned: &[String]) -> String {
+        fn walk(
+            dir: &Path,
+            root: &Path,
+            prefix: &str,
+            scanned: &[String],
+            visited: &mut Vec<PathBuf>,
+            out: &mut String,
+        ) {
+            let mut entries = fs::read_dir(dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name() != ".git")
+                .collect::<Vec<_>>();
+            entries.sort_by_key(|entry| entry.file_name());
+
+            for (i, entry) in entries.iter().enumerate() {
+                let last = i == entries.len() - 1;
+                let connector = if last { "└── " } else { "├── " };
+                let child_prefix = if last { "    " } else { "│   " };
+
+                let path = entry.path();
+                let name = entry.file_name().to_string_lossy().to_string();
+                let rel = path
+                    .strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/");
+
+                let file_type = entry.file_type().unwrap();
+
+                // A file is scanned when it shows up in the scanned files
+                // list. A folder is considered scanned when any scanned file
+                // lives inside of it. Paths that go through a symlink count
+                // towards the symlink, not towards the target directory.
+                let dir_prefix = format!("{rel}/");
+                let is_scanned = scanned
+                    .iter()
+                    .any(|file| file == &rel || file.starts_with(&dir_prefix));
+                let indicator = if is_scanned { "✓" } else { "✗" };
+
+                let mut display_name = name.clone();
+                if path.join(".git").exists() {
+                    display_name = format!("{display_name} (git)");
+                }
+                if file_type.is_symlink() {
+                    if let Ok(target) = fs::read_link(&path) {
+                        let target = target
+                            .strip_prefix(root)
+                            .unwrap_or(&target)
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        display_name = format!("{name} → {target}");
+                    }
+                }
+
+                out.push_str(&format!("{prefix}{connector}{indicator} {display_name}\n"));
+
+                // Print the contents of `.gitignore` files below the file
+                // itself, so the ignore rules are visible in the same output.
+                if name == ".gitignore" {
+                    if let Ok(contents) = fs::read_to_string(&path) {
+                        for line in contents.lines() {
+                            let line = format!("{prefix}{child_prefix}    {line}");
+                            out.push_str(line.trim_end());
+                            out.push('\n');
+                        }
+                    }
+                }
+
+                // Descend into directories, including symlinked ones. The
+                // paths inside a symlinked directory are computed through the
+                // symlink, so the indicators show what the scanner saw via
+                // that route. A visited stack prevents symlink cycles from
+                // recursing forever.
+                if path.metadata().map(|meta| meta.is_dir()).unwrap_or(false) {
+                    let Ok(canonical) = dunce::canonicalize(&path) else {
+                        continue;
+                    };
+                    if visited.contains(&canonical) {
+                        continue;
+                    }
+
+                    visited.push(canonical);
+                    walk(
+                        &path,
+                        root,
+                        &format!("{prefix}{child_prefix}"),
+                        scanned,
+                        visited,
+                        out,
+                    );
+                    visited.pop();
+                }
+            }
+        }
+
+        let mut visited = vec![dunce::canonicalize(root).unwrap()];
+        let mut out = if root.join(".git").exists() {
+            String::from(". (git)\n")
+        } else {
+            String::from(".\n")
+        };
+        walk(root, root, "", scanned, &mut visited, &mut out);
+        out
     }
 
     fn create_files_in(dir: &path::Path, paths: &[(&str, &str)]) {
@@ -167,11 +288,14 @@ mod scanner {
             .collect::<Vec<_>>();
         normalized_sources.sort();
 
+        let tree = fs_tree(&dir, &files);
+
         ScanResult {
             files,
             globs,
             normalized_sources,
             candidates,
+            tree,
         }
     }
 
@@ -185,6 +309,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             ("index.html", ""),
@@ -192,6 +317,14 @@ mod scanner {
             ("b.html", ""),
             ("c.html", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ a.html
+        ├── ✓ b.html
+        ├── ✓ c.html
+        └── ✓ index.html
+        ");
         assert_eq!(files, vec!["a.html", "b.html", "c.html", "index.html"]);
         assert_eq!(globs, vec!["*"]);
         assert_eq!(normalized_sources, vec!["**/*"]);
@@ -203,6 +336,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             (".gitignore", "b.html"),
@@ -211,6 +345,17 @@ mod scanner {
             ("b.html", ""),
             ("c.html", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       b.html
+        ├── ✓ a.html
+        ├── ✗ b.html
+        ├── ✓ c.html
+        └── ✓ index.html
+        ");
+
         assert_eq!(files, vec!["a.html", "c.html", "index.html"]);
         assert_eq!(globs, vec!["*"]);
         assert_eq!(normalized_sources, vec!["**/*"]);
@@ -222,6 +367,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             ("index.html", ""),
@@ -231,6 +377,20 @@ mod scanner {
             ("public/nested/c.html", ""),
             ("public/deeply/nested/c.html", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ index.html
+        └── ✓ public
+            ├── ✓ a.html
+            ├── ✓ b.html
+            ├── ✓ c.html
+            ├── ✓ deeply
+            │   └── ✓ nested
+            │       └── ✓ c.html
+            └── ✓ nested
+                └── ✓ c.html
+        ");
 
         assert_eq!(
             files,
@@ -253,6 +413,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             ("index.html", ""),
@@ -265,6 +426,25 @@ mod scanner {
             ("public/nested/again/a.html", ""),
             ("public/very/deeply/nested/a.html", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ index.html
+        └── ✓ public
+            ├── ✓ a.html
+            ├── ✓ b.html
+            ├── ✓ c.html
+            ├── ✓ nested
+            │   ├── ✓ a.html
+            │   ├── ✓ again
+            │   │   └── ✓ a.html
+            │   ├── ✓ b.html
+            │   └── ✓ c.html
+            └── ✓ very
+                └── ✓ deeply
+                    └── ✓ nested
+                        └── ✓ a.html
+        ");
 
         assert_eq!(
             files,
@@ -290,6 +470,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             (".gitignore", "public/b.html\na.html"),
@@ -298,6 +479,18 @@ mod scanner {
             ("public/b.html", ""),
             ("public/c.html", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       public/b.html
+        │       a.html
+        ├── ✓ index.html
+        └── ✓ public
+            ├── ✗ a.html
+            ├── ✗ b.html
+            └── ✓ c.html
+        ");
 
         assert_eq!(files, vec!["index.html", "public/c.html",]);
         assert_eq!(globs, vec!["*"]);
@@ -310,6 +503,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             ("index.html", ""),
@@ -317,6 +511,15 @@ mod scanner {
             ("src/b.html", ""),
             ("src/c.html", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ index.html
+        └── ✓ src
+            ├── ✓ a.html
+            ├── ✓ b.html
+            └── ✓ c.html
+        ");
 
         assert_eq!(
             files,
@@ -335,6 +538,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             ("index.html", ""),
@@ -342,6 +546,14 @@ mod scanner {
             ("b.png", ""),
             ("c.lock", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ a.mp4
+        ├── ✗ b.png
+        ├── ✗ c.lock
+        └── ✓ index.html
+        ");
 
         assert_eq!(files, vec!["index.html"]);
         assert_eq!(globs, vec!["*"]);
@@ -355,6 +567,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             // Looks like `.pages` binary extension, but it's a folder
@@ -368,6 +581,16 @@ mod scanner {
             ),
         ]);
 
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       other.pages
+        ├── ✗ other.pages
+        │   └── ✗ index.html
+        └── ✓ some.pages
+            └── ✓ index.html
+        ");
+
         assert_eq!(files, vec!["some.pages/index.html"]);
         assert_eq!(globs, vec!["*", "some.pages/**/*.{aspx,astro,cjs,cts,eex,erb,gjs,gts,haml,handlebars,hbs,heex,html,jade,js,jsx,liquid,md,mdx,mjs,mts,mustache,njk,nunjucks,php,pug,py,razor,rb,rhtml,rs,slim,svelte,tpl,ts,tsx,twig,vue}"]);
         assert_eq!(normalized_sources, vec!["**/*"]);
@@ -379,6 +602,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             ("index.html", ""),
@@ -386,6 +610,14 @@ mod scanner {
             ("b.sass", ""),
             ("c.less", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ a.css
+        ├── ✗ b.sass
+        ├── ✗ c.less
+        └── ✓ index.html
+        ");
 
         assert_eq!(files, vec!["a.css", "index.html"]);
         assert_eq!(globs, vec!["*"]);
@@ -398,8 +630,15 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[("src/index.my-extension", "")]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            └── ✓ index.my-extension
+        ");
 
         assert_eq!(files, vec!["src/index.my-extension"]);
         assert_eq!(globs, vec!["*", "src/**/*.{aspx,astro,cjs,cts,eex,erb,gjs,gts,haml,handlebars,hbs,heex,html,jade,js,jsx,liquid,md,mdx,mjs,mts,mustache,my-extension,njk,nunjucks,php,pug,py,razor,rb,rhtml,rs,slim,svelte,tpl,ts,tsx,twig,vue}"]);
@@ -412,12 +651,20 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             ("index.html", ""),
             ("package-lock.json", ""),
             ("yarn.lock", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ index.html
+        ├── ✗ package-lock.json
+        └── ✗ yarn.lock
+        ");
 
         assert_eq!(files, vec!["index.html"]);
         assert_eq!(globs, vec!["*"]);
@@ -430,6 +677,7 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             // Explicitly listed root files
@@ -473,6 +721,58 @@ mod scanner {
             ("nested-d/very/deeply/nested/directory/baz.html", ""),
             ("nested-d/very/deeply/nested/directory/again/foo.html", ""),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ bar.html
+        ├── ✓ baz.html
+        ├── ✓ foo.html
+        ├── ✓ nested-a
+        │   ├── ✓ bar.html
+        │   ├── ✓ baz.html
+        │   └── ✓ foo.html
+        ├── ✓ nested-b
+        │   └── ✓ deeply-nested
+        │       ├── ✓ bar.html
+        │       ├── ✓ baz.html
+        │       └── ✓ foo.html
+        ├── ✓ nested-c
+        │   ├── ✗ .gitignore
+        │   │       ignored-folder/
+        │   ├── ✓ bar.html
+        │   ├── ✓ baz.html
+        │   ├── ✓ foo.html
+        │   ├── ✗ ignored-folder
+        │   │   ├── ✗ bar.html
+        │   │   ├── ✗ baz.html
+        │   │   └── ✗ foo.html
+        │   └── ✓ sibling-folder
+        │       ├── ✓ bar.html
+        │       ├── ✓ baz.html
+        │       └── ✓ foo.html
+        └── ✓ nested-d
+            ├── ✗ .gitignore
+            │       deep/
+            ├── ✓ bar.html
+            ├── ✓ baz.html
+            ├── ✓ foo.html
+            └── ✓ very
+                └── ✓ deeply
+                    └── ✓ nested
+                        ├── ✓ bar.html
+                        ├── ✓ baz.html
+                        ├── ✗ deep
+                        │   ├── ✗ bar.html
+                        │   ├── ✗ baz.html
+                        │   └── ✗ foo.html
+                        ├── ✓ directory
+                        │   ├── ✓ again
+                        │   │   └── ✓ foo.html
+                        │   ├── ✓ bar.html
+                        │   ├── ✓ baz.html
+                        │   └── ✓ foo.html
+                        └── ✓ foo.html
+        ");
 
         assert_eq!(
             files,
@@ -528,6 +828,7 @@ mod scanner {
         let ScanResult {
             candidates,
             normalized_sources,
+            tree,
             ..
         } = scan(&[
             // The gitignore file is used to filter out files but not scanned for candidates
@@ -549,6 +850,21 @@ mod scanner {
             ("index3.svelte", "<div\n  class:px-6='condition'></div>"),
             ("index4.svelte", "<div\nclass:px-7='condition'></div>"),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       # md:font-bold
+        │       foo.html
+        ├── ✗ foo.html
+        ├── ✗ foo.jpg
+        ├── ✓ index.angular.html
+        ├── ✓ index.html
+        ├── ✓ index.svelte
+        ├── ✓ index2.svelte
+        ├── ✓ index3.svelte
+        └── ✓ index4.svelte
+        ");
 
         assert_eq!(
             candidates,
@@ -573,11 +889,20 @@ mod scanner {
         let ScanResult {
             candidates,
             normalized_sources,
+            tree,
             ..
         } = scan_with_globs(
             &[("foo/bar/baz/foo.html", "content-['foo.html']")],
             vec!["@source '**/*'", "@source './foo/bar/baz/..'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ foo
+            └── ✓ bar
+                └── ✓ baz
+                    └── ✓ foo.html
+        ");
 
         assert_eq!(candidates, vec!["content-['foo.html']"]);
         assert_eq!(normalized_sources, vec!["**/*", "foo/bar/**/*"]);
@@ -610,6 +935,19 @@ mod scanner {
         ]);
         let candidates = scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ project-a
+        │   └── ✗ src
+        │       └── ✗ index.css
+        └── ✓ project-b
+            ├── ✓ ignored
+            │   ├── ✓ except.html
+            │   └── ✗ ignored.html
+            └── ✓ keep
+                └── ✓ keep.html
+        ");
+
         assert_eq!(candidates, vec!["content-['GOOD-1']", "content-['GOOD-2']"]);
     }
 
@@ -619,11 +957,17 @@ mod scanner {
         let ScanResult {
             candidates,
             normalized_sources,
+            tree,
             ..
         } = scan_with_globs(
             &[("my-file", "content-['my-file']")],
             vec!["@source '**/*'", "@source './my-file'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ my-file
+        ");
 
         assert_eq!(candidates, vec!["content-['my-file']"]);
         assert_eq!(normalized_sources, vec!["**/*", "my-file"]);
@@ -635,6 +979,7 @@ mod scanner {
         let ScanResult {
             candidates,
             normalized_sources,
+            tree,
             ..
         } = scan_with_globs(
             &[
@@ -654,6 +999,14 @@ mod scanner {
             ],
         );
 
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ my-folder.bin
+        │   └── ✓ foo.html
+        └── ✓ my-folder.templates
+            └── ✓ foo.html
+        ");
+
         assert_eq!(
             candidates,
             vec![
@@ -672,6 +1025,7 @@ mod scanner {
         let ScanResult {
             candidates,
             normalized_sources,
+            tree,
             ..
         } = scan_with_globs(
             &[
@@ -681,6 +1035,11 @@ mod scanner {
             ],
             vec!["@source '**/*'", "@source '*.styl'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ foo.styl
+        ");
 
         assert_eq!(candidates, vec!["content-['foo.styl']"]);
         assert_eq!(normalized_sources, vec!["**/*", "*.styl"]);
@@ -693,6 +1052,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 (
@@ -706,6 +1067,18 @@ mod scanner {
             ],
             vec!["@source './blog/*/foo/bar/baz/**/*'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ blog
+            └── ✓ 2024
+                └── ✓ foo
+                    └── ✓ bar
+                        ├── ✓ baz
+                        │   └── ✓ index.html
+                        └── ✗ qux
+                            └── ✗ index.html
+        ");
 
         assert_eq!(
             candidates,
@@ -721,6 +1094,7 @@ mod scanner {
         let ScanResult {
             candidates,
             normalized_sources,
+            tree,
             ..
         } = scan_with_globs(
             &[
@@ -733,6 +1107,19 @@ mod scanner {
             ],
             vec!["@source '**/*'", "@source './**/*.{styl}'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ app
+            ├── ✓ (theme)
+            │   └── ✓ page.styl
+            ├── ✓ [...slug]
+            │   └── ✓ page.styl
+            ├── ✓ [[...slug]]
+            │   └── ✓ page.styl
+            └── ✓ [slug]
+                └── ✓ page.styl
+        ");
 
         assert_eq!(
             candidates,
@@ -775,6 +1162,14 @@ mod scanner {
         let mut scanner = Scanner::new(sources);
         let candidates = scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        ├── ✓ project-a
+        │   └── ✓ index.html
+        └── ✓ project-b
+            └── ✓ index.html
+        ");
+
         // We've done the initial scan and found the files
         assert_eq!(
             candidates,
@@ -790,6 +1185,7 @@ mod scanner {
         let ScanResult {
             candidates,
             normalized_sources,
+            tree,
             ..
         } = scan_with_globs(
             &[
@@ -801,6 +1197,13 @@ mod scanner {
             // But explicitly including them should still work
             vec!["@source '**/*'", "@source 'foo.styl'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       foo.styl
+        └── ✓ foo.styl
+        ");
 
         assert_eq!(candidates, vec!["content-['foo.styl']"]);
         assert_eq!(normalized_sources, vec!["**/*", "foo.styl"]);
@@ -830,6 +1233,14 @@ mod scanner {
 
         let mut scanner = Scanner::new(sources);
         let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        ├── ✓ project-a
+        │   └── ✓ index.html
+        └── ✓ project-b
+            └── ✓ index.html
+        ");
 
         // We've done the initial scan and found the files
         assert_eq!(
@@ -935,6 +1346,24 @@ mod scanner {
                 "content-['project-b/sub1/sub2/new.html']"
             ]
         );
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        ├── ✓ project-a
+        │   ├── ✓ index.html
+        │   ├── ✓ new.html
+        │   └── ✓ sub1
+        │       └── ✓ sub2
+        │           ├── ✓ index.html
+        │           └── ✓ new.html
+        └── ✓ project-b
+            ├── ✓ index.html
+            ├── ✓ new.html
+            └── ✓ sub1
+                └── ✓ sub2
+                    ├── ✓ index.html
+                    └── ✓ new.html
+        ");
     }
 
     #[test]
@@ -966,6 +1395,14 @@ mod scanner {
             vec!["src/index.html", "src/keep.html", "src/remove.html"]
         );
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        └── ✓ src
+            ├── ✓ index.html
+            ├── ✓ keep.html
+            └── ✓ remove.html
+        ");
+
         fs::remove_file(dir.join("src/remove.html")).unwrap();
 
         scanner.scan();
@@ -973,6 +1410,13 @@ mod scanner {
             scanned_files(&mut scanner, &dir),
             vec!["src/index.html", "src/keep.html"]
         );
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        └── ✓ src
+            ├── ✓ index.html
+            └── ✓ keep.html
+        ");
     }
 
     #[test]
@@ -1013,6 +1457,18 @@ mod scanner {
             ]
         );
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        └── ✓ src
+            ├── ✓ index.html
+            ├── ✓ keep
+            │   └── ✓ index.html
+            └── ✓ remove
+                ├── ✓ index.html
+                └── ✓ nested
+                    └── ✓ index.html
+        ");
+
         fs::remove_dir_all(dir.join("src/remove")).unwrap();
 
         scanner.scan();
@@ -1020,6 +1476,14 @@ mod scanner {
             scanned_files(&mut scanner, &dir),
             vec!["src/index.html", "src/keep/index.html"]
         );
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        └── ✓ src
+            ├── ✓ index.html
+            └── ✓ keep
+                └── ✓ index.html
+        ");
     }
 
     #[test]
@@ -1046,12 +1510,24 @@ mod scanner {
 
         scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        ├── ✓ index.html
+        └── ✓ src
+            └── ✓ index.html
+        ");
+
         let globs = scanned_globs(&mut scanner, &dir);
         assert!(globs.iter().any(|glob| glob.starts_with("src/**/*")));
 
         fs::remove_dir_all(dir.join("src")).unwrap();
 
         scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        . (git)
+        └── ✓ index.html
+        ");
 
         let globs = scanned_globs(&mut scanner, &dir);
         assert!(!globs.iter().any(|glob| glob.starts_with("src/**/*")));
@@ -1111,6 +1587,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("src/index.ts", "content-['src/index.ts']"),
@@ -1137,6 +1615,25 @@ mod scanner {
                 "@source not 'dist'",
             ],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            ├── ✓ admin
+            │   └── ✓ foo
+            │       └── ✓ template.html
+            ├── ✗ colors
+            │   ├── ✗ blue.tsx
+            │   ├── ✗ green.tsx
+            │   └── ✗ red.jsx
+            ├── ✗ index.ts
+            ├── ✓ templates
+            │   └── ✓ index.html
+            └── ✗ utils
+                ├── ✗ date.ts
+                ├── ✗ file.ts
+                └── ✗ string.ts
+        ");
 
         assert_eq!(
             candidates,
@@ -1183,6 +1680,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             // Typically skipped
             &[
@@ -1193,6 +1692,15 @@ mod scanner {
             // But explicitly included
             vec!["@source '**/*'", "@source 'src/**/*.{exe,bin}'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ out
+        │   └── ✗ out.exe
+        └── ✓ src
+            ├── ✓ index.bin
+            └── ✓ index.exe
+        ");
 
         assert_eq!(
             candidates,
@@ -1221,6 +1729,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("index.html", "content-['index.html']"),
@@ -1245,6 +1755,21 @@ mod scanner {
             ],
         );
 
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ index.html
+        └── ✓ src
+            ├── ✓ admin
+            │   ├── ✗ ignore.html
+            │   └── ✓ index.html
+            ├── ✓ dashboard
+            │   ├── ✗ ignore.html
+            │   └── ✓ index.html
+            ├── ✗ ignore.html
+            ├── ✗ index.html
+            └── ✗ lib.ts
+        ");
+
         assert_eq!(
             candidates,
             vec![
@@ -1264,7 +1789,10 @@ mod scanner {
     #[test]
     fn it_should_restrict_explicit_file_sources_to_the_matching_file() {
         let ScanResult {
-            candidates, files, ..
+            candidates,
+            files,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("src/foo.html", "content-['src/foo.html']"),
@@ -1273,6 +1801,13 @@ mod scanner {
             vec!["@source './src/foo.html'"],
         );
 
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            ├── ✗ bar.html
+            └── ✓ foo.html
+        ");
+
         assert_eq!(candidates, vec!["content-['src/foo.html']"]);
         assert_eq!(files, vec!["src/foo.html"]);
     }
@@ -1280,7 +1815,10 @@ mod scanner {
     #[test]
     fn it_should_combine_multiple_restricted_sources_for_the_same_base() {
         let ScanResult {
-            candidates, files, ..
+            candidates,
+            files,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("src/foo.html", "content-['src/foo.html']"),
@@ -1289,6 +1827,14 @@ mod scanner {
             ],
             vec!["@source './src/foo.html'", "@source './src/bar.html'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            ├── ✓ bar.html
+            ├── ✗ baz.html
+            └── ✓ foo.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1313,7 +1859,10 @@ mod scanner {
         ];
 
         let ScanResult {
-            candidates, files, ..
+            candidates,
+            files,
+            tree,
+            ..
         } = scan_with_globs(
             paths_with_content,
             vec![
@@ -1321,6 +1870,17 @@ mod scanner {
                 "@source './component-sources.classes.txt'",
             ],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ component-sources.classes.txt
+        ├── ✗ ignore-me
+        │   └── ✗ component.html
+        ├── ✗ ignore-me.txt
+        └── ✓ nested
+            ├── ✓ component.html
+            └── ✗ ignore-me.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1336,7 +1896,10 @@ mod scanner {
 
         // Same setup, but with the root-level source declared first
         let ScanResult {
-            candidates, files, ..
+            candidates,
+            files,
+            tree,
+            ..
         } = scan_with_globs(
             paths_with_content,
             vec![
@@ -1344,6 +1907,17 @@ mod scanner {
                 "@source './nested/component.html'",
             ],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ component-sources.classes.txt
+        ├── ✗ ignore-me
+        │   └── ✗ component.html
+        ├── ✗ ignore-me.txt
+        └── ✓ nested
+            ├── ✓ component.html
+            └── ✗ ignore-me.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1361,11 +1935,20 @@ mod scanner {
     #[test]
     fn it_should_allow_later_ignores_to_override_restricted_sources() {
         let ScanResult {
-            candidates, files, ..
+            candidates,
+            files,
+            tree,
+            ..
         } = scan_with_globs(
             &[("src/foo.html", "content-['src/foo.html']")],
             vec!["@source './src/foo.html'", "@source not './src/foo.html'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✗ src
+            └── ✗ foo.html
+        ");
 
         assert!(candidates.is_empty());
         assert!(files.is_empty());
@@ -1375,7 +1958,10 @@ mod scanner {
     fn it_should_handle_sources_with_parent_patterns() {
         {
             let ScanResult {
-                candidates, files, ..
+                candidates,
+                files,
+                tree,
+                ..
             } = scan_with_globs(
                 &[
                     ("src/foo.html", "content-['src/foo.html']"),
@@ -1384,6 +1970,15 @@ mod scanner {
                 ],
                 vec!["@source './src/ba*/*.html'"],
             );
+
+            assert_snapshot!(tree, @"
+            . (git)
+            └── ✓ src
+                ├── ✓ bar
+                │   ├── ✓ ignore.html
+                │   └── ✓ index.html
+                └── ✗ foo.html
+            ");
 
             assert_eq!(
                 candidates,
@@ -1397,7 +1992,10 @@ mod scanner {
 
         {
             let ScanResult {
-                candidates, files, ..
+                candidates,
+                files,
+                tree,
+                ..
             } = scan_with_globs(
                 &[
                     ("src/foo.html", "content-['src/foo.html']"),
@@ -1410,13 +2008,25 @@ mod scanner {
                 ],
             );
 
+            assert_snapshot!(tree, @"
+            . (git)
+            └── ✓ src
+                ├── ✓ bar
+                │   ├── ✗ ignore.html
+                │   └── ✓ index.html
+                └── ✗ foo.html
+            ");
+
             assert_eq!(candidates, vec!["content-['src/bar/index.html']"]);
             assert_eq!(files, vec!["src/bar/index.html"]);
         }
 
         {
             let ScanResult {
-                candidates, files, ..
+                candidates,
+                files,
+                tree,
+                ..
             } = scan_with_globs(
                 &[
                     ("src/foo.html", "content-['src/foo.html']"),
@@ -1426,13 +2036,25 @@ mod scanner {
                 vec!["@source '**/*'", "@source not './src/ba*/*.html'"],
             );
 
+            assert_snapshot!(tree, @"
+            . (git)
+            └── ✓ src
+                ├── ✗ bar
+                │   ├── ✗ ignore.html
+                │   └── ✗ index.html
+                └── ✓ foo.html
+            ");
+
             assert_eq!(candidates, vec!["content-['src/foo.html']"]);
             assert_eq!(files, vec!["src/foo.html"]);
         }
 
         {
             let ScanResult {
-                candidates, files, ..
+                candidates,
+                files,
+                tree,
+                ..
             } = scan_with_globs(
                 &[
                     ("src/foo.html", "content-['src/foo.html']"),
@@ -1445,6 +2067,15 @@ mod scanner {
                     "@source './src/bar/index.html'", //
                 ],
             );
+
+            assert_snapshot!(tree, @"
+            . (git)
+            └── ✓ src
+                ├── ✓ bar
+                │   ├── ✗ ignore.html
+                │   └── ✓ index.html
+                └── ✓ foo.html
+            ");
 
             assert_eq!(
                 candidates,
@@ -1460,7 +2091,10 @@ mod scanner {
         // specific `@source` points at a single file inside a subdirectory. The restriction
         // added for the explicit file must not hide its siblings from the broad source.
         let ScanResult {
-            candidates, files, ..
+            candidates,
+            files,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("src/components/button.html", "content-['button']"),
@@ -1468,6 +2102,14 @@ mod scanner {
             ],
             vec!["@source '**/*'", "@source './src/components/button.html'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            └── ✓ components
+                ├── ✓ button.html
+                └── ✓ card.html
+        ");
 
         assert_eq!(candidates, vec!["content-['button']", "content-['card']"]);
         assert_eq!(
@@ -1481,7 +2123,10 @@ mod scanner {
         // Same as above, but the broad source is an auto-detected directory (`@source "src"`)
         // and the explicit file lives in a nested subdirectory of it.
         let ScanResult {
-            candidates, files, ..
+            candidates,
+            files,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("src/components/button.html", "content-['button']"),
@@ -1489,6 +2134,14 @@ mod scanner {
             ],
             vec!["@source 'src'", "@source './src/components/button.html'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            └── ✓ components
+                ├── ✓ button.html
+                └── ✓ card.html
+        ");
 
         assert_eq!(candidates, vec!["content-['button']", "content-['card']"]);
         assert_eq!(
@@ -1499,7 +2152,9 @@ mod scanner {
 
     #[test]
     fn root_file_source_should_not_suppress_sibling_source_roots() {
-        let ScanResult { candidates, .. } = scan_with_globs(
+        let ScanResult {
+            candidates, tree, ..
+        } = scan_with_globs(
             &[
                 ("index.css", ""),
                 ("src/index.html", "content-['src/index.html']"),
@@ -1512,6 +2167,17 @@ mod scanner {
                 "@source './index.css'",
             ],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✓ index.css
+        ├── ✓ pages
+        │   ├── ✓ foo.html
+        │   └── ✓ nested
+        │       └── ✓ foo.html
+        └── ✓ src
+            └── ✓ index.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1530,6 +2196,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 (".gitignore", "ignore-1.html\nweb/ignore-2.html"),
@@ -1540,6 +2208,19 @@ mod scanner {
             ],
             vec!["@source './src'", "@source './web'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       ignore-1.html
+        │       web/ignore-2.html
+        ├── ✓ src
+        │   └── ✓ index.html
+        └── ✓ web
+            ├── ✗ ignore-1.html
+            ├── ✗ ignore-2.html
+            └── ✓ index.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1558,6 +2239,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("src/logo.jpg", "content-['/src/logo.jpg']"),
@@ -1565,6 +2248,13 @@ mod scanner {
             ],
             vec!["@source './src/logo.{jpg,png}'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            ├── ✓ logo.jpg
+            └── ✓ logo.png
+        ");
 
         assert_eq!(
             candidates,
@@ -1582,6 +2272,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 (".gitignore", "ignore-1.html\n/web/ignore-2.html"),
@@ -1591,6 +2283,17 @@ mod scanner {
             ],
             vec!["@source './web'", "@source './web/ignore-1.html'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       ignore-1.html
+        │       /web/ignore-2.html
+        └── ✓ web
+            ├── ✓ ignore-1.html
+            ├── ✗ ignore-2.html
+            └── ✓ index.html
+        ");
         assert_eq!(
             candidates,
             vec![
@@ -1611,7 +2314,10 @@ mod scanner {
         // A `.gitignore` that ignores everything (`/*`) and then whitelists specific
         // directories and files using negated patterns.
         let ScanResult {
-            files, candidates, ..
+            files,
+            candidates,
+            tree,
+            ..
         } = scan(&[
             (
                 ".gitignore",
@@ -1628,6 +2334,28 @@ mod scanner {
                 "content-['node_modules/my-ui-lib/index.html']",
             ),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       /*
+        │       !/app
+        │       !/public
+        │       !/package.json
+        │       !/.gitignore
+        ├── ✓ app
+        │   └── ✓ index.html
+        ├── ✗ build
+        │   └── ✗ generated.html
+        ├── ✗ logs
+        │   └── ✗ dev.log
+        ├── ✗ node_modules
+        │   └── ✗ my-ui-lib
+        │       └── ✗ index.html
+        ├── ✓ package.json
+        └── ✓ public
+            └── ✓ index.html
+        ");
 
         assert_eq!(
             files,
@@ -1654,7 +2382,10 @@ mod scanner {
         // !/foo/bar
         // ```
         let ScanResult {
-            files, candidates, ..
+            files,
+            candidates,
+            tree,
+            ..
         } = scan(&[
             (
                 ".gitignore",
@@ -1670,6 +2401,25 @@ mod scanner {
             ("foo/index.html", "content-['foo/index.html']"),
             ("foo/baz/index.html", "content-['foo/baz/index.html']"),
         ]);
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       # exclude everything except directory foo/bar
+        │       /*
+        │       !/foo
+        │       /foo/*
+        │       !/foo/bar
+        ├── ✓ foo
+        │   ├── ✓ bar
+        │   │   ├── ✓ index.html
+        │   │   └── ✓ nested
+        │   │       └── ✓ index.html
+        │   ├── ✗ baz
+        │   │   └── ✗ index.html
+        │   └── ✗ index.html
+        └── ✗ index.html
+        ");
 
         assert_eq!(
             files,
@@ -1691,7 +2441,10 @@ mod scanner {
         // contents. Only when the directory itself is ignored (by an ancestor
         // `.gitignore`, see the tests above) do we bypass the ignore rules.
         let ScanResult {
-            files, candidates, ..
+            files,
+            candidates,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("vendor/.gitignore", "ignored.html"),
@@ -1700,6 +2453,15 @@ mod scanner {
             ],
             vec!["@source 'vendor'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ vendor
+            ├── ✗ .gitignore
+            │       ignored.html
+            ├── ✗ ignored.html
+            └── ✓ index.html
+        ");
 
         assert_eq!(files, vec!["vendor/index.html"]);
         assert_eq!(candidates, vec!["content-['vendor/index.html']"]);
@@ -1711,6 +2473,7 @@ mod scanner {
             candidates,
             files,
             globs,
+            tree,
             ..
         } = scan_with_globs(
             &[
@@ -1721,6 +2484,18 @@ mod scanner {
             ],
             vec!["@source './src/ef*/*.html'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       src/efgh/
+        └── ✓ src
+            ├── ✗ abcd
+            │   └── ✗ index.html
+            └── ✓ efgh
+                ├── ✗ ignore.js
+                └── ✓ index.html
+        ");
 
         assert_eq!(candidates, vec!["content-['src/efgh/index.html']"]);
         assert_eq!(files, vec!["src/efgh/index.html"]);
@@ -1797,7 +2572,33 @@ mod scanner {
             ),
         ];
 
-        let candidates = Scanner::new(sources.clone()).scan();
+        let mut scanner = Scanner::new(sources.clone());
+        let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ home
+            ├── ✗ .gitignore
+            │       ignore-home.html
+            └── ✓ project
+                ├── ✗ .gitignore
+                │       ignore-project.html
+                └── ✓ apps
+                    ├── ✗ .gitignore
+                    │       ignore-apps.html
+                    ├── ✓ admin
+                    │   └── ✓ index.html
+                    ├── ✓ dashboard
+                    │   └── ✓ index.html
+                    └── ✓ web
+                        ├── ✗ .gitignore
+                        │       ignore-web.html
+                        ├── ✗ ignore-apps.html
+                        ├── ✗ ignore-home.html
+                        ├── ✗ ignore-project.html
+                        ├── ✗ ignore-web.html
+                        └── ✓ index.html
+        ");
 
         // All ignore files are applied because there's no git repo
         assert_eq!(
@@ -1815,7 +2616,33 @@ mod scanner {
             .arg("init")
             .current_dir(dir.join("home"))
             .output();
-        let candidates = Scanner::new(sources.clone()).scan();
+        let mut scanner = Scanner::new(sources.clone());
+        let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ home (git)
+            ├── ✗ .gitignore
+            │       ignore-home.html
+            └── ✓ project
+                ├── ✗ .gitignore
+                │       ignore-project.html
+                └── ✓ apps
+                    ├── ✗ .gitignore
+                    │       ignore-apps.html
+                    ├── ✓ admin
+                    │   └── ✓ index.html
+                    ├── ✓ dashboard
+                    │   └── ✓ index.html
+                    └── ✓ web
+                        ├── ✗ .gitignore
+                        │       ignore-web.html
+                        ├── ✗ ignore-apps.html
+                        ├── ✗ ignore-home.html
+                        ├── ✗ ignore-project.html
+                        ├── ✗ ignore-web.html
+                        └── ✓ index.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1834,7 +2661,33 @@ mod scanner {
             .arg("init")
             .current_dir(dir.join("home/project"))
             .output();
-        let candidates = Scanner::new(sources.clone()).scan();
+        let mut scanner = Scanner::new(sources.clone());
+        let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ home
+            ├── ✗ .gitignore
+            │       ignore-home.html
+            └── ✓ project (git)
+                ├── ✗ .gitignore
+                │       ignore-project.html
+                └── ✓ apps
+                    ├── ✗ .gitignore
+                    │       ignore-apps.html
+                    ├── ✓ admin
+                    │   └── ✓ index.html
+                    ├── ✓ dashboard
+                    │   └── ✓ index.html
+                    └── ✓ web
+                        ├── ✗ .gitignore
+                        │       ignore-web.html
+                        ├── ✗ ignore-apps.html
+                        ├── ✓ ignore-home.html
+                        ├── ✗ ignore-project.html
+                        ├── ✗ ignore-web.html
+                        └── ✓ index.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1854,7 +2707,33 @@ mod scanner {
             .arg("init")
             .current_dir(dir.join("home/project/apps"))
             .output();
-        let candidates = Scanner::new(sources.clone()).scan();
+        let mut scanner = Scanner::new(sources.clone());
+        let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ home
+            ├── ✗ .gitignore
+            │       ignore-home.html
+            └── ✓ project
+                ├── ✗ .gitignore
+                │       ignore-project.html
+                └── ✓ apps (git)
+                    ├── ✗ .gitignore
+                    │       ignore-apps.html
+                    ├── ✓ admin
+                    │   └── ✓ index.html
+                    ├── ✓ dashboard
+                    │   └── ✓ index.html
+                    └── ✓ web
+                        ├── ✗ .gitignore
+                        │       ignore-web.html
+                        ├── ✗ ignore-apps.html
+                        ├── ✓ ignore-home.html
+                        ├── ✓ ignore-project.html
+                        ├── ✗ ignore-web.html
+                        └── ✓ index.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1876,7 +2755,33 @@ mod scanner {
             .current_dir(dir.join("home/project/apps/web"))
             .output();
 
-        let candidates = Scanner::new(sources.clone()).scan();
+        let mut scanner = Scanner::new(sources.clone());
+        let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ home
+            ├── ✗ .gitignore
+            │       ignore-home.html
+            └── ✓ project
+                ├── ✗ .gitignore
+                │       ignore-project.html
+                └── ✓ apps
+                    ├── ✗ .gitignore
+                    │       ignore-apps.html
+                    ├── ✓ admin
+                    │   └── ✓ index.html
+                    ├── ✓ dashboard
+                    │   └── ✓ index.html
+                    └── ✓ web (git)
+                        ├── ✗ .gitignore
+                        │       ignore-web.html
+                        ├── ✓ ignore-apps.html
+                        ├── ✓ ignore-home.html
+                        ├── ✓ ignore-project.html
+                        ├── ✗ ignore-web.html
+                        └── ✓ index.html
+        ");
 
         assert_eq!(
             candidates,
@@ -1910,7 +2815,15 @@ mod scanner {
             public_source_entry_from_pattern(dir.clone(), "@source not 'src/ignore-me.html'"),
         ];
 
-        let candidates = Scanner::new(sources.clone()).scan();
+        let mut scanner = Scanner::new(sources.clone());
+        let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ src
+            ├── ✗ ignore-me.html
+            └── ✓ keep-me.html
+        ");
 
         assert_eq!(candidates, vec!["content-['keep-me.html']"]);
     }
@@ -1937,7 +2850,17 @@ mod scanner {
             ),
         ];
 
-        let candidates = Scanner::new(sources.clone()).scan();
+        let mut scanner = Scanner::new(sources.clone());
+        let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ src
+            └── ✓ app
+                └── ✓ [foo]
+                    ├── ✗ ignore-me.html
+                    └── ✓ keep-me.html
+        ");
 
         assert_eq!(candidates, vec!["content-['keep-me.html']"]);
     }
@@ -1963,6 +2886,12 @@ mod scanner {
 
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['src/keep-me.html']"]);
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ src
+            └── ✓ keep-me.html
+        ");
 
         // Create new files that should definitely be ignored
         create_files_in(
@@ -1990,6 +2919,18 @@ mod scanner {
         );
 
         let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       src/ignored-by-gitignore.html
+        └── ✓ src
+            ├── ✗ ignore-by-extension.bin
+            ├── ✓ ignored-by-gitignore.html
+            ├── ✗ ignored-by-source-not.html
+            ├── ✓ keep-me.html
+            └── ✓ new-file.html
+        ");
 
         assert_eq!(
             candidates,
@@ -2020,6 +2961,11 @@ mod scanner {
         let candidates = scanner.scan();
         assert!(candidates.is_empty());
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✗ foo.styl
+        ");
+
         // Explicitly allow `.styl` files
         let mut scanner = Scanner::new(vec![
             public_source_entry_from_pattern(dir.clone(), "@source '**/*'"),
@@ -2028,6 +2974,11 @@ mod scanner {
 
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['foo.styl']"]);
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        └── ✓ foo.styl
+        ");
     }
 
     #[test]
@@ -2052,6 +3003,13 @@ mod scanner {
         let candidates = scanner.scan();
         assert!(candidates.is_empty());
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       index.html
+        └── ✗ index.html
+        ");
+
         let mut scanner = Scanner::new(vec![
             public_source_entry_from_pattern(dir.clone(), "@source '**/*'"),
             public_source_entry_from_pattern(dir.clone(), "@source './*.html'"),
@@ -2059,6 +3017,13 @@ mod scanner {
 
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['index.html']"]);
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       index.html
+        └── ✓ index.html
+        ");
     }
 
     #[test]
@@ -2093,6 +3058,17 @@ mod scanner {
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['src/index.html']"]);
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       node_modules
+        ├── ✗ node_modules
+        │   └── ✗ my-ui-lib
+        │       └── ✗ index.html
+        └── ✓ src
+            └── ✓ index.html
+        ");
+
         // Explicitly listing all `*.html` files, should not include `node_modules` because it's
         // ignored
         let sources = vec![public_source_entry_from_pattern(
@@ -2103,6 +3079,17 @@ mod scanner {
         let mut scanner = Scanner::new(sources.clone());
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['src/index.html']"]);
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       node_modules
+        ├── ✗ node_modules
+        │   └── ✗ my-ui-lib
+        │       └── ✗ index.html
+        └── ✓ src
+            └── ✓ index.html
+        ");
 
         // Explicitly listing all `*.html` files
         // Explicitly list the `node_modules/my-ui-lib`
@@ -2121,12 +3108,25 @@ mod scanner {
                 "content-['src/index.html']"
             ]
         );
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       node_modules
+        ├── ✓ node_modules
+        │   └── ✓ my-ui-lib
+        │       └── ✓ index.html
+        └── ✓ src
+            └── ✓ index.html
+        ");
     }
 
     // https://github.com/tailwindlabs/tailwindcss/issues/19844
     #[test]
     fn test_allow_explicit_sources_ignored_by_allow_list_gitignore() {
-        let ScanResult { candidates, .. } = scan_with_globs(
+        let ScanResult {
+            candidates, tree, ..
+        } = scan_with_globs(
             &[
                 (".gitignore", "*\n!/app\n!/app/design\n!/app/design/**\n"),
                 (
@@ -2141,6 +3141,27 @@ mod scanner {
             vec!["@source 'vendor/acme/theme'"],
         );
 
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       *
+        │       !/app
+        │       !/app/design
+        │       !/app/design/**
+        ├── ✗ app
+        │   └── ✗ design
+        │       └── ✗ frontend
+        │           └── ✗ theme
+        │               └── ✗ templates
+        │                   └── ✗ component.phtml
+        └── ✓ vendor
+            └── ✓ acme
+                └── ✓ theme
+                    └── ✓ module
+                        └── ✓ templates
+                            └── ✓ component.phtml
+        ");
+
         assert_eq!(
             candidates,
             vec!["content-['vendor/acme/theme/module/templates/component.phtml']"]
@@ -2154,6 +3175,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 (
@@ -2172,6 +3195,17 @@ mod scanner {
             vec!["@source '**/*'"],
         );
 
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ node_modules
+        │   └── ✗ index.html
+        └── ✓ packages
+            └── ✓ web
+                ├── ✓ index.html
+                └── ✗ node_modules
+                    └── ✗ index.html
+        ");
+
         assert_eq!(candidates, vec!["content-['packages/web/index.html']"]);
 
         assert_eq!(files, vec!["packages/web/index.html",]);
@@ -2186,6 +3220,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 (".gitignore", "node_modules\ndist"),
@@ -2200,6 +3236,18 @@ mod scanner {
             ],
             vec!["@source 'node_modules/my-ui-lib'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       node_modules
+        │       dist
+        └── ✓ node_modules
+            └── ✓ my-ui-lib
+                ├── ✓ dist
+                │   └── ✓ index.html
+                └── ✗ node.exe
+        ");
 
         assert_eq!(
             candidates,
@@ -2241,6 +3289,17 @@ mod scanner {
 
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['src/components/button.tsx']"]);
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       *.jsx
+        │       generated/
+        └── ✓ src
+            └── ✓ components
+                ├── ✗ button.jsx
+                └── ✓ button.tsx
+        ");
 
         // Create 2 new files, one "good" and one "bad" file, and manually scan them. This should
         // only return the "good" file because the "bad" one is ignored by a `.gitignore` file.
@@ -2302,6 +3361,8 @@ mod scanner {
             files,
             globs,
             normalized_sources,
+            tree,
+            ..
         } = scan_with_globs(
             &[
                 ("src/💩.js", "content-['src/💩.js']"),
@@ -2310,6 +3371,15 @@ mod scanner {
             ],
             vec!["@source '**/*'", "@source not 'src/🤦‍♂️'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        └── ✓ src
+            ├── ✓ 💩.js
+            ├── ✗ 🤦‍♂️
+            │   └── ✗ foo.tsx
+            └── ✓ 🤦‍♂️.tsx
+        ");
 
         assert_eq!(
             candidates,
@@ -2347,6 +3417,23 @@ mod scanner {
         )]);
         let candidates = scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       node_modules
+        │       dist
+        └── ✓ node_modules
+            ├── ✓ .pnpm
+            │   └── ✓ @org+my-ui-library
+            │       └── ✓ dist
+            │           └── ✓ index.ts
+            └── ✓ @org
+                ├── ✓ .gitkeep
+                └── ✓ my-ui-library → node_modules/.pnpm/@org+my-ui-library
+                    └── ✓ dist
+                        └── ✓ index.ts
+        ");
+
         assert_eq!(
             candidates,
             vec!["content-['node_modules/.pnpm/@org+my-ui-library/dist/index.ts']"]
@@ -2358,6 +3445,23 @@ mod scanner {
         )]);
         let candidates = scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       node_modules
+        │       dist
+        └── ✓ node_modules
+            ├── ✓ .pnpm
+            │   └── ✓ @org+my-ui-library
+            │       └── ✓ dist
+            │           └── ✓ index.ts
+            └── ✓ @org
+                ├── ✗ .gitkeep
+                └── ✓ my-ui-library → node_modules/.pnpm/@org+my-ui-library
+                    └── ✓ dist
+                        └── ✓ index.ts
+        ");
+
         assert_eq!(
             candidates,
             vec!["content-['node_modules/.pnpm/@org+my-ui-library/dist/index.ts']"]
@@ -2368,6 +3472,23 @@ mod scanner {
             "@source 'node_modules/@org'",
         )]);
         let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ .gitignore
+        │       node_modules
+        │       dist
+        └── ✓ node_modules
+            ├── ✓ .pnpm
+            │   └── ✓ @org+my-ui-library
+            │       └── ✓ dist
+            │           └── ✓ index.ts
+            └── ✓ @org
+                ├── ✓ .gitkeep
+                └── ✓ my-ui-library → node_modules/.pnpm/@org+my-ui-library
+                    └── ✓ dist
+                        └── ✓ index.ts
+        ");
 
         assert_eq!(
             candidates,
@@ -2398,6 +3519,16 @@ mod scanner {
         )]);
         let candidates = scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ a → c
+        ├── ✓ b
+        │   └── ✓ index.html
+        ├── ✗ c → b/c
+        └── ✓ z
+            └── ✓ index.html
+        ");
+
         assert_eq!(
             candidates,
             vec!["content-['b/index.html']", "content-['z/index.html']"]
@@ -2421,6 +3552,14 @@ mod scanner {
             "@source 'efgh/*.html'",
         )]);
         let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✓ abcd
+        │   └── ✓ xyz.html
+        └── ✓ efgh → abcd
+            └── ✓ xyz.html
+        ");
 
         assert_eq!(candidates, vec!["content-['abcd/xyz.html']"]);
 
@@ -2462,6 +3601,18 @@ mod scanner {
         ]);
         let candidates = scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ actual-dir
+        │   └── ✗ ignore.html
+        ├── ✗ actual-file.html
+        ├── ✗ linked-dir → actual-dir
+        │   └── ✗ ignore.html
+        ├── ✗ linked-file.html → actual-file.html
+        └── ✓ src
+            └── ✓ keep.html
+        ");
+
         assert_eq!(candidates, vec!["content-['src/keep.html']"]);
 
         let mut scanner = Scanner::new(vec![
@@ -2499,6 +3650,16 @@ mod scanner {
         )]);
         let candidates = scanner.scan();
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✓ actual-dir
+        │   └── ✓ ignore.html
+        └── ✓ project
+            ├── ✓ keep.html
+            └── ✓ linked-dir → actual-dir
+                └── ✓ ignore.html
+        ");
+
         assert_eq!(
             candidates,
             vec![
@@ -2512,6 +3673,16 @@ mod scanner {
             public_source_entry_from_pattern(base.clone(), "@source not 'linked-dir'"),
         ]);
         let candidates = scanner.scan();
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✗ actual-dir
+        │   └── ✗ ignore.html
+        └── ✓ project
+            ├── ✓ keep.html
+            └── ✗ linked-dir → actual-dir
+                └── ✗ ignore.html
+        ");
 
         assert_eq!(candidates, vec!["content-['project/keep.html']"]);
     }
@@ -2570,6 +3741,23 @@ mod scanner {
             ]
         );
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✓ linked.html → packages/other/index.html
+        ├── ✓ node_modules
+        │   └── ✓ repro → packages/repro
+        │       ├── ✓ nested
+        │       │   └── ✓ deep.html
+        │       └── ✓ source.html
+        └── ✓ packages
+            ├── ✓ other
+            │   └── ✓ index.html
+            └── ✓ repro
+                ├── ✓ nested
+                │   └── ✓ deep.html
+                └── ✓ source.html
+        ");
+
         // Both the symlinked paths and the canonical paths should be tracked, such that file
         // watchers watching the returned files also watch the real files on disk.
         let files = scanned_files(&mut scanner, &dir);
@@ -2603,6 +3791,16 @@ mod scanner {
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['v1']"]);
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✓ node_modules
+        │   └── ✓ repro → packages/repro
+        │       └── ✓ source.html
+        └── ✓ packages
+            └── ✓ repro
+                └── ✓ source.html
+        ");
+
         // Update the real file on disk. This is the path file watchers will report changes for.
         create_files_in(&dir, &[("packages/repro/source.html", "content-['v2']")]);
 
@@ -2630,6 +3828,16 @@ mod scanner {
         let candidates = scanner.scan();
         assert_eq!(candidates, vec!["content-['a']"]);
 
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✓ node_modules
+        │   └── ✓ repro → packages/repro
+        │       └── ✓ a.html
+        └── ✓ packages
+            └── ✓ repro
+                └── ✓ a.html
+        ");
+
         // Create a new file in the real directory. File watchers watching the real directory
         // will report the new file with its canonical path.
         create_files_in(&dir, &[("packages/repro/b.html", "content-['b']")]);
@@ -2639,12 +3847,26 @@ mod scanner {
             "html".into(),
         )]);
         assert_eq!(candidates, vec!["content-['b']"]);
+
+        assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
+        .
+        ├── ✓ node_modules
+        │   └── ✓ repro → packages/repro
+        │       ├── ✓ a.html
+        │       └── ✓ b.html
+        └── ✓ packages
+            └── ✓ repro
+                ├── ✓ a.html
+                └── ✗ b.html
+        ");
     }
 
     // https://github.com/tailwindlabs/tailwindcss/pull/20408
     #[test]
     fn test_resolving_globs_does_not_traverse_gitignored_directories() {
-        let ScanResult { files, globs, .. } = scan_with_globs(
+        let ScanResult {
+            files, globs, tree, ..
+        } = scan_with_globs(
             &[
                 (".gitignore", "/vendor\n"),
                 ("vendor/pkg/canary/index.html", ""),
@@ -2652,6 +3874,18 @@ mod scanner {
             ],
             vec!["@source '**/*'", "@source './vendor/pkg/canary'"],
         );
+
+        assert_snapshot!(tree, @"
+        . (git)
+        ├── ✗ .gitignore
+        │       /vendor
+        ├── ✓ src
+        │   └── ✓ index.html
+        └── ✓ vendor
+            └── ✓ pkg
+                └── ✓ canary
+                    └── ✓ index.html
+        ");
 
         assert_eq!(
             files,

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -65,13 +65,42 @@ mod scanner {
     /// - `✓` — scanned
     /// - `✗` — ignored / skipped
     ///
-    /// Symlinks are rendered as `link → target`, and the contents of every
+    /// Symlinks are rendered as `link → target`, where the target is shown
+    /// relative to the folder containing the symlink. The contents of every
     /// `.gitignore` file are printed right below the file itself.
     ///
     /// Folders that are a git repository root (they contain a `.git` folder)
     /// are marked with `(git)`, because ignore rules behave differently
     /// inside and outside of a repository.
     fn fs_tree(root: &Path, scanned: &[String]) -> String {
+        /// Computes the relative path from `parent` to `target`, where both
+        /// are relative to the same root, e.g.: `b/c` seen from `b` is `c`,
+        /// and the root itself seen from `b` is `..`.
+        fn relative_to(target: &Path, parent: &Path) -> String {
+            let target = target.components().collect::<Vec<_>>();
+            let parent = parent.components().collect::<Vec<_>>();
+
+            let common = target
+                .iter()
+                .zip(&parent)
+                .take_while(|(a, b)| **a == **b)
+                .count();
+
+            let mut parts = vec![".."; parent.len() - common];
+            parts.extend(
+                target[common..]
+                    .iter()
+                    .map(|component| component.as_os_str().to_str().unwrap()),
+            );
+
+            if parts.is_empty() {
+                // The symlink points to its own parent folder
+                ".".into()
+            } else {
+                parts.join("/")
+            }
+        }
+
         fn walk(
             dir: &Path,
             root: &Path,
@@ -118,15 +147,13 @@ mod scanner {
                 }
                 if file_type.is_symlink() {
                     if let Ok(target) = fs::read_link(&path) {
-                        let mut target = target
-                            .strip_prefix(root)
-                            .unwrap_or(&target)
-                            .to_string_lossy()
-                            .replace('\\', "/");
-                        if target.is_empty() {
-                            // The symlink points to the root itself
-                            target = ".".into();
-                        }
+                        // Show the target relative to the folder containing
+                        // the symlink, or as-is when it points outside of the
+                        // tree.
+                        let target = match (target.strip_prefix(root), dir.strip_prefix(root)) {
+                            (Ok(target), Ok(parent)) => relative_to(target, parent),
+                            _ => target.to_string_lossy().replace('\\', "/"),
+                        };
                         display_name = format!("{name} → {target}");
 
                         // The symlink points to a target that doesn't exist
@@ -3438,7 +3465,7 @@ mod scanner {
             │           └── ✓ index.ts
             └── ✓ @org
                 ├── ✓ .gitkeep
-                └── ✓ my-ui-library → node_modules/.pnpm/@org+my-ui-library
+                └── ✓ my-ui-library → ../.pnpm/@org+my-ui-library
                     └── ✓ dist
                         └── ✓ index.ts
         ");
@@ -3466,7 +3493,7 @@ mod scanner {
             │           └── ✓ index.ts
             └── ✓ @org
                 ├── ✗ .gitkeep
-                └── ✓ my-ui-library → node_modules/.pnpm/@org+my-ui-library
+                └── ✓ my-ui-library → ../.pnpm/@org+my-ui-library
                     └── ✓ dist
                         └── ✓ index.ts
         ");
@@ -3494,7 +3521,7 @@ mod scanner {
             │           └── ✓ index.ts
             └── ✓ @org
                 ├── ✓ .gitkeep
-                └── ✓ my-ui-library → node_modules/.pnpm/@org+my-ui-library
+                └── ✓ my-ui-library → ../.pnpm/@org+my-ui-library
                     └── ✓ dist
                         └── ✓ index.ts
         ");
@@ -3534,17 +3561,17 @@ mod scanner {
         assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
         .
         ├── ✓ a → b
-        │   ├── ✗ c → c
+        │   ├── ✗ c → ../c
         │   ├── ✓ index.html
-        │   └── ✗ root → .
+        │   └── ✗ root → ..
         ├── ✓ b
-        │   ├── ✗ c → c
+        │   ├── ✗ c → ../c
         │   ├── ✓ index.html
-        │   └── ✗ root → .
+        │   └── ✗ root → ..
         ├── ✓ c → a
-        │   ├── ✗ c → c
+        │   ├── ✗ c → .
         │   ├── ✓ index.html
-        │   └── ✗ root → .
+        │   └── ✗ root → ..
         └── ✓ z
             └── ✓ index.html
         ");
@@ -3676,7 +3703,7 @@ mod scanner {
         │   └── ✓ ignore.html
         └── ✓ project
             ├── ✓ keep.html
-            └── ✓ linked-dir → actual-dir
+            └── ✓ linked-dir → ../actual-dir
                 └── ✓ ignore.html
         ");
 
@@ -3700,7 +3727,7 @@ mod scanner {
         │   └── ✗ ignore.html
         └── ✓ project
             ├── ✓ keep.html
-            └── ✗ linked-dir → actual-dir
+            └── ✗ linked-dir → ../actual-dir
                 └── ✗ ignore.html
         ");
 
@@ -3765,7 +3792,7 @@ mod scanner {
         .
         ├── ✓ linked.html → packages/other/index.html
         ├── ✓ node_modules
-        │   └── ✓ repro → packages/repro
+        │   └── ✓ repro → ../packages/repro
         │       ├── ✓ nested
         │       │   └── ✓ deep.html
         │       └── ✓ source.html
@@ -3814,7 +3841,7 @@ mod scanner {
         assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
         .
         ├── ✓ node_modules
-        │   └── ✓ repro → packages/repro
+        │   └── ✓ repro → ../packages/repro
         │       └── ✓ source.html
         └── ✓ packages
             └── ✓ repro
@@ -3851,7 +3878,7 @@ mod scanner {
         assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
         .
         ├── ✓ node_modules
-        │   └── ✓ repro → packages/repro
+        │   └── ✓ repro → ../packages/repro
         │       └── ✓ a.html
         └── ✓ packages
             └── ✓ repro
@@ -3871,7 +3898,7 @@ mod scanner {
         assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
         .
         ├── ✓ node_modules
-        │   └── ✓ repro → packages/repro
+        │   └── ✓ repro → ../packages/repro
         │       ├── ✓ a.html
         │       └── ✓ b.html
         └── ✓ packages

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -59,23 +59,21 @@ mod scanner {
         tree: String,
     }
 
-    /// Renders the directory as a tree, annotating every file and folder with
-    /// an indicator that shows whether the scanner picked it up:
+    /// Renders the directory as a tree, annotating every file and folder with an indicator that
+    /// shows whether the scanner picked it up:
     ///
     /// - `✓` — scanned
     /// - `✗` — ignored / skipped
     ///
-    /// Symlinks are rendered as `link → target`, where the target is shown
-    /// relative to the folder containing the symlink. The contents of every
-    /// `.gitignore` file are printed right below the file itself.
+    /// Symlinks are rendered as `link → target`, where the target is shown relative to the folder
+    /// containing the symlink. The contents of every `.gitignore` file are printed right below the
+    /// file itself.
     ///
-    /// Folders that are a git repository root (they contain a `.git` folder)
-    /// are marked with `(git)`, because ignore rules behave differently
-    /// inside and outside of a repository.
+    /// Folders that are a git repository root (they contain a `.git` folder) are marked with
+    /// `(git)`, because ignore rules behave differently inside and outside of a repository.
     fn fs_tree(root: &Path, scanned: &[String]) -> String {
-        /// Computes the relative path from `parent` to `target`, where both
-        /// are relative to the same root, e.g.: `b/c` seen from `b` is `c`,
-        /// and the root itself seen from `b` is `..`.
+        /// Computes the relative path from `parent` to `target`, where both are relative to the
+        /// same root, e.g.: `b/c` seen from `b` is `c`, and the root itself seen from `b` is `..`.
         fn relative_to(target: &Path, parent: &Path) -> String {
             let target = target.components().collect::<Vec<_>>();
             let parent = parent.components().collect::<Vec<_>>();
@@ -131,10 +129,9 @@ mod scanner {
 
                 let file_type = entry.file_type().unwrap();
 
-                // A file is scanned when it shows up in the scanned files
-                // list. A folder is considered scanned when any scanned file
-                // lives inside of it. Paths that go through a symlink count
-                // towards the symlink, not towards the target directory.
+                // a file is scanned when it shows up in the scanned files list. a folder is
+                // considered scanned when any scanned file lives inside of it. paths that go
+                // through a symlink count towards the symlink, not towards the target directory.
                 let dir_prefix = format!("{rel}/");
                 let is_scanned = scanned
                     .iter()
@@ -147,9 +144,8 @@ mod scanner {
                 }
                 if file_type.is_symlink() {
                     if let Ok(target) = fs::read_link(&path) {
-                        // Show the target relative to the folder containing
-                        // the symlink, or as-is when it points outside of the
-                        // tree.
+                        // Show the target relative to the folder containing the symlink, or as-is
+                        // when it points outside of the tree.
                         let target = match (target.strip_prefix(root), dir.strip_prefix(root)) {
                             (Ok(target), Ok(parent)) => relative_to(target, parent),
                             _ => target.to_string_lossy().replace('\\', "/"),
@@ -165,8 +161,8 @@ mod scanner {
 
                 out.push_str(&format!("{prefix}{connector}{indicator} {display_name}\n"));
 
-                // Print the contents of `.gitignore` files below the file
-                // itself, so the ignore rules are visible in the same output.
+                // Print the contents of `.gitignore` files below the file itself, so the ignore
+                // rules are visible in the same output.
                 if name == ".gitignore" {
                     if let Ok(contents) = fs::read_to_string(&path) {
                         for line in contents.lines() {
@@ -177,10 +173,9 @@ mod scanner {
                     }
                 }
 
-                // Descend into directories, including symlinked ones. The
-                // paths inside a symlinked directory are computed through the
-                // symlink, so the indicators show what the scanner saw via
-                // that route. A visited stack prevents symlink cycles from
+                // Descend into directories, including symlinked ones. The paths inside a symlinked
+                // directory are computed through the symlink, so the indicators show what the
+                // scanner saw via that route. A visited stack prevents symlink cycles from
                 // recursing forever.
                 if path.metadata().map(|meta| meta.is_dir()).unwrap_or(false) {
                     let Ok(canonical) = dunce::canonicalize(&path) else {

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -124,6 +124,11 @@ mod scanner {
                             .to_string_lossy()
                             .replace('\\', "/");
                         display_name = format!("{name} → {target}");
+
+                        // The symlink points to a target that doesn't exist
+                        if path.metadata().is_err() {
+                            display_name = format!("{display_name} (broken)");
+                        }
                     }
                 }
 
@@ -3521,10 +3526,10 @@ mod scanner {
 
         assert_snapshot!(fs_tree(&dir, &scanned_files(&mut scanner, &dir)), @"
         .
-        ├── ✗ a → c
+        ├── ✗ a → c (broken)
         ├── ✓ b
         │   └── ✓ index.html
-        ├── ✗ c → b/c
+        ├── ✗ c → b/c (broken)
         └── ✓ z
             └── ✓ index.html
         ");


### PR DESCRIPTION
This PR improves the scanner related tests a bit. Right now all the scanner tests (a lot of them) are somewhat hard to reason about and to figure out whether these are actually correct or not.

With this PR, the existing are extended with a visualization of the file system tree, but with indicators to know whether or not a file was scanned or not. If a `.gitignore` is present, it's content is also shown to make it easier to see why some files are included or not included.

One of the outputs look like this:
```
.
├── ✗ .gitignore
│       src/ignored-by-gitignore.html
└── ✓ src
    ├── ✗ ignore-by-extension.bin
    ├── ✓ ignored-by-gitignore.html
    ├── ✗ ignored-by-source-not.html
    ├── ✓ keep-me.html
    └── ✓ new-file.html
```

I'm sure we can cleanup a lot of these tests, simplify, deduplicate, but I didn't want to do that as part of this PR. This PR is purely adding this visualization.

This uses the [insta.rs](https://insta.rs) library for (inline) snapshot tests. If at some point the snapshots change, then you get a nice UI:
<img width="958" height="670" alt="image" src="https://github.com/user-attachments/assets/652cf48f-e1b1-4fe5-a42a-29c5a888063a" />


## Test plan

1. All tests should pass [ci-all]
2. Nothing in the code itself changed, so nothing should break

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>