### PR TITLE
Fix `in-*` variant generating invalid CSS with relative arbitrary selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalization: don't merge utilities that reference different theme variables set to CSS-wide keywords like `unset` ([#20417](https://github.com/tailwindlabs/tailwindcss/pull/20417))
 - Don't generate utilities when a modifier is used that would otherwise be silently ignored (e.g. `rounded-sm/[5]`, `shadow-sm/foo`, `stroke-2/50`) ([#20419](https://github.com/tailwindlabs/tailwindcss/pull/20419))
 - Only normalize top-level `and`, `or`, and `not` keywords in `supports-[…]` variants (e.g. `selector(a: not (.foo))` → `selector(a:not(.foo))`) ([#20420](https://github.com/tailwindlabs/tailwindcss/pull/20420))
+- Don't generate invalid CSS for `in-*` variants using a relative arbitrary selector (e.g. `in-[>img]`), matching existing behavior for `not-*`, `group-*`, and `peer-*`
 
 ## [4.3.3] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalization: don't merge utilities that reference different theme variables set to CSS-wide keywords like `unset` ([#20417](https://github.com/tailwindlabs/tailwindcss/pull/20417))
 - Don't generate utilities when a modifier is used that would otherwise be silently ignored (e.g. `rounded-sm/[5]`, `shadow-sm/foo`, `stroke-2/50`) ([#20419](https://github.com/tailwindlabs/tailwindcss/pull/20419))
 - Only normalize top-level `and`, `or`, and `not` keywords in `supports-[…]` variants (e.g. `selector(a: not (.foo))` → `selector(a:not(.foo))`) ([#20420](https://github.com/tailwindlabs/tailwindcss/pull/20420))
-- Don't generate invalid CSS for `in-*` variants using a relative arbitrary selector (e.g. `in-[>img]`), matching existing behavior for `not-*`, `group-*`, and `peer-*`
+- Don't generate invalid CSS for `in-*` variants using a relative arbitrary selector (e.g. `in-[>img]`), matching existing behavior for `not-*`, `group-*`, and `peer-*` ([#20424](https://github.com/tailwindlabs/tailwindcss/pull/20424))
 
 ## [4.3.3] - 2026-07-16
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -2000,6 +2000,10 @@ test('in', async () => {
     "
   `)
   expect(await run(['in-p:flex', 'in-foo-bar:flex'])).toEqual('')
+
+  // `in-*` is built using `:where(…) &`, which — unlike `:has(…)` — does not
+  // accept relative selectors, so these must not generate any output.
+  expect(await run(['in-[>img]:flex', 'in-[+img]:flex', 'in-[~img]:flex'])).toEqual('')
 })
 
 test('has', async () => {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -782,6 +782,8 @@ export function createVariants(theme: Theme): Variants {
   staticVariant('inert', ['&:is([inert], [inert] *)'])
 
   variants.compound('in', Compounds.StyleRules, (ruleNode, variant) => {
+    if (variant.variant.kind === 'arbitrary' && variant.variant.relative) return null
+
     if (variant.modifier) return null
 
     let didApply = false


### PR DESCRIPTION
## Summary

`in-*` builds its selector as `:where(…) &`, but unlike `:has()`, `:where()` doesn't accept relative selectors (e.g. `>img`, `+img`, `~img`).

This meant `in-[>img]:flex` silently produced:

```css
:where() .in-\[\>img\]\:flex {
  display: flex;
}
```

An empty, invalid `:where()` that every browser drops the rule for — the utility is silently non-functional. `not-*`, `group-*`, and `peer-*` already guard against this exact case (they bail out and generate no CSS for a relative arbitrary selector), but `in-*` was missing the same guard.

This adds the same one-line guard already used by `not`, `group`, and `peer` to the `in` compound variant.

## Test plan

- Added a regression test to `in-*`'s existing test block in `variants.test.ts` asserting `in-[>img]:flex`, `in-[+img]:flex`, and `in-[~img]:flex` all produce no output, mirroring the existing `peer-[>img]:flex` / `group-[>img]:flex` assertions.
- `pnpm vitest run` — all 5007 existing tests in the `tailwindcss` package pass, no regressions.