### PR TITLE
test: fix 'with with' typo in css parser tests

### DIFF
--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -203,7 +203,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ])
     })
 
-    it('should parse declarations with with strings and escaped string endings', () => {
+    it('should parse declarations with strings and escaped string endings', () => {
       expect(
         parse(css`
           content: 'These are not the end "\' of the string';


### PR DESCRIPTION
## Summary

Fixes a minor grammatical repetition typo (`with with` instead of `with`) inside the core CSS parser test suite (`packages/tailwindcss/src/css-parser.test.ts`) to keep test assertions clean, correct, and readable.

## Test plan

- Run the CSS parser unit tests locally using:
  `pnpm test`
- Verified that the modified test file parses correctly and all test suites pass without any regression or compilation issues.
