### PR TITLE
Don't space out `and`/`or`/`not` inside function calls in `supports-[…]` variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Oxide: drop invalid UTF-8 candidates ([#20389](https://github.com/tailwindlabs/tailwindcss/pull/20389))
 - `@tailwindcss/vite` no longer forces a full page reload for external files (e.g.: `.php` files) ([#20414](https://github.com/tailwindlabs/tailwindcss/issues/20414))
 - Canonicalization: don't merge utilities that reference different theme variables set to CSS-wide keywords like `unset` ([#20417](https://github.com/tailwindlabs/tailwindcss/pull/20417))
+- Don't space out `and`, `or`, and `not` inside function calls like `selector(a:not(.foo))` in `supports-[…]` variants ([#20420](https://github.com/tailwindlabs/tailwindcss/pull/20420))
 
 ## [4.3.3] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@tailwindcss/vite` no longer forces a full page reload for external files (e.g.: `.php` files) ([#20414](https://github.com/tailwindlabs/tailwindcss/issues/20414))
 - Canonicalization: don't merge utilities that reference different theme variables set to CSS-wide keywords like `unset` ([#20417](https://github.com/tailwindlabs/tailwindcss/pull/20417))
 - Don't generate utilities when a modifier is used that would otherwise be silently ignored (e.g. `rounded-sm/[5]`, `shadow-sm/foo`, `stroke-2/50`) ([#20419](https://github.com/tailwindlabs/tailwindcss/pull/20419))
-- Don't space out `and`, `or`, and `not` inside function calls like `selector(a:not(.foo))` in `supports-[…]` variants ([#20420](https://github.com/tailwindlabs/tailwindcss/pull/20420))
+- Only normalize top-level `and`, `or`, and `not` keywords in `supports-[…]` variants (e.g. `selector(a: not (.foo))` → `selector(a:not(.foo))`) ([#20420](https://github.com/tailwindlabs/tailwindcss/pull/20420))
 
 ## [4.3.3] - 2026-07-16
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1431,6 +1431,8 @@ test('supports: `and`, `or`, and `not` inside function calls are not spaced out'
       'supports-[selector(a:is(.and,.or))]:flex',
       'supports-[(display:grid)or(display:flex)]:grid',
       'supports-[not(display:grid)]:flex',
+      'supports-[foo-not(display:grid)]:flex',
+      'supports-[selector([data-foo="("])or(display:grid)]:flex',
     ]),
   ).toMatchInlineSnapshot(`
     "
@@ -1440,8 +1442,20 @@ test('supports: `and`, `or`, and `not` inside function calls are not spaced out'
       }
     }
 
+    @supports foo-not(display:grid) {
+      .supports-\\[foo-not\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
     @supports not (display: grid) {
       .supports-\\[not\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector([data-foo="("]) or (display: grid) {
+      .supports-\\[selector\\(\\[data-foo\\=\\"\\(\\"\\]\\)or\\(display\\:grid\\)\\]\\:flex {
         display: flex;
       }
     }

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1424,64 +1424,6 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
   `)
 })
 
-test('supports: `and`, `or`, and `not` inside function calls are not spaced out', async () => {
-  expect(
-    await run([
-      'supports-[selector(a:not(.foo))]:flex',
-      'supports-[selector(a:is(.and,.or))]:flex',
-      'supports-[(display:grid)or(display:flex)]:grid',
-      'supports-[not(display:grid)]:flex',
-      'supports-[foo-not(display:grid)]:flex',
-      'supports-[selector([data-foo="("])or(display:grid)]:flex',
-      'supports-[selector(.foo\\(bar)or(display:grid)]:flex',
-    ]),
-  ).toMatchInlineSnapshot(`
-    "
-    @supports (display: grid) or (display: flex) {
-      .supports-\\[\\(display\\:grid\\)or\\(display\\:flex\\)\\]\\:grid {
-        display: grid;
-      }
-    }
-
-    @supports foo-not(display:grid) {
-      .supports-\\[foo-not\\(display\\:grid\\)\\]\\:flex {
-        display: flex;
-      }
-    }
-
-    @supports not (display: grid) {
-      .supports-\\[not\\(display\\:grid\\)\\]\\:flex {
-        display: flex;
-      }
-    }
-
-    @supports selector(.foo\\(bar) or (display: grid) {
-      .supports-\\[selector\\(\\.foo\\\\\\(bar\\)or\\(display\\:grid\\)\\]\\:flex {
-        display: flex;
-      }
-    }
-
-    @supports selector([data-foo="("]) or (display: grid) {
-      .supports-\\[selector\\(\\[data-foo\\=\\"\\(\\"\\]\\)or\\(display\\:grid\\)\\]\\:flex {
-        display: flex;
-      }
-    }
-
-    @supports selector(a:is(.and,.or)) {
-      .supports-\\[selector\\(a\\:is\\(\\.and\\,\\.or\\)\\)\\]\\:flex {
-        display: flex;
-      }
-    }
-
-    @supports selector(a:not(.foo)) {
-      .supports-\\[selector\\(a\\:not\\(\\.foo\\)\\)\\]\\:flex {
-        display: flex;
-      }
-    }
-    "
-  `)
-})
-
 test('supports', async () => {
   expect(
     await run([
@@ -1493,6 +1435,16 @@ test('supports', async () => {
       'supports-[font-tech(color-COLRv1)]:flex',
       'supports-[var(--test)]:flex',
       'supports-[--test]:flex',
+
+      // Only top-level and/or/not should have spaces around them. We should
+      // ignore and/or/not inside of `selector(…)`
+      'supports-[selector(a:not(.foo))]:flex',
+      'supports-[selector(a:is(.and,.or))]:flex',
+      'supports-[(display:grid)or(display:flex)]:grid',
+      'supports-[not(display:grid)]:flex',
+      'supports-[foo-not(display:grid)]:flex',
+      'supports-[selector([data-foo="("])or(display:grid)]:flex',
+      'supports-[selector(.foo\\(bar)or(display:grid)]:flex',
     ]),
   ).toMatchInlineSnapshot(`
     "
@@ -1504,6 +1456,12 @@ test('supports', async () => {
 
     @supports (display: grid) and font-format(opentype) {
       .supports-\\[\\(display\\:grid\\)_and_font-format\\(opentype\\)\\]\\:grid {
+        display: grid;
+      }
+    }
+
+    @supports (display: grid) or (display: flex) {
+      .supports-\\[\\(display\\:grid\\)or\\(display\\:flex\\)\\]\\:grid {
         display: grid;
       }
     }
@@ -1532,8 +1490,44 @@ test('supports', async () => {
       }
     }
 
+    @supports foo-not(display:grid) {
+      .supports-\\[foo-not\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports not (display: grid) {
+      .supports-\\[not\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector(.foo\\(bar) or (display: grid) {
+      .supports-\\[selector\\(\\.foo\\\\\\(bar\\)or\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
     @supports selector(A > B) {
       .supports-\\[selector\\(A_\\>_B\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector([data-foo="("]) or (display: grid) {
+      .supports-\\[selector\\(\\[data-foo\\=\\"\\(\\"\\]\\)or\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector(a:is(.and,.or)) {
+      .supports-\\[selector\\(a\\:is\\(\\.and\\,\\.or\\)\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector(a:not(.foo)) {
+      .supports-\\[selector\\(a\\:not\\(\\.foo\\)\\)\\]\\:flex {
         display: flex;
       }
     }

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1433,6 +1433,7 @@ test('supports: `and`, `or`, and `not` inside function calls are not spaced out'
       'supports-[not(display:grid)]:flex',
       'supports-[foo-not(display:grid)]:flex',
       'supports-[selector([data-foo="("])or(display:grid)]:flex',
+      'supports-[selector(.foo\\(bar)or(display:grid)]:flex',
     ]),
   ).toMatchInlineSnapshot(`
     "
@@ -1450,6 +1451,12 @@ test('supports: `and`, `or`, and `not` inside function calls are not spaced out'
 
     @supports not (display: grid) {
       .supports-\\[not\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector(.foo\\(bar) or (display: grid) {
+      .supports-\\[selector\\(\\.foo\\\\\\(bar\\)or\\(display\\:grid\\)\\]\\:flex {
         display: flex;
       }
     }

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1445,11 +1445,18 @@ test('supports', async () => {
       'supports-[foo-not(display:grid)]:flex',
       'supports-[selector([data-foo="("])or(display:grid)]:flex',
       'supports-[selector(.foo\\(bar)or(display:grid)]:flex',
+      'supports-[((display:grid)or(display:flex))]:grid',
     ]),
   ).toMatchInlineSnapshot(`
     "
     @supports (gap: var(--tw)) {
       .supports-gap\\:grid {
+        display: grid;
+      }
+    }
+
+    @supports (display: grid) or (display: flex) {
+      .supports-\\[\\(\\(display\\:grid\\)or\\(display\\:flex\\)\\)\\]\\:grid {
         display: grid;
       }
     }

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1424,6 +1424,43 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
   `)
 })
 
+test('supports: `and`, `or`, and `not` inside function calls are not spaced out', async () => {
+  expect(
+    await run([
+      'supports-[selector(a:not(.foo))]:flex',
+      'supports-[selector(a:is(.and,.or))]:flex',
+      'supports-[(display:grid)or(display:flex)]:grid',
+      'supports-[not(display:grid)]:flex',
+    ]),
+  ).toMatchInlineSnapshot(`
+    "
+    @supports (display: grid) or (display: flex) {
+      .supports-\\[\\(display\\:grid\\)or\\(display\\:flex\\)\\]\\:grid {
+        display: grid;
+      }
+    }
+
+    @supports not (display: grid) {
+      .supports-\\[not\\(display\\:grid\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector(a:is(.and,.or)) {
+      .supports-\\[selector\\(a\\:is\\(\\.and\\,\\.or\\)\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports selector(a:not(.foo)) {
+      .supports-\\[selector\\(a\\:not\\(\\.foo\\)\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+    "
+  `)
+})
+
 test('supports', async () => {
   expect(
     await run([

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -937,30 +937,20 @@ export function createVariants(theme: Theme): Variants {
       // other functions, we can use the value as-is.
       if (/^[\w-]*\s*\(/.test(value)) {
         // Chrome has a bug where `(condition1)or(condition2)` is not valid, but
-        // `(condition1) or (condition2)` is supported. Only space out keywords
-        // in the condition itself, not inside function calls like
-        // `selector(a:not(.foo))` where `not` is part of a selector.
-        let parens: boolean[] = []
-        let inFunction = 0
-        let query = value.replace(
-          /\\.|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[()]|[\w-]+/g,
-          (match, offset: number) => {
-            if (match === '(') {
-              let head = value.slice(0, offset)
-              let isFunction = /[\w-]$/.test(head) && !/(?:^|[^\w-])(?:and|or|not)$/.test(head)
-              parens.push(isFunction)
-              if (isFunction) inFunction++
-            } else if (match === ')') {
-              if (parens.pop()) inFunction--
-            } else if (
-              inFunction === 0 &&
-              (match === 'and' || match === 'or' || match === 'not')
-            ) {
-              return ` ${match} `
-            }
-            return match
-          },
-        )
+        // `(condition1) or (condition2)` is supported.
+        let changed = false
+        let ast = ValueParser.parse(value)
+        for (let node of ast) {
+          if (
+            node.kind === 'function' &&
+            (node.value === 'and' || node.value === 'or' || node.value === 'not')
+          ) {
+            changed = true
+            node.value = ` ${node.value} `
+          }
+        }
+
+        let query = changed ? ValueParser.toCss(ast) : value
 
         ruleNode.nodes = [atRule('@supports', query, ruleNode.nodes)]
         return

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -943,7 +943,7 @@ export function createVariants(theme: Theme): Variants {
         let parens: boolean[] = []
         let inFunction = 0
         let query = value.replace(
-          /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[()]|[\w-]+/g,
+          /\\.|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[()]|[\w-]+/g,
           (match, offset: number) => {
             if (match === '(') {
               let head = value.slice(0, offset)

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -940,15 +940,18 @@ export function createVariants(theme: Theme): Variants {
         // `(condition1) or (condition2)` is supported.
         let changed = false
         let ast = ValueParser.parse(value)
-        for (let node of ast) {
-          if (
-            node.kind === 'function' &&
-            (node.value === 'and' || node.value === 'or' || node.value === 'not')
-          ) {
+        walk(ast, (node) => {
+          if (node.kind !== 'function') return
+
+          // Leave selectors as-is, they could contain `selector(a:not(b))`, and
+          // in this case we don't want the space around the `not`.
+          if (node.value === 'selector') return WalkAction.Skip
+
+          if (node.value === 'and' || node.value === 'or' || node.value === 'not') {
             changed = true
             node.value = ` ${node.value} `
           }
-        }
+        })
 
         let query = changed ? ValueParser.toCss(ast) : value
 

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -937,8 +937,24 @@ export function createVariants(theme: Theme): Variants {
       // other functions, we can use the value as-is.
       if (/^[\w-]*\s*\(/.test(value)) {
         // Chrome has a bug where `(condition1)or(condition2)` is not valid, but
-        // `(condition1) or (condition2)` is supported.
-        let query = value.replace(/\b(and|or|not)\b/g, ' $1 ')
+        // `(condition1) or (condition2)` is supported. Only space out keywords
+        // in the condition itself, not inside function calls like
+        // `selector(a:not(.foo))` where `not` is part of a selector.
+        let parens: boolean[] = []
+        let inFunction = 0
+        let query = value.replace(/[()]|\b(?:and|or|not)\b/g, (match, offset: number) => {
+          if (match === '(') {
+            let head = value.slice(0, offset)
+            let isFunction = /[\w-]$/.test(head) && !/(?:^|[^\w-])(?:and|or|not)$/.test(head)
+            parens.push(isFunction)
+            if (isFunction) inFunction++
+          } else if (match === ')') {
+            if (parens.pop()) inFunction--
+          } else if (inFunction === 0) {
+            return ` ${match} `
+          }
+          return match
+        })
 
         ruleNode.nodes = [atRule('@supports', query, ruleNode.nodes)]
         return

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -942,19 +942,25 @@ export function createVariants(theme: Theme): Variants {
         // `selector(a:not(.foo))` where `not` is part of a selector.
         let parens: boolean[] = []
         let inFunction = 0
-        let query = value.replace(/[()]|\b(?:and|or|not)\b/g, (match, offset: number) => {
-          if (match === '(') {
-            let head = value.slice(0, offset)
-            let isFunction = /[\w-]$/.test(head) && !/(?:^|[^\w-])(?:and|or|not)$/.test(head)
-            parens.push(isFunction)
-            if (isFunction) inFunction++
-          } else if (match === ')') {
-            if (parens.pop()) inFunction--
-          } else if (inFunction === 0) {
-            return ` ${match} `
-          }
-          return match
-        })
+        let query = value.replace(
+          /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[()]|[\w-]+/g,
+          (match, offset: number) => {
+            if (match === '(') {
+              let head = value.slice(0, offset)
+              let isFunction = /[\w-]$/.test(head) && !/(?:^|[^\w-])(?:and|or|not)$/.test(head)
+              parens.push(isFunction)
+              if (isFunction) inFunction++
+            } else if (match === ')') {
+              if (parens.pop()) inFunction--
+            } else if (
+              inFunction === 0 &&
+              (match === 'and' || match === 'or' || match === 'not')
+            ) {
+              return ` ${match} `
+            }
+            return match
+          },
+        )
 
         ruleNode.nodes = [atRule('@supports', query, ruleNode.nodes)]
         return


### PR DESCRIPTION
## Summary

The `supports-[…]` variant works around a Chrome bug where `@supports (a)or(b)`
is invalid by spacing out the `and`, `or`, and `not` keywords. However, the
replacement is applied to the entire value, including the inside of function
calls, where these words can be part of a selector.

For example, `supports-[selector(a:not(.foo))]:flex` generates:

```css
@supports selector(a: not (.foo))
```

The selector `a: not (.foo)` is unparsable, so a condition that is true in
every browser silently becomes false and the utility never applies. The same
happens to class names like `.and` or `.or` inside `selector(…)`.

This PR only spaces out the keywords at the condition level: parens preceded by
an identifier (other than the keywords themselves) start a function call, and
everything inside is left as-is. The Chrome workaround still applies to the
condition itself, e.g. `supports-[(display:grid)or(display:flex)]` still
becomes `@supports (display: grid) or (display: flex)`.

## Test plan

- Added a test covering `selector(a:not(.foo))`, class names `.and`/`.or`
  inside `selector(…)`, the Chrome `(a)or(b)` workaround, and a top-level
  `not(…)` condition.
- `pnpm vitest run packages/tailwindcss/src/variants.test.ts` — 102 passed.