### PR TITLE
Fix utility staticValues shadowed by fallback theme namespaces

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -8787,6 +8787,27 @@ test('columns', async () => {
     }
     "
   `)
+
+  // A custom `--container-auto` value must not shadow the `columns-auto`
+  // static value: https://github.com/tailwindlabs/tailwindcss/issues/19722
+  expect(
+    await run(
+      ['columns-auto'],
+      css`
+        @theme {
+          --container-auto: 500px;
+        }
+        @tailwind utilities;
+      `,
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    .columns-auto {
+      columns: auto;
+    }
+    "
+  `)
+
   expect(
     await run([
       'columns',
@@ -25074,6 +25095,89 @@ test('backdrop-filter', async () => {
     }
     "
   `)
+
+  // A custom `--blur-none` value must not shadow the `backdrop-blur-none`
+  // static value: https://github.com/tailwindlabs/tailwindcss/issues/19722
+  expect(
+    await run(
+      ['backdrop-blur-none'],
+      css`
+        @theme {
+          --blur-none: 0;
+        }
+        @tailwind utilities;
+      `,
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    @layer properties {
+      @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *, :before, :after, ::backdrop {
+          --tw-backdrop-blur: initial;
+          --tw-backdrop-brightness: initial;
+          --tw-backdrop-contrast: initial;
+          --tw-backdrop-grayscale: initial;
+          --tw-backdrop-hue-rotate: initial;
+          --tw-backdrop-invert: initial;
+          --tw-backdrop-opacity: initial;
+          --tw-backdrop-saturate: initial;
+          --tw-backdrop-sepia: initial;
+        }
+      }
+    }
+
+    .backdrop-blur-none {
+      --tw-backdrop-blur:  ;
+      -webkit-backdrop-filter: var(--tw-backdrop-blur, ) var(--tw-backdrop-brightness, ) var(--tw-backdrop-contrast, ) var(--tw-backdrop-grayscale, ) var(--tw-backdrop-hue-rotate, ) var(--tw-backdrop-invert, ) var(--tw-backdrop-opacity, ) var(--tw-backdrop-saturate, ) var(--tw-backdrop-sepia, );
+      backdrop-filter: var(--tw-backdrop-blur, ) var(--tw-backdrop-brightness, ) var(--tw-backdrop-contrast, ) var(--tw-backdrop-grayscale, ) var(--tw-backdrop-hue-rotate, ) var(--tw-backdrop-invert, ) var(--tw-backdrop-opacity, ) var(--tw-backdrop-saturate, ) var(--tw-backdrop-sepia, );
+    }
+
+    @property --tw-backdrop-blur {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-brightness {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-contrast {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-grayscale {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-hue-rotate {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-invert {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-opacity {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-saturate {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-sepia {
+      syntax: "*";
+      inherits: false
+    }
+    "
+  `)
 })
 
 test('transition', async () => {
@@ -25742,6 +25846,40 @@ test('leading', async () => {
     .leading-none {
       --tw-leading: var(--leading-none);
       line-height: var(--leading-none);
+    }
+
+    @property --tw-leading {
+      syntax: "*";
+      inherits: false
+    }
+    "
+  `)
+
+  // A custom `--spacing-none` value must not shadow the `leading-none`
+  // static value: https://github.com/tailwindlabs/tailwindcss/issues/19722
+  expect(
+    await run(
+      ['leading-none'],
+      css`
+        @theme {
+          --spacing-none: 0;
+        }
+        @tailwind utilities;
+      `,
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+    @layer properties {
+      @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *, :before, :after, ::backdrop {
+          --tw-leading: initial;
+        }
+      }
+    }
+
+    .leading-none {
+      --tw-leading: 1;
+      line-height: 1;
     }
 
     @property --tw-leading {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -416,6 +416,16 @@ export function createUtilities(theme: Theme) {
           value = candidate.value.value
           dataType = candidate.value.dataType
         } else {
+          // Resolved against the utility's own dedicated theme namespace only
+          // (i.e. `desc.themeKeys[0]`), ignoring any secondary/fallback theme
+          // keys (like `--spacing` or `--container`) that are shared across
+          // many unrelated utilities. Used below to make sure `staticValues`
+          // (like `none` or `auto`) aren't shadowed just because some other
+          // utility's custom theme value happens to share the same suffix.
+          let ownValue = desc.themeKeys?.[0]
+            ? theme.resolve(candidate.value.fraction ?? candidate.value.value, [desc.themeKeys[0]])
+            : null
+
           value = theme.resolve(
             candidate.value.fraction ?? candidate.value.value,
             desc.themeKeys ?? [],
@@ -449,7 +459,12 @@ export function createUtilities(theme: Theme) {
             if (!value?.includes('/') && candidate.modifier) return
           }
 
-          if (value === null && !negative && desc.staticValues && !candidate.modifier) {
+          // A `staticValues` entry (e.g. `none`, `auto`) should win unless the
+          // utility's own theme namespace explicitly defines a value for this
+          // name. A fallback namespace shared with other utilities (like
+          // `--spacing` or `--container`) resolving a same-named value isn't
+          // enough to shadow it.
+          if (!negative && !candidate.modifier && desc.staticValues && ownValue === null) {
             let fallback = desc.staticValues[candidate.value.value]
             if (fallback) return fallback.map(cloneAstNode)
           }


### PR DESCRIPTION
## Summary

Some functional utilities resolve their value against two theme namespaces: their own dedicated one, and a shared fallback used by many unrelated utilities (e.g. `leading` uses `['--leading', '--spacing']`, `columns` uses `['--columns', '--container']`, `backdrop-blur` uses `['--backdrop-blur', '--blur']`). These utilities also define `staticValues` for special keywords like `none`/`auto`.

The `staticValues` fallback only kicked in when the theme resolved to nothing at all across *every* key in `themeKeys`. This means a same-named custom theme value defined for a completely different, unrelated utility silently wins over the intended static value:

```css
@theme {
  --spacing-none: 0; /* meant for spacing utilities, e.g. p-none */
}
```

```html
<p class="leading-none">...</p>
<!-- outputs line-height: var(--spacing-none) → 0, instead of the intended line-height: 1 -->
```

This fixes #19722 (`leading-none` shadowed by a custom `--spacing-none`), and also fixes two more previously unreported instances of the exact same root cause:

- `columns-auto` shadowed by a custom `--container-auto` (outputs `columns: 500px` instead of `columns: auto`)
- `backdrop-blur-none` shadowed by a custom `--blur-none` (doesn't properly reset the backdrop blur)

**Fix:** `functionalUtility()` now also resolves the candidate against just the utility's own dedicated namespace (`themeKeys[0]`). A `staticValues` entry is only shadowed if that resolution (not the combined fallback resolution) finds a value — i.e. only when the utility's *own* namespace defines something for that name. A same-named value that only exists in a shared fallback namespace no longer suppresses the static value.

## Test plan

- Added regression tests in `utilities.test.ts` for all three affected utilities (`leading-none`, `columns-auto`, `backdrop-blur-none`), each reproducing the shadowing with a colliding custom theme value and asserting the correct static output.
- `pnpm vitest run packages/tailwindcss/src` — all 5007 tests pass (1 pre-existing skip), no regressions from this change.